### PR TITLE
add CentOS 7 clone steps

### DIFF
--- a/manual/2.1-CreateCloneVMs.md
+++ b/manual/2.1-CreateCloneVMs.md
@@ -35,17 +35,17 @@ Run the following steps to create the clone VM:
 1. Select "Full clone" and click "Next"
 1. Select "Everything" and click "Clone"
 
-Now you must do a little work to fix the networking settings for the clone:
+Now you must do a little work to fix the networking settings for the clone. Note that for CentOS 7, some steps are not necessary.
 
 1. Start your VM
 1. Log in
-1. Open your VM network settings, find the MAC Address for Adapter 1
-1. `vi /etc/sysconfig/network-scripts/ifcfg-eth0`
-1. Change HWADDR to match your clone's Adapter 1 MAC Address
-1. Open your VM network settings, find the MAC Address for Adapter 2
-1. `vi /etc/sysconfig/network-scripts/ifcfg-eth1`
-1. Change HWADDR to match your clone's Adapter 2 MAC Address
-1. Optional: If you want to access this VM from a different IP address, change that in `ifcfg-eth1` as well.
+1. (CentOS 6 only) Open your VM network settings, find the MAC Address for Adapter 1
+1. (CentOS 6 only) `vi /etc/sysconfig/network-scripts/ifcfg-eth0`
+1. (CentOS 6 only) Change HWADDR to match your clone's Adapter 1 MAC Address
+1. (CentOS 6 only) Open your VM network settings, find the MAC Address for Adapter 2
+1. (CentOS 6 only) `vi /etc/sysconfig/network-scripts/ifcfg-eth1`
+1. (CentOS 6 only) Change HWADDR to match your clone's Adapter 2 MAC Address
+1. Optional: If you want to access this VM from a different IP address, change that in `ifcfg-eth1` (CentOS 6) or `ifcfg-enp0s8` (CentOS 7) as well.
 1. `rm -f /etc/udev/rules.d/70-persistent-net.rules`
 
 At this point you either need to reboot `shutdown -r now` or shut down `shutdown -h now` for the settings to update. Then your clone should have functioning networking.

--- a/manual/2.1-CreateCloneVMs.md
+++ b/manual/2.1-CreateCloneVMs.md
@@ -46,6 +46,6 @@ Now you must do a little work to fix the networking settings for the clone. Note
 1. (CentOS 6 only) `vi /etc/sysconfig/network-scripts/ifcfg-eth1`
 1. (CentOS 6 only) Change HWADDR to match your clone's Adapter 2 MAC Address
 1. Optional: If you want to access this VM from a different IP address, change that in `ifcfg-eth1` (CentOS 6) or `ifcfg-enp0s8` (CentOS 7) as well.
-1. `rm -f /etc/udev/rules.d/70-persistent-net.rules`
+1. (CentOS 6 only) `rm -f /etc/udev/rules.d/70-persistent-net.rules`
 
 At this point you either need to reboot `shutdown -r now` or shut down `shutdown -h now` for the settings to update. Then your clone should have functioning networking.


### PR DESCRIPTION
This is a simple update to the manual for cloning VMs using CentOS 7.

To test, follow the steps to create a clone and verify you can SSH to the clone. Optionally run two VMs at once using two IP addresses.