### PR TITLE
update permissions to wiki and config path

### DIFF
--- a/scripts/import-wikis.sh
+++ b/scripts/import-wikis.sh
@@ -124,6 +124,7 @@ for d in */ ; do
 	fi
 
 	mv "$imports_dir/$wiki_id" "$wiki_install_path"
+	chmod 755 "$wiki_install_path"
 
 	# Configure images folder
 	# Ref: https://www.mediawiki.org/wiki/Manual:Configuring_file_uploads
@@ -151,6 +152,7 @@ for d in */ ; do
 	if [ ! -f "$wiki_install_path/config/disableSearchUpdate.php" ]; then
 		cp "$m_meza/wiki-init/config/disableSearchUpdate.php" "$wiki_install_path/config/disableSearchUpdate.php"
 	fi
+	chmod -R 755 "$wiki_install_path/config"
 
 	# insert wiki name and auth type into setup.php if it's still "placeholder"
 	sed -r -i "s/wgSitename = 'placeholder';/wgSitename = '$wiki_name';/g;" "$wiki_install_path/config/setup.php"


### PR DESCRIPTION
This PR modifies the permissions of any wiki added using import-wikis.sh. Specifically it allows anyone to read and execute the wiki's directory and the config directory within that. This closes #232. There may be other, more tightly controlled ways of handling this, but it's what I could come up with based on some basic trial and error.