### PR TITLE
Hard-code PHP version, enable OPcache

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -56,11 +56,12 @@ read usergithubtoken
 usergithubtoken=${usergithubtoken:-$default_usergithubtoken}
 
 # Prompt user for PHP version
-default_phpversion="5.4.42"
-echo -e "\nVisit http://php.net/downloads.php for version numbers"
-echo -e "Type the version of PHP you would like (such as 5.4.42) and press [ENTER]:"
-read -e -i $default_phpversion phpversion
-phpversion=${phpversion:-$default_phpversion}
+default_phpversion="5.6.14"
+phpversion=$default_phpversion #hard code version for now based on #24
+# echo -e "\nVisit http://php.net/downloads.php for version numbers"
+# echo -e "Type the version of PHP you would like (such as 5.4.42) and press [ENTER]:"
+# read -e -i $default_phpversion phpversion
+# phpversion=${phpversion:-$default_phpversion}
 
 # Prompt user for MySQL password
 default_mysql_root_pass=`cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1`

--- a/scripts/php.ini-development
+++ b/scripts/php.ini-development
@@ -742,7 +742,7 @@ enable_dl = Off
 ; will look for to know it is OK to continue execution.  Setting this variable MAY
 ; cause security issues, KNOW WHAT YOU ARE DOING FIRST.
 ; http://php.net/cgi.redirect-status-env
-;cgi.redirect_status_env = 
+;cgi.redirect_status_env =
 
 ; cgi.fix_pathinfo provides *real* PATH_INFO/PATH_TRANSLATED support for CGI.  PHP's
 ; previous behaviour was to set PATH_TRANSLATED to SCRIPT_FILENAME, and to not grok
@@ -883,8 +883,8 @@ default_socket_timeout = 60
 ;extension=php_pspell.dll
 ;extension=php_shmop.dll
 
-; The MIBS data available in the PHP distribution must be installed. 
-; See http://www.php.net/manual/en/snmp.installation.php 
+; The MIBS data available in the PHP distribution must be installed.
+; See http://www.php.net/manual/en/snmp.installation.php
 ;extension=php_snmp.dll
 
 ;extension=php_soap.dll
@@ -1829,3 +1829,104 @@ ldap.max_links = -1
 ; Local Variables:
 ; tab-width: 4
 ; End:
+
+[opcache]
+; add OPcache file location
+zend_extension=/usr/local/php/lib/php/extensions/no-debug-zts-20131226/opcache.so
+
+; Determines if Zend OPCache is enabled
+opcache.enable=1
+
+; Determines if Zend OPCache is enabled for the CLI version of PHP
+opcache.enable_cli=1
+
+; The OPcache shared memory storage size
+opcache.memory_consumption=256
+
+; The amount of memory for interned strings in Mbytes
+opcache.interned_strings_buffer=4
+
+; The maximum number of keys (scripts) in the OPcache hash table
+; Only numbers between 200 and 100000 are allowed
+opcache.max_accelerated_files=20000
+
+; The maximum percentage of "wasted" memory until a restart is scheduled
+;opcache.max_wasted_percentage=5
+
+; When this directive is enabled, the OPcache appends the current working
+; directory to the script key, thus eliminating possible collisions between
+; files with the same name (basename). Disabling the directive improves
+; performance, but may break existing applications.
+;opcache.use_cwd=1
+
+; When disabled, you must reset the OPcache manually or restart the
+; webserver for changes to the filesystem to take effect
+opcache.validate_timestamps=1
+
+; How often (in seconds) to check file timestamps for changes to the shared
+; memory storage allocation. ("1" means validate once per second, but only
+; once per request. "0" means always validate)
+opcache.revalidate_freq=30
+
+; Enables or disables file search in include_path optimization
+;opcache.revalidate_path=0
+
+; If disabled, all PHPDoc comments are dropped from the code to reduce the
+; size of the optimized code.
+;opcache.save_comments=1
+
+; If disabled, PHPDoc comments are not loaded from SHM, so "Doc Comments"
+; may be always stored (save_comments=1), but not loaded by applications
+; that don't need them anyway.
+;opcache.load_comments=1
+
+; If enabled, a fast shutdown sequence is used for the accelerated code
+;opcache.fast_shutdown=0
+
+; Allow file existence override (file_exists, etc.) performance feature.
+;opcache.enable_file_override=0
+
+; A bitmask, where each bit enables or disables the appropriate OPcache
+; passes
+;opcache.optimization_level=0xffffffff
+
+;opcache.inherited_hack=1
+;opcache.dups_fix=0
+
+; The location of the OPcache blacklist file (wildcards allowed).
+; Each OPcache blacklist file is a text file that holds the names of files
+; that should not be accelerated. The file format is to add each filename
+; to a new line. The filename may be a full path or just a file prefix
+; (i.e., /var/www/x  blacklists all the files and directories in /var/www
+; that start with 'x'). Line starting with a ; are ignored (comments).
+;opcache.blacklist_filename=
+
+; Allows exclusion of large files from being cached. By default all files
+; are cached.
+;opcache.max_file_size=0
+
+; Check the cache checksum each N requests.
+; The default value of "0" means that the checks are disabled.
+;opcache.consistency_checks=0
+
+; How long to wait (in seconds) for a scheduled restart to begin if the cache
+; is not being accessed.
+; Default was 180 (3 minutes), changed to 1 hour to keep the
+; cache from being reset regularly.
+opcache.force_restart_timeout=3600
+
+; OPcache error_log file name. Empty string assumes "stderr".
+; opcache.error_log=/opt/meza/logs/opcache_error.log
+
+; All OPcache errors go to the Web server log.
+; By default, only fatal errors (level 0) or errors (level 1) are logged.
+; You can also enable warnings (level 2), info messages (level 3) or
+; debug messages (level 4).
+;opcache.log_verbosity_level=1
+
+; Preferred Shared Memory back-end. Leave empty and let the system decide.
+;opcache.preferred_memory_model=
+
+; Protect the shared memory from unexpected writing during script execution.
+; Useful for internal debugging only.
+;opcache.protect_memory=0

--- a/scripts/php.ini-production
+++ b/scripts/php.ini-production
@@ -883,8 +883,8 @@ default_socket_timeout = 60
 ;extension=php_pspell.dll
 ;extension=php_shmop.dll
 
-; The MIBS data available in the PHP distribution must be installed. 
-; See http://www.php.net/manual/en/snmp.installation.php 
+; The MIBS data available in the PHP distribution must be installed.
+; See http://www.php.net/manual/en/snmp.installation.php
 ;extension=php_snmp.dll
 
 ;extension=php_soap.dll
@@ -1829,3 +1829,104 @@ ldap.max_links = -1
 ; Local Variables:
 ; tab-width: 4
 ; End:
+
+[opcache]
+; add OPcache file location
+zend_extension=/usr/local/php/lib/php/extensions/no-debug-zts-20131226/opcache.so
+
+; Determines if Zend OPCache is enabled
+opcache.enable=1
+
+; Determines if Zend OPCache is enabled for the CLI version of PHP
+opcache.enable_cli=1
+
+; The OPcache shared memory storage size
+opcache.memory_consumption=256
+
+; The amount of memory for interned strings in Mbytes
+opcache.interned_strings_buffer=4
+
+; The maximum number of keys (scripts) in the OPcache hash table
+; Only numbers between 200 and 100000 are allowed
+opcache.max_accelerated_files=20000
+
+; The maximum percentage of "wasted" memory until a restart is scheduled
+;opcache.max_wasted_percentage=5
+
+; When this directive is enabled, the OPcache appends the current working
+; directory to the script key, thus eliminating possible collisions between
+; files with the same name (basename). Disabling the directive improves
+; performance, but may break existing applications.
+;opcache.use_cwd=1
+
+; When disabled, you must reset the OPcache manually or restart the
+; webserver for changes to the filesystem to take effect
+opcache.validate_timestamps=1
+
+; How often (in seconds) to check file timestamps for changes to the shared
+; memory storage allocation. ("1" means validate once per second, but only
+; once per request. "0" means always validate)
+opcache.revalidate_freq=30
+
+; Enables or disables file search in include_path optimization
+;opcache.revalidate_path=0
+
+; If disabled, all PHPDoc comments are dropped from the code to reduce the
+; size of the optimized code.
+;opcache.save_comments=1
+
+; If disabled, PHPDoc comments are not loaded from SHM, so "Doc Comments"
+; may be always stored (save_comments=1), but not loaded by applications
+; that don't need them anyway.
+;opcache.load_comments=1
+
+; If enabled, a fast shutdown sequence is used for the accelerated code
+;opcache.fast_shutdown=0
+
+; Allow file existence override (file_exists, etc.) performance feature.
+;opcache.enable_file_override=0
+
+; A bitmask, where each bit enables or disables the appropriate OPcache
+; passes
+;opcache.optimization_level=0xffffffff
+
+;opcache.inherited_hack=1
+;opcache.dups_fix=0
+
+; The location of the OPcache blacklist file (wildcards allowed).
+; Each OPcache blacklist file is a text file that holds the names of files
+; that should not be accelerated. The file format is to add each filename
+; to a new line. The filename may be a full path or just a file prefix
+; (i.e., /var/www/x  blacklists all the files and directories in /var/www
+; that start with 'x'). Line starting with a ; are ignored (comments).
+;opcache.blacklist_filename=
+
+; Allows exclusion of large files from being cached. By default all files
+; are cached.
+;opcache.max_file_size=0
+
+; Check the cache checksum each N requests.
+; The default value of "0" means that the checks are disabled.
+;opcache.consistency_checks=0
+
+; How long to wait (in seconds) for a scheduled restart to begin if the cache
+; is not being accessed.
+; Default was 180 (3 minutes), changed to 1 hour to keep the
+; cache from being reset regularly.
+opcache.force_restart_timeout=3600
+
+; OPcache error_log file name. Empty string assumes "stderr".
+; opcache.error_log=/opt/meza/logs/opcache_error.log
+
+; All OPcache errors go to the Web server log.
+; By default, only fatal errors (level 0) or errors (level 1) are logged.
+; You can also enable warnings (level 2), info messages (level 3) or
+; debug messages (level 4).
+;opcache.log_verbosity_level=1
+
+; Preferred Shared Memory back-end. Leave empty and let the system decide.
+;opcache.preferred_memory_model=
+
+; Protect the shared memory from unexpected writing during script execution.
+; Useful for internal debugging only.
+;opcache.protect_memory=0

--- a/scripts/php.sh
+++ b/scripts/php.sh
@@ -7,12 +7,12 @@ print_title "Starting script php.sh"
 #
 # Prompt user for PHP version
 #
-while [ -z "$phpversion" ]
-do
-echo -e "\n\n\n\nVisit http://php.net/downloads.php"
-echo -e "\nEnter the version of PHP you would like (such as 5.4.42) and press [ENTER]: "
-read phpversion
-done
+# while [ -z "$phpversion" ]
+# do
+# echo -e "\n\n\n\nVisit http://php.net/downloads.php"
+# echo -e "\nEnter the version of PHP you would like (such as 5.4.42) and press [ENTER]: "
+# read phpversion
+# done
 
 
 #


### PR DESCRIPTION
This PR removes the prompt asking the user for which version of PHP they want to install. Now it is hard-coded to 5.6.14. This closes #24. This PR also adds lines to php.ini enabling and configuring OPcache. This closes #16.

#### To test:
Run install.sh on both CentOS 6 and 7 using the `opcache` branch:
* `curl -LO https://raw.githubusercontent.com/enterprisemediawiki/meza/opcache/scripts/install.sh`
* `sudo bash install.sh`

Verify OPcache was enabled by running `php -v` in the command line. You should see something like the following:

```
PHP 5.6.14 (cli) (built: Oct 18 2015 19:46:38) 
Copyright (c) 1997-2015 The PHP Group
Zend Engine v2.6.0, Copyright (c) 1998-2015 Zend Technologies
    with Zend OPcache v7.0.6-dev, Copyright (c) 1999-2015, by Zend Technologies
```

You can also add a php.info file to check in the browser. This requires a couple steps:
* `sudo vi /opt/meza/htdocs/info.php`
* Insert `<?php phpinfo();`
* `sudo vi /opt/meza/htdocs/.htaccess`
* Add `RewriteRule ^info.php(.*) - [L]` after the similar line for index.php
* Navigate to your VM's IP address/info.php and search for "opcache" to find the configuration settings

#### Reference
* [PHP.net documentation](http://php.net/manual/en/opcache.installation.php)
* [Fideloper.com tutorial](http://fideloper.com/install-zend-opcache)