### PR TITLE
Add deltarpm package to reduce install time

### DIFF
--- a/scripts/yums.sh
+++ b/scripts/yums.sh
@@ -43,6 +43,17 @@ curl -LO "http://dl.fedoraproject.org/pub/epel/$epel_version"
 
 
 #
+# Make sure deltarpm is installed
+# CentOS 7 minimal install removed the deltarpm package, which handles the
+# difference between versions of an RPM package. This means the whole new RPM
+# does not have to be downloaded saving bandwidth. Do this before `yum update`
+# so bandwidth savings are achieved immediately.
+# Ref: http://danielgibbs.co.uk/2015/05/delta-rpms-disabled/
+#
+yum install -y deltarpm
+
+
+#
 # Update everything managed by yum
 #
 cmd_profile "START yum update"


### PR DESCRIPTION
Adds yum package missing in CentOS 7, the absence of which was causing delays during install.

## Testing

1. `curl -LO https://raw.githubusercontent.com/enterprisemediawiki/meza/deltarpm/scripts/install.sh`
2. `sudo bash install.sh`
3. Use `deltarpm` branch
4. Do standard testing.

## Issues

* Closes #246