### PR TITLE
Checkout specific version of parsoid

### DIFF
--- a/scripts/VE.sh
+++ b/scripts/VE.sh
@@ -59,6 +59,8 @@ echo "******* Downloading parsoid *******"
 cd /etc
 git clone https://gerrit.wikimedia.org/r/p/mediawiki/services/parsoid
 cd parsoid
+git checkout "9260e5d"
+
 echo "******* Installing parsoid *******"
 #npm install -g # install globally
 #attempt to install globally was resulting in several errors

--- a/scripts/VE.sh
+++ b/scripts/VE.sh
@@ -59,7 +59,7 @@ echo "******* Downloading parsoid *******"
 cd /etc
 git clone https://gerrit.wikimedia.org/r/p/mediawiki/services/parsoid
 cd parsoid
-git checkout "9260e5d"
+git checkout "$parsoid_version"
 
 echo "******* Installing parsoid *******"
 #npm install -g # install globally

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -55,6 +55,13 @@ echo -e "and copy/paste your 40-character token and press [ENTER]: "
 read usergithubtoken
 usergithubtoken=${usergithubtoken:-$default_usergithubtoken}
 
+# Set Parsoid version.
+# This should be able to be set in any of these forms:
+#   9260e5d       (a sha1 hash)
+#   tags/v0.4.1   (a tag name)
+#   master        (a branch name)
+parsoid_version"9260e5d"
+
 # Prompt user for PHP version
 default_phpversion="5.6.14"
 phpversion=$default_phpversion #hard code version for now based on #24

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -60,7 +60,7 @@ usergithubtoken=${usergithubtoken:-$default_usergithubtoken}
 #   9260e5d       (a sha1 hash)
 #   tags/v0.4.1   (a tag name)
 #   master        (a branch name)
-parsoid_version"9260e5d"
+parsoid_version="9260e5d"
 
 # Prompt user for PHP version
 default_phpversion="5.6.14"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -60,7 +60,7 @@ usergithubtoken=${usergithubtoken:-$default_usergithubtoken}
 #   9260e5d       (a sha1 hash)
 #   tags/v0.4.1   (a tag name)
 #   master        (a branch name)
-parsoid_version="9260e5d"
+parsoid_version="ba26a55"
 
 # Prompt user for PHP version
 default_phpversion="5.6.14"


### PR DESCRIPTION
This PR checks out a specific version of parsoid. The version was chosen somewhat arbitrarily. We should test the currently-selected version, then try some newer versions to see if they work. We should try to identify which version breaks Parsoid for us and communicate that back to the WMF.

# Testing

1. `curl -LO https://raw.githubusercontent.com/enterprisemediawiki/meza/parsoid-version/scripts/install.sh`
2. `sudo bash install.sh`
3. Use branch `parsoid-version`
4. Perform standard tests, with focus on VE.

# Issues

* Closes #248 
* Address comments in #236 which were initially attributed to that issue (Flow) or to #161 (Upload Wizard)