### PR TITLE
Edit NameSpaces using Flow/VE, allow Flow to use VE

### DIFF
--- a/scripts/config/LocalSettings.php
+++ b/scripts/config/LocalSettings.php
@@ -992,6 +992,14 @@ $wgVisualEditorParsoidURL = 'http://127.0.0.1:8000';
 // Parsoid will be called as $url/$prefix/$pagename
 $wgVisualEditorParsoidPrefix = $wikiId;
 
+// Define which namespaces will use VE
+$wgVisualEditorNamespaces = array_merge(
+	$wgContentNamespaces,
+        array( NS_USER, 
+          NS_HELP,
+          NS_PROJECT
+	)
+);
 
 #
 # Extension:Elastica
@@ -1085,12 +1093,22 @@ $wgFlowContentFormat = 'html';
 // use VE
 $wgFlowEditorList = array( 'visualeditor', 'none' );
 
-// enable in Project Talk, User Talk, and Talk (content namespace talk)
-$wgNamespaceContentModels[NS_PROJECT_TALK] = CONTENT_MODEL_FLOW_BOARD;
-$wgNamespaceContentModels[NS_USER_TALK]    = CONTENT_MODEL_FLOW_BOARD;
-$wgNamespaceContentModels[NS_TALK]         = CONTENT_MODEL_FLOW_BOARD;
+// Define which namespaces will use Flow
+$wgNamespaceContentModels[NS_PROJECT_TALK]        = CONTENT_MODEL_FLOW_BOARD;
+$wgNamespaceContentModels[NS_USER_TALK]           = CONTENT_MODEL_FLOW_BOARD;
+$wgNamespaceContentModels[NS_TALK]                = CONTENT_MODEL_FLOW_BOARD;
+$wgNamespaceContentModels[NS_HELP_TALK]           = CONTENT_MODEL_FLOW_BOARD;
+$wgNamespaceContentModels[NS_FILE_TALK]           = CONTENT_MODEL_FLOW_BOARD;
+$wgNamespaceContentModels[NS_CATEGORY_TALK]       = CONTENT_MODEL_FLOW_BOARD;
+$wgNamespaceContentModels[NS_MEDIAWIKI_TALK]      = CONTENT_MODEL_FLOW_BOARD;
+$wgNamespaceContentModels[NS_TEMPLATE_TALK]       = CONTENT_MODEL_FLOW_BOARD;
+$wgNamespaceContentModels[SMW_NS_FORM_TALK]       = CONTENT_MODEL_FLOW_BOARD;
+$wgNamespaceContentModels[SMW_NS_PROPERTY_TALK]   = CONTENT_MODEL_FLOW_BOARD;
+$wgNamespaceContentModels[SMW_NS_CONCEPT_TALK]    = CONTENT_MODEL_FLOW_BOARD;
 
-
+// Connect Flow to Parsoid
+$wgFlowParsoidURL = 'http://127.0.0.1:8000';
+$wgFlowParsoidPrefix = $wikiId;
 
 
 


### PR DESCRIPTION
This is an update to LocalSettings.php to revise the list of namespaces on which VE and Flow are enabled. Additionally this addresses an issue where Flow was not enabled to use VE.

## Testing
You can either just replace LocalSettings.php in a recent install (recommended) or do a full install (not recommended).

Optional full install steps:
* `curl -LO https://raw.githubusercontent.com/enterprisemediawiki/meza/flow-ve-settings/scripts/install.sh`
* `sudo bash install.sh`
* Use `flow-ve-settings` branch

### Actual testing steps
* Verify VE works on `User`, `Help`, and `Project` pages
* Verify Flow works on a `Property` page (you can test the full list if you want, but this should be good)
* Use VE in Flow by toggling the button just above "Add topic"

![image](https://cloud.githubusercontent.com/assets/6728676/11080014/f30ff752-87d5-11e5-8f02-c2932286fe27.png)


## Issues
* Closes #228
* Closes #269 