### PR TITLE
Disable search update for runJobs during import

### DIFF
--- a/scripts/import-wikis.sh
+++ b/scripts/import-wikis.sh
@@ -197,7 +197,9 @@ for d in */ ; do
 		# Run runJobs.php
 		# Note that should prob be removed: Daren saw 12k+ jobs in the queue after performing the above steps
 		echo "Running MediaWiki maintenance script \"runJobs.php\""
+		sed -r -i 's/false/true/g;' "$m_htdocs/wikis/$wiki_id/config/disableSearchUpdate.php"
 		WIKI="$wiki_id" php "$m_mediawiki/maintenance/runJobs.php" --quick
+		sed -r -i 's/true/false/g;' "$m_htdocs/wikis/$wiki_id/config/disableSearchUpdate.php"
 	else
 		echo -e "\nSKIPPING SemanticMediaWiki rebuildData.php and runjobs.php (no SMW)"
 	fi


### PR DESCRIPTION
This PR closes #256 by temporarily setting wgDisableSearchUpdate to false before executing runJobs.php. This allows the job queue to clear without generating bogus search indices.

## Testing
* Either run a full install of the `import-fix` branch or just swap this file out for the existing `import-wikis.sh` file
* Verify the OSO wiki on the FOD development server still has jobs in the queue (with job_attempts=0)
* Import the OSO wiki from the FOD development server
* Test ES