### PR TITLE
SummaryTimeline checkout tagged version

### DIFF
--- a/scripts/config/LocalSettings.php
+++ b/scripts/config/LocalSettings.php
@@ -875,7 +875,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"SummaryTimeline",
 	"https://github.com/darenwelsh/SummaryTimeline.git",
-	"master"
+	"tags/0.1.2"
 );
 
 

--- a/scripts/config/LocalSettings.php
+++ b/scripts/config/LocalSettings.php
@@ -875,7 +875,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"SummaryTimeline",
 	"https://github.com/darenwelsh/SummaryTimeline.git",
-	"tags/0.1.2"
+	"tags/0.1.3"
 );
 
 

--- a/scripts/extensions.sh
+++ b/scripts/extensions.sh
@@ -28,7 +28,7 @@ echo -e "\n\n## meza: Install ExtensionLoader and apply changes to MW settings"
 cd "$m_mediawiki/extensions"
 git clone https://github.com/jamesmontalvo3/ExtensionLoader.git
 cd ./ExtensionLoader
-git checkout tags/v0.2.1
+git checkout tags/v0.2.2
 cd "$m_mediawiki"
 
 

--- a/scripts/extensions.sh
+++ b/scripts/extensions.sh
@@ -28,7 +28,7 @@ echo -e "\n\n## meza: Install ExtensionLoader and apply changes to MW settings"
 cd "$m_mediawiki/extensions"
 git clone https://github.com/jamesmontalvo3/ExtensionLoader.git
 cd ./ExtensionLoader
-git checkout tags/v0.2.2
+git checkout tags/v0.2.3
 cd "$m_mediawiki"
 
 


### PR DESCRIPTION
In this pull request SummaryTimeline checks out tag `0.1.2`. Also, ExtensionLoader is upgraded to `0.2.3` in order to fix support for tags.

## Testing

1. `curl -LO https://raw.githubusercontent.com/enterprisemediawiki/meza/extload-tags-fix/scripts/install.sh`
2. `sudo bash install.sh`
3. Use `extload-tags-fix`
4. Perform normal testing
5. Verify extensions load properly
6. Verify correct version of Summary Timeline

## Issues 
* Closes #148