### PR TITLE
Does initial install with wiki served over https

### DIFF
--- a/scripts/VE.sh
+++ b/scripts/VE.sh
@@ -22,8 +22,9 @@ do
 done
 
 
-# MediaWiki's API URI, for parsoid
-mw_api_uri="$mw_api_protocol://$mw_api_domain/"
+# MediaWiki's API URI, for parsoid. Parsoid communicates with MediaWiki PHP API
+# via Apache httpd over port 8142
+mw_api_uri="$mw_api_protocol://$mw_api_domain:8142/"
 
 
 echo "******* Downloading node.js *******"

--- a/scripts/VE.sh
+++ b/scripts/VE.sh
@@ -23,8 +23,9 @@ done
 
 
 # MediaWiki's API URI, for parsoid. Parsoid communicates with MediaWiki PHP API
-# via Apache httpd over port 8142
-mw_api_uri="$mw_api_protocol://$mw_api_domain:8142/"
+# via Apache httpd over port 8142. Note: protocol was $mw_api_protocol, but was
+# changed to hard-coded http when Parsoid was given it's own port.
+mw_api_uri="http://$mw_api_domain:8142/"
 
 
 echo "******* Downloading node.js *******"

--- a/scripts/apache.sh
+++ b/scripts/apache.sh
@@ -93,6 +93,12 @@ cd /usr/local/apache2/conf
 mv httpd.conf httpd.default.conf
 cp "$m_meza/scripts/config/httpd.conf" ./httpd.conf
 
+# insert proper domain name
+sed -r -i "s/ServerName IPADDRESS:443/ServerName $mw_api_domain:443/g;" ./httpd.conf
+
+
+
+
 # create service script
 cd /etc/init.d
 cp "$m_meza/scripts/initd_httpd.sh" ./httpd
@@ -121,20 +127,23 @@ then
 	echo "Enterprise Linux version 7. Applying rule changes to firewalld"
 
 	# Add access to http now
-	firewall-cmd --zone=public --add-port=http/tcp
-
 	# Add it as "permanent" so it get's done on future reboots
-	firewall-cmd --zone=public --add-port=http/tcp --permanent
+	firewall-cmd --zone=public --add-service=https
+	firewall-cmd --zone=public --permanent --add-service=https
+
+	# firewall-cmd --zone=public --add-port=http/tcp
+	# firewall-cmd --zone=public --add-port=http/tcp --permanent
 
 else
     echo "Enterprise Linux version 6. Applying rule changes to iptables"
 
 	#
-	# Configure IPTABLES to open port 80 (for Apache HTTP)
+	# Configure IPTABLES to open port 80 (for Apache HTTP), or 443 for https
 	# @todo: consider method to define entire iptables config:
 	# http://blog.astaz3l.com/2015/03/06/secure-firewall-for-centos/
 	#
-	iptables -I INPUT 5 -i eth1 -p tcp --dport 80 -m state --state NEW,ESTABLISHED -j ACCEPT
+	# iptables -I INPUT 5 -i eth1 -p tcp --dport 80 -m state --state NEW,ESTABLISHED -j ACCEPT
+	iptables -I INPUT 5 -i eth1 -p tcp --dport 443 -m state --state NEW,ESTABLISHED -j ACCEPT
 	service iptables save
 
 fi

--- a/scripts/apache.sh
+++ b/scripts/apache.sh
@@ -93,6 +93,8 @@ cd /usr/local/apache2/conf
 mv httpd.conf httpd.default.conf
 cp "$m_meza/scripts/config/httpd.conf" ./httpd.conf
 
+# replace INSERT-DOMAIN-OR-IP with domain...or IP address
+sed -r -i "s/INSERT-DOMAIN-OR-IP/$mw_api_domain/g;" ./httpd.conf
 
 
 # create service script
@@ -114,13 +116,14 @@ if grep -Fxq "VERSION_ID=\"7\"" /etc/os-release
 then
 	echo "Enterprise Linux version 7. Applying rule changes to firewalld"
 
-	# Add access to http now
+	# Add access to https now
 	# Add it as "permanent" so it get's done on future reboots
 	firewall-cmd --zone=public --add-service=https
 	firewall-cmd --zone=public --permanent --add-service=https
 
-	# firewall-cmd --zone=public --add-port=http/tcp
-	# firewall-cmd --zone=public --add-port=http/tcp --permanent
+	# access via http allowed, but forwarded to https (see httpd.conf)
+	firewall-cmd --zone=public --add-port=http/tcp
+	firewall-cmd --zone=public --add-port=http/tcp --permanent
 
 else
     echo "Enterprise Linux version 6. Applying rule changes to iptables"

--- a/scripts/apache.sh
+++ b/scripts/apache.sh
@@ -93,10 +93,6 @@ cd /usr/local/apache2/conf
 mv httpd.conf httpd.default.conf
 cp "$m_meza/scripts/config/httpd.conf" ./httpd.conf
 
-# insert proper domain name
-sed -r -i "s/ServerName IPADDRESS:443/ServerName $mw_api_domain:443/g;" ./httpd.conf
-
-
 
 
 # create service script
@@ -109,14 +105,6 @@ cd /etc/logrotate.d
 cp "$m_meza/scripts/logrotated_httpd" ./httpd
 
 cd "$m_htdocs"
-
-#
-# Defer starting httpd until PHP installed
-#
-# # Start webserver service
-# chkconfig httpd on
-# service httpd status
-# service httpd restart
 
 
 # modify firewall rules
@@ -149,5 +137,4 @@ else
 fi
 
 
-echo -e "\n\nYour Apache 2.4 webserver has been setup.\n\nPlease use the web browser on your host computer to navigate to http://192.168.56.56 to test it out"
-
+# Apache httpd service not started yet. Started in php.sh

--- a/scripts/config/httpd.conf
+++ b/scripts/config/httpd.conf
@@ -504,7 +504,7 @@ SSLRandomSeed connect builtin
 Listen 80
 <VirtualHost *:80>
      ServerName Meza:80
-     Redirect "/" "https://"
+     Redirect "/" "https://INSERT-DOMAIN-OR-IP"
 </VirtualHost>
 
 # main handling via https

--- a/scripts/config/httpd.conf
+++ b/scripts/config/httpd.conf
@@ -40,24 +40,6 @@ ServerRoot "/usr/local/apache2"
 #
 # Mutex default:logs
 
-#
-# Listen: Allows you to bind Apache to specific IP addresses and/or
-# ports, instead of the default. See also the <VirtualHost>
-# directive.
-#
-# Change this to Listen on specific IP addresses as shown below to
-# prevent Apache from glomming onto all bound IP addresses.
-#
-#Listen 12.34.56.78:80
-Listen 443
-
-ServerName IPADDRESS:443
-LoadModule ssl_module modules/mod_ssl.so
-
-SSLEngine on
-SSLCertificateFile /etc/pki/tls/certs/meza.crt
-SSLCertificateKeyFile /etc/pki/tls/private/meza.key
-
 
 #
 # Dynamic Shared Object (DSO) Support
@@ -134,7 +116,7 @@ LoadModule version_module modules/mod_version.so
 #LoadModule session_cookie_module modules/mod_session_cookie.so
 #LoadModule session_dbd_module modules/mod_session_dbd.so
 #LoadModule slotmem_shm_module modules/mod_slotmem_shm.so
-#LoadModule ssl_module modules/mod_ssl.so
+LoadModule ssl_module modules/mod_ssl.so
 #LoadModule lbmethod_byrequests_module modules/mod_lbmethod_byrequests.so
 #LoadModule lbmethod_bytraffic_module modules/mod_lbmethod_bytraffic.so
 #LoadModule lbmethod_bybusyness_module modules/mod_lbmethod_bybusyness.so
@@ -220,40 +202,40 @@ ServerAdmin you@example.com
 # documents. By default, all requests are taken from this directory, but
 # symbolic links and aliases may be used to point to other locations.
 #
-DocumentRoot "/opt/meza/htdocs"
-<Directory "/opt/meza/htdocs">
-    #
-    # Possible values for the Options directive are "None", "All",
-    # or any combination of:
-    #   Indexes Includes FollowSymLinks SymLinksifOwnerMatch ExecCGI MultiViews
-    #
-    # Note that "MultiViews" must be named *explicitly* --- "Options All"
-    # doesn't give it to you.
-    #
-    # The Options directive is both complicated and important.  Please see
-    # http://httpd.apache.org/docs/2.4/mod/core.html#options
-    # for more information.
-    #
-    Options Indexes FollowSymLinks
+# DocumentRoot "/opt/meza/htdocs"
+# <Directory "/opt/meza/htdocs">
+#     #
+#     # Possible values for the Options directive are "None", "All",
+#     # or any combination of:
+#     #   Indexes Includes FollowSymLinks SymLinksifOwnerMatch ExecCGI MultiViews
+#     #
+#     # Note that "MultiViews" must be named *explicitly* --- "Options All"
+#     # doesn't give it to you.
+#     #
+#     # The Options directive is both complicated and important.  Please see
+#     # http://httpd.apache.org/docs/2.4/mod/core.html#options
+#     # for more information.
+#     #
+#     Options Indexes FollowSymLinks
 
-    #
-    # AllowOverride controls what directives may be placed in .htaccess files.
-    # It can be "All", "None", or any combination of the keywords:
-    #   AllowOverride FileInfo AuthConfig Limit
-    #
-    AllowOverride all
+#     #
+#     # AllowOverride controls what directives may be placed in .htaccess files.
+#     # It can be "All", "None", or any combination of the keywords:
+#     #   AllowOverride FileInfo AuthConfig Limit
+#     #
+#     AllowOverride all
 
-    #
-    # Controls who can get stuff from this server.
-    #
-    Require all granted
+#     #
+#     # Controls who can get stuff from this server.
+#     #
+#     Require all granted
 
-    #
-    # Disable directory browsing
-    #
-    Options All -Indexes
+#     #
+#     # Disable directory browsing
+#     #
+#     Options All -Indexes
 
-</Directory>
+# </Directory>
 
 #
 # DirectoryIndex: sets the file that Apache will serve if a directory
@@ -517,13 +499,69 @@ SSLRandomSeed connect builtin
 
 
 
-#################################################
-#                                               #
-# The contents below were added via the GitHub  #
-# repository EnterpriseMediaWiki/meza           #
-#                                               #
-#################################################
 
+# http redirect to https
+Listen 80
+<VirtualHost *:80>
+     ServerName Meza:80
+     Redirect "/" "https://"
+</VirtualHost>
+
+# main handling via https
+Listen 443
+<VirtualHost *:443>
+	SSLEngine on
+	SSLCertificateFile /etc/pki/tls/certs/meza.crt
+	SSLCertificateKeyFile /etc/pki/tls/private/meza.key
+
+	<Directory /opt/meza/htdocs>
+
+		#
+		AllowOverride All
+
+		#
+		Options Indexes FollowSymLinks
+
+		# Controls who can get stuff from this server.
+		Require all granted
+
+		# Disable directory browsing
+		Options All -Indexes
+	</Directory>
+
+	DocumentRoot /opt/meza/htdocs
+	ServerName Meza:443
+
+</VirtualHost>
+
+# Allow non-https access via port 8142. This port is NOT accessible
+# externally (e.g. 8142 is not opened in the firewall). This port
+# is to be used by Parsoid for non-SSL traffic internally.
+Listen 8142
+<VirtualHost *:8142>
+	<Directory /opt/meza/htdocs>
+
+		#
+		AllowOverride All
+
+		#
+		Options Indexes FollowSymLinks
+
+		# Controls who can get stuff from this server.
+		Require all granted
+
+		# Disable directory browsing
+		Options All -Indexes
+	</Directory>
+
+	DocumentRoot /opt/meza/htdocs
+	ServerName Meza:8142
+</VirtualHost>
+
+
+#
+# Handle files ending in .php, .php5, .php6, etc with PHP
+#
 <FilesMatch "\.ph(p[2-6]?|tml)$">
     SetHandler application/x-httpd-php
 </FilesMatch>
@@ -539,3 +577,4 @@ SSLRandomSeed connect builtin
     Order Allow,Deny
     Deny From All
 </DirectoryMatch>
+

--- a/scripts/config/httpd.conf
+++ b/scripts/config/httpd.conf
@@ -49,7 +49,15 @@ ServerRoot "/usr/local/apache2"
 # prevent Apache from glomming onto all bound IP addresses.
 #
 #Listen 12.34.56.78:80
-Listen 80
+Listen 443
+
+ServerName IPADDRESS:443
+LoadModule ssl_module modules/mod_ssl.so
+
+SSLEngine on
+SSLCertificateFile /etc/pki/tls/certs/meza.crt
+SSLCertificateKeyFile /etc/pki/tls/private/meza.key
+
 
 #
 # Dynamic Shared Object (DSO) Support

--- a/scripts/config/httpd.conf
+++ b/scripts/config/httpd.conf
@@ -504,7 +504,7 @@ SSLRandomSeed connect builtin
 Listen 80
 <VirtualHost *:80>
      ServerName Meza:80
-     Redirect "/" "https://INSERT-DOMAIN-OR-IP"
+     Redirect "/" "https://INSERT-DOMAIN-OR-IP/"
 </VirtualHost>
 
 # main handling via https

--- a/scripts/config/httpd.conf
+++ b/scripts/config/httpd.conf
@@ -501,11 +501,13 @@ SSLRandomSeed connect builtin
 
 
 # http redirect to https
-Listen 80
-<VirtualHost *:80>
-     ServerName Meza:80
-     Redirect "/" "https://INSERT-DOMAIN-OR-IP/"
-</VirtualHost>
+# UNFORTUNATELY this is not playing nicely with Elasticsearch and is
+# disabled for now.
+# Listen 80
+# <VirtualHost *:80>
+#      ServerName MezaHttpRedirect
+#      Redirect "/" "https://INSERT-DOMAIN-OR-IP/"
+# </VirtualHost>
 
 # main handling via https
 Listen 443
@@ -530,7 +532,7 @@ Listen 443
 	</Directory>
 
 	DocumentRoot /opt/meza/htdocs
-	ServerName Meza:443
+	ServerName Meza
 
 </VirtualHost>
 
@@ -555,7 +557,7 @@ Listen 8142
 	</Directory>
 
 	DocumentRoot /opt/meza/htdocs
-	ServerName Meza:8142
+	ServerName MezaParsoidEntryPoint
 </VirtualHost>
 
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -117,6 +117,7 @@ read -e -i $default_mediawiki_git_install mediawiki_git_install
 mediawiki_git_install=${mediawiki_git_install:-$default_mediawiki_git_install}
 
 
+echo ""
 echo "Next you're going to setup your self-signed certificate for https."
 echo "Enter values for each of the following fields. Hit any key to continue."
 read -s dummy # is there another way to do this?

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -83,11 +83,12 @@ echo -e "or leave blank for a randomly generated password and press [ENTER]:"
 read -s mysql_root_pass
 mysql_root_pass=${mysql_root_pass:-$default_mysql_root_pass}
 
-# Prompt user for MW API protocol
-default_mw_api_protocol="http"
-echo -e "\nType http or https for MW API and press [ENTER]:"
-read -e -i $default_mw_api_protocol mw_api_protocol
-mw_api_protocol=${mw_api_protocol:-$default_mw_api_protocol}
+# Prompt user for MW API protocol -- ASSUME HTTPS. Perhaps we'll remove this assumption later
+# default_mw_api_protocol="http"
+# echo -e "\nType http or https for MW API and press [ENTER]:"
+# read -e -i $default_mw_api_protocol mw_api_protocol
+# mw_api_protocol=${mw_api_protocol:-$default_mw_api_protocol}
+mw_api_protocol=https
 
 # Prompt user for MW API Domain or IP address
 # This for loop attempts to find the correct network adapter from which to pull the domain or IP address
@@ -114,6 +115,16 @@ default_mediawiki_git_install="y"
 echo -e "\nInstall MediaWiki with git? (y/n) [ENTER]:"
 read -e -i $default_mediawiki_git_install mediawiki_git_install
 mediawiki_git_install=${mediawiki_git_install:-$default_mediawiki_git_install}
+
+
+echo "Next you're going to setup your self-signed certificate for https."
+echo "Enter values for each of the following fields. Hit any key to continue."
+read -s dummy # is there another way to do this?
+
+
+# generate a self-signed SSL signature (for swap-out of a good signature later, of course!)
+sudo openssl req -newkey rsa:2048 -nodes -keyout /etc/pki/tls/private/meza.key -x509 -days 365 -out /etc/pki/tls/certs/meza.crt
+
 
 
 # Check if git installed, and install it if required


### PR DESCRIPTION
Initial certificate is self-signed. Should be easy to drop in proper certificates later.

## Changes

* Parsoid accesses MediaWiki's PHP API via port 8142 now. Special handling in httpd.conf.
* Firewall opens both http and https ports 80 and 443 (for future forwarding of http to https)
* Attempted to make http forward to https, which worked for that purpose but broke Elasticsearch. This has been disabled for now and will be solved later.
* httpd load mod_ssl
* http vs https option removed from initial prompts in `install.sh`
* Prompts added to `install.sh` for setting up self-signed certificate