### PR TITLE
Install MediaWiki 1.26

### DIFF
--- a/scripts/VE.sh
+++ b/scripts/VE.sh
@@ -90,7 +90,7 @@ cp ./localsettings.js /etc/parsoid/localsettings.js
 # Insert contents of "$mw_api_uri" in place of "<<INSERTED_BY_VE.sh>>"
 # Note on escape syntax: result="${original_var//text_to_replace/text_to_replace_with}
 escaped_mw_api_uri=${mw_api_uri//\//\\\/} # need to replace / with \/ for regex
-sed -r -i "s/INSERTED_BY_VE_SCRIPT/$escaped_mw_api_uri/g;" /etc/parsoid/api/localsettings.js
+sed -r -i "s/INSERTED_BY_VE_SCRIPT/$escaped_mw_api_uri/g;" /etc/parsoid/localsettings.js
 
 
 #

--- a/scripts/VE.sh
+++ b/scripts/VE.sh
@@ -84,7 +84,7 @@ echo "******* Downloading configuration files *******"
 cd "$m_meza/scripts"
 
 # Copy Parsoid settings from Meza to Parsoid install
-cp ./localsettings.js /etc/parsoid/api/localsettings.js
+cp ./localsettings.js /etc/parsoid/localsettings.js
 
 # Insert proper MediaWiki API URI
 # Insert contents of "$mw_api_uri" in place of "<<INSERTED_BY_VE.sh>>"

--- a/scripts/config/LocalSettings.php
+++ b/scripts/config/LocalSettings.php
@@ -577,7 +577,7 @@ $egExtensionLoader = new ExtensionLoader();
 require_once $egExtensionLoader->registerLegacyExtension(
 	"ParserFunctions",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/ParserFunctions.git",
-	"REL1_25"
+	"REL1_26"
 );
 $wgPFEnableStringFunctions = true;
 
@@ -588,7 +588,7 @@ $wgPFEnableStringFunctions = true;
 require_once $egExtensionLoader->registerLegacyExtension(
 	"StringFunctionsEscaped",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/StringFunctionsEscaped.git",
-	"REL1_25"
+	"REL1_26"
 );
 
 
@@ -598,7 +598,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"ExternalData",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/ExternalData.git",
-	"REL1_25"
+	"REL1_26"
 );
 
 
@@ -608,7 +608,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"LabeledSectionTransclusion",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/LabeledSectionTransclusion.git",
-	"REL1_25"
+	"REL1_26"
 );
 
 
@@ -618,7 +618,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"Cite",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/Cite.git",
-	"REL1_25"
+	"REL1_26"
 );
 $wgCiteEnablePopups = true;
 
@@ -639,7 +639,7 @@ $wgCiteEnablePopups = true;
 require_once $egExtensionLoader->registerLegacyExtension(
 	"WhoIsWatching",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/WhoIsWatching.git",
-	"REL1_25"
+	"REL1_26"
 );
 $wgPageShowWatchingUsers = true;
 
@@ -650,7 +650,7 @@ $wgPageShowWatchingUsers = true;
 require_once $egExtensionLoader->registerLegacyExtension(
 	"CharInsert",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/CharInsert.git",
-	"REL1_25"
+	"REL1_26"
 );
 
 
@@ -660,7 +660,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"SemanticForms",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/SemanticForms.git",
-	"REL1_25"
+	"REL1_26"
 );
 
 
@@ -670,7 +670,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"SemanticInternalObjects",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/SemanticInternalObjects.git",
-	"REL1_25"
+	"REL1_26"
 );
 
 
@@ -680,7 +680,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"SemanticCompoundQueries",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/SemanticCompoundQueries.git",
-	"REL1_25"
+	"REL1_26"
 );
 
 
@@ -690,7 +690,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"Arrays",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/Arrays.git",
-	"REL1_25"
+	"REL1_26"
 );
 
 
@@ -700,7 +700,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"TitleKey",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/TitleKey.git",
-	"REL1_25"
+	"REL1_26"
 );
 
 
@@ -720,7 +720,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"AdminLinks",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/AdminLinks.git",
-	"REL1_25"
+	"REL1_26"
 );
 $wgGroupPermissions['sysop']['adminlinks'] = true;
 
@@ -731,7 +731,7 @@ $wgGroupPermissions['sysop']['adminlinks'] = true;
 require_once $egExtensionLoader->registerLegacyExtension(
 	"DismissableSiteNotice",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/DismissableSiteNotice.git",
-	"REL1_25"
+	"REL1_26"
 );
 
 
@@ -741,7 +741,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"BatchUserRights",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/BatchUserRights.git",
-	"REL1_25"
+	"REL1_26"
 );
 
 
@@ -751,7 +751,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"HeaderTabs",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/HeaderTabs.git",
-	"REL1_25"
+	"REL1_26"
 );
 $htEditTabLink = false;
 $htRenderSingleTab = true;
@@ -763,7 +763,7 @@ $htRenderSingleTab = true;
 require_once $egExtensionLoader->registerLegacyExtension(
 	"WikiEditor",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/WikiEditor.git",
-	"REL1_25"
+	"REL1_26"
 );
 $wgDefaultUserOptions['usebetatoolbar'] = 1;
 $wgDefaultUserOptions['usebetatoolbar-cgd'] = 1;
@@ -794,7 +794,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"SyntaxHighlight_GeSHi",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/SyntaxHighlight_GeSHi.git",
-	"REL1_25"
+	"REL1_26"
 );
 
 
@@ -825,7 +825,7 @@ $egApprovedRevsAutomaticApprovals = false;
 require_once $egExtensionLoader->registerLegacyExtension(
 	"InputBox",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/InputBox.git",
-	"REL1_25"
+	"REL1_26"
 );
 
 
@@ -835,7 +835,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"ReplaceText",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/ReplaceText.git",
-	"REL1_25"
+	"REL1_26"
 );
 
 
@@ -845,7 +845,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"Interwiki",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/Interwiki.git",
-	"REL1_25"
+	"REL1_26"
 );
 $wgGroupPermissions['sysop']['interwiki'] = true;
 
@@ -899,7 +899,7 @@ $egPendingReviewsEmphasizeDays = 10;
 require_once $egExtensionLoader->registerLegacyExtension(
 	"Variables",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/Variables.git",
-	"REL1_25"
+	"REL1_26"
 );
 
 
@@ -919,7 +919,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"YouTube",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/YouTube.git",
-	"REL1_25"
+	"REL1_26"
 );
 
 
@@ -929,7 +929,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"ContributionScores",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/ContributionScores.git",
-	"REL1_25"
+	"REL1_26"
 );
 // Exclude Bots from the reporting - Can be omitted.
 $wgContribScoreIgnoreBots = true;
@@ -972,7 +972,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"PdfHandler",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/PdfHandler",
-	"REL1_25"
+	"REL1_26"
 );
 // Location of PdfHandler dependencies
 $wgPdfProcessor = '/usr/bin/gs'; // installed via yum
@@ -986,7 +986,7 @@ $wgPdfInfo = '/usr/local/bin/pdfinfo'; // pre-built binaries installed
 require_once $egExtensionLoader->registerLegacyExtension(
 	"UniversalLanguageSelector",
 	"https://gerrit.wikimedia.org/r/p/mediawiki/extensions/UniversalLanguageSelector.git",
-	"REL1_25"
+	"REL1_26"
 );
 
 
@@ -996,7 +996,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"VisualEditor",
 	"https://gerrit.wikimedia.org/r/p/mediawiki/extensions/VisualEditor.git",
-	"REL1_25"
+	"REL1_26"
 );
 // Allow read and edit permission for requests from the server (e.g. Parsoid)
 // Ref: https://www.mediawiki.org/wiki/Talk:Parsoid/Archive#Running_Parsoid_on_a_.22private.22_wiki_-_AccessDeniedError
@@ -1017,13 +1017,13 @@ $wgHiddenPrefs[] = 'visualeditor-enable';
 // OPTIONAL: Enable VisualEditor's experimental code features
 #$wgDefaultUserOptions['visualeditor-enable-experimental'] = 1;
 
-// URL to the Parsoid instance
-// MUST NOT end in a slash due to Parsoid bug
-$wgVisualEditorParsoidURL = 'http://127.0.0.1:8000';
 
-// Interwiki prefix to pass to the Parsoid instance
-// Parsoid will be called as $url/$prefix/$pagename
-$wgVisualEditorParsoidPrefix = $wikiId;
+// must match localsettings.js
+$wgVirtualRestConfig['modules']['parsoid'] = array(
+        'url' => 'http://127.0.0.1:8000',
+        'domain' => 'localhost',
+        'prefix' => $wikiId
+);
 
 // Define which namespaces will use VE
 $wgVisualEditorNamespaces = array_merge(
@@ -1040,7 +1040,7 @@ $wgVisualEditorNamespaces = array_merge(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"Elastica",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/Elastica.git",
-	"REL1_25"
+	"REL1_26"
 );
 
 
@@ -1050,7 +1050,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"CirrusSearch",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/CirrusSearch.git",
-	"REL1_25"
+	"REL1_26"
 );
 $wgSearchType = 'CirrusSearch';
 include "$m_htdocs/wikis/$wikiId/config/disableSearchUpdate.php";
@@ -1063,7 +1063,7 @@ include "$m_htdocs/wikis/$wikiId/config/disableSearchUpdate.php";
 require_once $egExtensionLoader->registerLegacyExtension(
 	"Echo",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/Echo.git",
-	"REL1_25"
+	"REL1_26"
 );
 $wgEchoEmailFooterAddress = $wgPasswordSender;
 
@@ -1074,7 +1074,7 @@ $wgEchoEmailFooterAddress = $wgPasswordSender;
 require_once $egExtensionLoader->registerLegacyExtension(
 	"Thanks",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/Thanks.git",
-	"REL1_25"
+	"REL1_26"
 );
 $wgThanksConfirmationRequired = false;
 
@@ -1085,7 +1085,7 @@ $wgThanksConfirmationRequired = false;
 require_once $egExtensionLoader->registerLegacyExtension(
 	'UploadWizard',
 	'https://gerrit.wikimedia.org/r/mediawiki/extensions/UploadWizard',
-	'REL1_25'
+	'REL1_26'
 );
 
 // Needed to make UploadWizard work in IE, see bug 39877
@@ -1118,7 +1118,7 @@ $wgUploadWizardConfig = array(
 // require_once $egExtensionLoader->registerLegacyExtension(
 // 	'Flow',
 // 	'https://gerrit.wikimedia.org/r/mediawiki/extensions/Flow.git',
-// 	'REL1_25'
+// 	'REL1_26'
 // );
 
 // // only allow sysops to create new flow boards

--- a/scripts/extensions.sh
+++ b/scripts/extensions.sh
@@ -48,6 +48,9 @@ git submodule update --init
 cd "$m_mediawiki/extensions/Elastica"
 composer install
 
+# Install SyntaxHighlight dependencies
+cd "$m_mediawiki/extensions/SyntaxHighlight_GeSHi"
+composer install
 
 
 

--- a/scripts/initd_parsoid.sh
+++ b/scripts/initd_parsoid.sh
@@ -11,10 +11,10 @@
 USER="parsoid"
 
 DAEMON="/usr/local/bin/node"
-ROOT_DIR="/etc/parsoid/api"
+ROOT_DIR="/etc/parsoid/bin"
 
 SERVER="$ROOT_DIR/server.js"
-LOG_FILE="$ROOT_DIR/server.js.log"
+LOG_FILE="$ROOT_DIR/../server.js.log"
 
 LOCK_FILE="/var/lock/subsys/node-server"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -66,7 +66,7 @@ usergithubtoken=${usergithubtoken:-$default_usergithubtoken}
 #   9260e5d       (a sha1 hash)
 #   tags/v0.4.1   (a tag name)
 #   master        (a branch name)
-parsoid_version="ba26a55"
+parsoid_version="8976ab9"
 
 # Prompt user for PHP version
 default_phpversion="5.6.14"

--- a/scripts/localsettings.js
+++ b/scripts/localsettings.js
@@ -24,7 +24,8 @@ exports.setup = function(parsoidConfig) {
 	for ( var i = 0; i < wikis.length; i++ ) {
 		parsoidConfig.setMwApi( {
 			prefix: wikis[i],
-			uri: domain + wikis[i] + '/api.php'
+			uri: domain + wikis[i] + '/api.php',
+			domain: "localhost"
 		} );
 	}
 

--- a/scripts/mediawiki.sh
+++ b/scripts/mediawiki.sh
@@ -50,14 +50,14 @@ if [ "$mediawiki_git_install" = "y" ]; then
 	cd mediawiki
 
 	# Checkout latest released version
-	git checkout tags/1.25.1
+	git checkout tags/1.26.2
 	cmd_profile "END mediawiki git clone"
 else
 	cmd_profile "START mediawiki get from tarball"
-	wget http://releases.wikimedia.org/mediawiki/1.25/mediawiki-core-1.25.1.tar.gz
+	wget http://releases.wikimedia.org/mediawiki/1.26/mediawiki-core-1.26.2.tar.gz
 
 	mkdir mediawiki
-	tar xpvf mediawiki-core-1.25.1.tar.gz -C ./mediawiki --strip-components 1
+	tar xpvf mediawiki-core-1.26.1.tar.gz -C ./mediawiki --strip-components 1
 	cd mediawiki
 	cmd_profile "END mediawiki get from tarball"
 fi
@@ -81,12 +81,12 @@ if [ "$mediawiki_git_install" = "y" ]; then
 	# git clone https://github.com/wikimedia/mediawiki-skins-Vector.git Vector
 	git clone https://gerrit.wikimedia.org/r/p/mediawiki/skins/Vector.git Vector
 	cd Vector
-	git checkout REL1_25
+	git checkout REL1_26
 	cd ..
 else
-	wget https://github.com/wikimedia/mediawiki-skins-Vector/archive/REL1_25.tar.gz
+	wget https://github.com/wikimedia/mediawiki-skins-Vector/archive/REL1_26.tar.gz
 	mkdir Vector
-	tar xpvf REL1_25.tar.gz -C ./Vector --strip-components 1
+	tar xpvf REL1_26.tar.gz -C ./Vector --strip-components 1
 fi
 
 #


### PR DESCRIPTION
This pull request will add MediaWiki 1.26 and extensions to the meza v0.9 branch.

### Testing
* `curl -LO https://raw.githubusercontent.com/enterprisemediawiki/meza/mw1_26/scripts/install.sh`
* `sudo bash install.sh`
* Use `mw1_26` branch
* Perform normal tests.

### Changes
* Parsoid changes
  * Parsoid settings file `localsettings.js` moved from `/etc/parsoid/api` directory to `/etc/parsoid`. Could not find when in Parsoid development that requirement changed.
  * Parsoid `server.js` moved to `/etc/parsoid/bin`
  * Checking out parsoid commit `8976ab9`, which was the latest commit as of my testing. Ideally there would be a branch or a tag we could checkout, but that does not appear to be the case
  * Add "domain" param to localsettings.js parsoidConfig
* Checking out REL1_26 branch of all extensions
* Extension:SyntaxHighlight (aka Extension:SyntaxHighlight_GeSHi, though it doesn't use GeSHi anymore) now requires `composer install`
* VisualEditor config now within `$wgVirtualRestConfig` variable
* Updated install-meza-without-git lines, but did not test them (since I think these should be removed)

### Issues

* Closes #271 