### PR TITLE
Bump to MW 1.25.5 from MW 1.25.1

### DIFF
--- a/scripts/mediawiki.sh
+++ b/scripts/mediawiki.sh
@@ -50,14 +50,14 @@ if [ "$mediawiki_git_install" = "y" ]; then
 	cd mediawiki
 
 	# Checkout latest released version
-	git checkout tags/1.25.1
+	git checkout tags/1.25.5
 	cmd_profile "END mediawiki git clone"
 else
 	cmd_profile "START mediawiki get from tarball"
-	wget http://releases.wikimedia.org/mediawiki/1.25/mediawiki-core-1.25.1.tar.gz
+	wget http://releases.wikimedia.org/mediawiki/1.25/mediawiki-core-1.25.5.tar.gz
 
 	mkdir mediawiki
-	tar xpvf mediawiki-core-1.25.1.tar.gz -C ./mediawiki --strip-components 1
+	tar xpvf mediawiki-core-1.25.5.tar.gz -C ./mediawiki --strip-components 1
 	cd mediawiki
 	cmd_profile "END mediawiki get from tarball"
 fi


### PR DESCRIPTION
Bumping to MW 1.25.5 from 1.25.1.

## Testing

* `curl -LO https://raw.githubusercontent.com/enterprisemediawiki/meza/mw1.25.5/scripts/install.sh`
* `sudo bash install.sh`
* Use `mw1.25.5` branch
* Perform normal tests. 

## Issues

Closes #313 