### PR TITLE
Adding templates for issues and pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,1 @@
+Please don't forget to check out [CONTRIBUTING.md](https://github.com/enterprisemediawiki/meza/blob/master/CONTRIBUTING.md) before submitting an issue.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-A description of you pull request
+A description of the pull request
 
 ### Testing
 
@@ -18,3 +18,4 @@ A description of you pull request
 ### Issues
 
 * Closes #123456789 ???
+* Addresses #987654321 ???

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+A description of you pull request
+
+### Testing
+
+- [ ] `curl -LO https://raw.githubusercontent.com/enterprisemediawiki/meza/<<INSERT YOUR BRANCH>>/scripts/install.sh`
+- [ ] `sudo bash install.sh`
+- [ ] `<<INSERT YOUR BRANCH>>` branch
+- [ ] Perform standard tests from [CONTRIBUTING.md](https://github.com/enterprisemediawiki/meza/blob/master/CONTRIBUTING.md)
+- [ ] Any additional details for testing your specific changes?
+
+
+### Changes
+
+* List
+* Of
+* Changes
+
+### Issues
+
+* Closes #123456789 ???


### PR DESCRIPTION
Decided to try this out: https://github.com/blog/2111-issue-and-pull-request-templates. Seeing as the point of this pull request is that there should be standard content in PRs and issues, here's my standard content:

### Testing

- [x] Verify changes are going to do anything to meza
- [ ] Merge
- [ ] Actually test to see if templates work (can't imagine there's any way to test it before merging it to master)
- [ ] ...
- [ ] Profit!

### Changes

* Added `.github` directory with `ISSUE_TEMPLATE.md` and `PULL_REQUEST_TEMPLATE.md` to have standard content in issues and pull requests.

### Issues

* None