### PR TITLE
Relax elasticsearch API access to allow POST/PUT/DELETE

### DIFF
--- a/scripts/config/httpd.conf
+++ b/scripts/config/httpd.conf
@@ -456,7 +456,7 @@ Listen 8008
 	<Proxy balancer://main>
 		BalancerMember http://127.0.0.1:9200 max=1 retry=5
 
-		<Limit GET >
+		<Limit GET POST PUT DELETE>
 			Order Allow,Deny
 			Allow from all
 			AuthType Basic
@@ -465,10 +465,15 @@ Listen 8008
 			Require valid-user
 		</Limit>
 
-		<Limit POST PUT DELETE>
-			order deny,allow
-			deny from all
-		</Limit>
+		# ES plugins kopf and head won't allow queries with request bodies in
+		# GET requests, which means it's impossible to do more complex queries.
+		# I'm not sure if it's a good idea to have POST/PUT/DELETE available in
+		# production, but for pre-v1.0 it's good to be able to easily access
+		# the ES API.
+		#<Limit POST PUT DELETE>
+		#	order deny,allow
+		#	deny from all
+		#</Limit>
 
 	</Proxy>
 


### PR DESCRIPTION
In httpd.conf, this PR allows POST, PUT and DELETE requests to the Elasticsearch API. Without the ability to do POST it's impossible to do complex queries from ES management tools like Kopf. The API is still under authentication, so a username/password is required. If at some point in the future we need to re-restrict this that's fine, but during pre-v1.0 development it'll be nice to have easy access.

### Issues

* Assists with #70 
* Assists with #182 
* Assists with #296 
* Assists with #299