### PR TITLE
Fix images in VE

### DIFF
--- a/scripts/config/LocalSettings.php
+++ b/scripts/config/LocalSettings.php
@@ -1004,6 +1004,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 if ( isset( $_SERVER['REMOTE_ADDR'] ) && isset( $_SERVER['SERVER_ADDR'] )
 	&& $_SERVER['REMOTE_ADDR'] == $_SERVER['SERVER_ADDR'] )
 {
+	$wgServer = preg_replace( '/^http:\/\/([a-zA-Z\d-\.]+):9000/', 'https://$1', $wgServer );
 	$wgGroupPermissions['*']['read'] = true;
 	$wgGroupPermissions['*']['edit'] = true;
 }


### PR DESCRIPTION
Fixes issue of images not displaying in VE when the images existed already on the page. Newly-added images via VE always displayed well. See #329.

### Testing

- [x] `curl -LO https://raw.githubusercontent.com/enterprisemediawiki/meza/iss329/scripts/install.sh`
- [x] `sudo bash install.sh`
- [x] `iss329` branch
- [x] Perform standard tests from [CONTRIBUTING.md](https://github.com/enterprisemediawiki/meza/blob/master/CONTRIBUTING.md)

### Changes

* Make`$wgServer` get re-written to `https://<domain>` when parsoid accesses wiki via `http://<domain>:9000`.

### Issues

* Closes #329 
