### PR TITLE
Add Extension:CollapsibleVector

### DIFF
--- a/scripts/config/LocalSettings.php
+++ b/scripts/config/LocalSettings.php
@@ -1110,6 +1110,18 @@ $wgUploadWizardConfig = array(
 
 
 #
+# Extension:CollapsibleVector
+#
+require_once $egExtensionLoader->registerLegacyExtension(
+	'CollapsibleVector',
+	'https://gerrit.wikimedia.org/r/mediawiki/extensions/CollapsibleVector',
+	'REL1_25'
+);
+
+
+
+
+#
 # Extension:Flow
 #
 # Note: Flow removed due to being unable to search discussions. While the


### PR DESCRIPTION
Add Extension:CollapsibleVector to bring back collapsible items in the sidebar. This feature was removed in a recent version of the Vector skin, and this extension adds it back in.

### Testing

- [x] `curl -LO https://raw.githubusercontent.com/enterprisemediawiki/meza/collapse-vector/scripts/install.sh`
- [x] `sudo bash install.sh`
- [x] `collapse-vector` branch
- [x] Perform standard tests from [CONTRIBUTING.md](https://github.com/enterprisemediawiki/meza/blob/master/CONTRIBUTING.md)
- [x] Verify collapsible items in the sidebar

### Changes

* Add Extension:CollapsibleVector

### Issues

* Closes #310

