### PR TITLE
Slack

### DIFF
--- a/scripts/extensions.sh
+++ b/scripts/extensions.sh
@@ -20,8 +20,10 @@ echo -e "\n\nCreating new wiki called \"Demo Wiki\""
 imports_dir="new"
 wiki_id="demo"
 wiki_name="Demo Wiki"
+temp_slack="$slackwebhook" # don't notify when Demo Wiki is created.
+slackwebhook="n"
 source "$m_meza/scripts/create-wiki.sh"
-
+slackwebhook="$temp_slack"
 
 # Clone ExtensionLoader
 echo -e "\n\n## meza: Install ExtensionLoader and apply changes to MW settings"

--- a/scripts/import-remote-wikis.sh
+++ b/scripts/import-remote-wikis.sh
@@ -118,6 +118,18 @@ done
 
 cd "$full_remote_wikis_path"
 
+
+echo
+echo
+echo "Announce completion of each wiki on Slack?"
+echo "Enter webhook URI or leave blank to opt out:"
+read slackwebhook
+
+if [[ -z "$slackwebhook" ]]; then
+	slackwebhook="n"
+fi
+
+
 echo -e "\n\n\nIMPORTING WIKIS: $which_wikis\n"
 
 # copy each selected wiki directory, then get database

--- a/scripts/import-wikis.sh
+++ b/scripts/import-wikis.sh
@@ -220,7 +220,7 @@ for d in */ ; do
 		echo -e "\nSKIPPING elastic-build-index.sh (no CirrusSearch)"
 	fi
 
-	complete_msg="Wiki \"$wiki_id\" has been imported"
+	complete_msg="Wiki '$wiki_id' has been imported"
 	echo -e "\n$complete_msg\n"
 
 	if [[ ! -z "$slackwebhook" ]]; then

--- a/scripts/import-wikis.sh
+++ b/scripts/import-wikis.sh
@@ -226,7 +226,7 @@ for d in */ ; do
 	echo -e "\n$complete_msg\n"
 
 	if [[ ! -z "$slackwebhook" ]]; then
-		sudo bash "$m_meza/scripts/slack.sh" "$slackwebhook" "$complete_msg"
+		bash "$m_meza/scripts/slack.sh" "$slackwebhook" "$complete_msg"
 	fi
 
 	# delete remaining source files?

--- a/scripts/import-wikis.sh
+++ b/scripts/import-wikis.sh
@@ -87,6 +87,13 @@ if [ "$imports_dir" = "new" ]; then
 fi
 
 
+echo
+echo
+echo "Announce completion of each wiki on Slack?"
+echo "Enter webhook URI or leave blank to opt out:"
+read slackwebhook
+
+
 # setup configuration variables
 wikis_install_dir="$m_htdocs/wikis"
 skipped_wikis=""
@@ -213,7 +220,12 @@ for d in */ ; do
 		echo -e "\nSKIPPING elastic-build-index.sh (no CirrusSearch)"
 	fi
 
-	echo -e "\nWiki \"$wiki_id\" has been imported\n"
+	complete_msg="Wiki \"$wiki_id\" has been imported"
+	echo -e "\n$complete_msg\n"
+
+	if [[ ! -z "$slackwebhook" ]]; then
+		sudo bash "$m_meza/scripts/slack.sh" "$slackwebhook" "$complete_msg"
+	fi
 
 	# delete remaining source files?
 

--- a/scripts/import-wikis.sh
+++ b/scripts/import-wikis.sh
@@ -87,11 +87,13 @@ if [ "$imports_dir" = "new" ]; then
 fi
 
 
-echo
-echo
-echo "Announce completion of each wiki on Slack?"
-echo "Enter webhook URI or leave blank to opt out:"
-read slackwebhook
+if [[ -z "$slackwebhook" ]]; then
+	echo
+	echo
+	echo "Announce completion of each wiki on Slack?"
+	echo "Enter webhook URI or leave blank to opt out:"
+	read slackwebhook
+fi
 
 
 # setup configuration variables

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -126,9 +126,11 @@ read -s dummy # is there another way to do this?
 # generate a self-signed SSL signature (for swap-out of a good signature later, of course!)
 sudo openssl req -newkey rsa:2048 -nodes -keyout /etc/pki/tls/private/meza.key -x509 -days 365 -out /etc/pki/tls/certs/meza.crt
 
-
-echo "Announce completion on Slack? Enter webhook URI:"
-read $slackwebhook
+echo
+echo
+echo "Announce completion on Slack?"
+echo "Enter webhook URI or leave blank to opt out:"
+read slackwebhook
 
 
 # Check if git installed, and install it if required

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -275,31 +275,7 @@ echo "$cmd_times"
 
 # Announce on Slack if a slack webhook provided
 if [[ ! -z "$slackwebhook" ]]; then
-
-	text="Your meza installation is complete"
-
-	escapedText=$(echo $text | sed 's/"/\"/g' | sed "s/'/\'/g" )
-	json="{
-	    \"attachments\": [
-	        {
-	            \"color\": \"#339966\",
-	            \"fallback\": \"Installation times\",
-	            \"fields\": [
-	                {
-	                    \"short\": false,
-	                    \"title\": \"Installation times\",
-	                    \"value\": \"$cmd_times\"
-	                }
-	            ]
-	        }
-	    ],
-	    \"text\": \"Your meza installation is complete\"
-	}"
-
-	curl -s -d "payload=$json" "$slackwebhook"
-	echo
-	echo "Message sent to Slack webhook $slackwebhook"
-
+	sudo bash "$m_meza/scripts/slack.sh" "$slackwebhook" "Your meza installation is complete. Install times:" "$cmd_times"
 fi
 
 # Display Most Plusquamperfekt Wiki Pigeon of Victory

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -132,6 +132,10 @@ echo "Announce completion on Slack?"
 echo "Enter webhook URI or leave blank to opt out:"
 read slackwebhook
 
+if [[ -z "$slackwebhook" ]]; then
+	slackwebhook="n"
+fi
+
 
 # Check if git installed, and install it if required
 if ! hash git 2>/dev/null; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -279,7 +279,7 @@ echo "$cmd_times"
 
 # Announce on Slack if a slack webhook provided
 if [[ ! -z "$slackwebhook" ]]; then
-	sudo bash "$m_meza/scripts/slack.sh" "$slackwebhook" "Your meza installation is complete. Install times:" "$cmd_times"
+	bash "$m_meza/scripts/slack.sh" "$slackwebhook" "Your meza installation is complete. Install times:" "$cmd_times"
 fi
 
 # Display Most Plusquamperfekt Wiki Pigeon of Victory

--- a/scripts/slack.sh
+++ b/scripts/slack.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+#
+# Send a message to Slack
+
+slackwebhook="$1"
+title="$2"
+text="$3"
+
+
+# Announce on Slack if a slack webhook provided
+if [[ ! -z "$slackwebhook" ]]; then
+
+	if [[ ! -z "$title$text" ]]; then
+		primary="$title"
+		secondary="$text"
+	elif [[ ! -z "$title" ]]; then
+		primary="$title"
+	elif [[ ! -z "$text" ]]; then
+		primary="$text"
+	else
+		echo "no payload for webhook. exiting."
+		exit 1;
+	fi
+
+	# removed from json: \"text\": \"Your meza installation is complete\"
+
+
+	escapedPrimary=$(echo $title | sed 's/"/\"/g' | sed "s/'/\'/g" )
+
+
+
+	if [[ ! -z "$secondary" ]]; then
+		escapedSecondary=$(echo "$secondary" | sed 's/"/\"/g' | sed "s/'/\'/g" )
+		fields="\"title\": \"$escapedPrimary\" ,\"value\": \"$escapedSecondary\""
+	else
+		fields="\"value\": \"$escapedPrimary\""
+	fi
+
+	json="{
+	    \"attachments\": [
+	        {
+	            \"color\": \"#339966\",
+	            \"fallback\": \"$escapedPrimary\",
+	            \"fields\": [
+	                {
+	                    \"short\": false,
+	                    $fields
+	                }
+	            ]
+	        }
+	    ]
+	}"
+
+	curl -s -d "payload=$json" "$slackwebhook"
+	echo
+	echo
+	echo "Message sent to Slack webhook $slackwebhook"
+
+fi

--- a/scripts/slack.sh
+++ b/scripts/slack.sh
@@ -6,9 +6,12 @@ slackwebhook="$1"
 title="$2"
 text="$3"
 
-
 # Announce on Slack if a slack webhook provided
 if [[ ! -z "$slackwebhook" ]]; then
+
+	if [[ "$slackwebhook" = "n" ]]; then
+		exit;
+	fi
 
 	if [[ ! -z "$title$text" ]]; then
 		primary="$title"


### PR DESCRIPTION
Adds the option to provide a Slack webhook during installation or wiki creation/import. Merging into v0.9.

### Testing

- [ ] Create a slack webhook. See https://api.slack.com/incoming-webhooks
- [ ] `curl -LO https://raw.githubusercontent.com/enterprisemediawiki/meza/slack/scripts/install.sh`
- [ ] `sudo bash install.sh`
- [ ] `slack` branch
- [ ] Perform standard tests from [CONTRIBUTING.md](https://github.com/enterprisemediawiki/meza/blob/master/CONTRIBUTING.md)
- [ ] Test `create-wiki.sh`, `import-wikis.sh` and `import-remote-wikis.sh` with and without webhook

### Changes

* Slack announcements!

### Issues

* None
