### PR TITLE
fix m_apache config var to point to yum install

### DIFF
--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -9,4 +9,4 @@ m_htdocs="$m_meza/htdocs" # was: m_htdocs="$m_www_meza/htdocs"
 m_mediawiki="$m_htdocs/mediawiki"
 
 # app locations
-m_apache="/usr/local/apache2"
+m_apache="/etc/httpd"


### PR DESCRIPTION
`saml.sh` relies upon the `$m_apache` variable in `config.sh`. This variable was still set to the compiled-apache location. This PR changes it to the yum-installed location.

