### PR TITLE
Provide method for handling custom extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ While the goal is to have an entirely scripted install of CentOS and the entire 
 
 * [Creating and importing wikis](manual/AddingWikis.md)
 * [Accessing Elasticsearch plugins](manual/ElasticsearchPlugins.md)
+* [Installing additional extensions](manual/installing-additional-extensions.md)
 
 ## Contributing
 If you'd like to contribute to this project, please see [this guide on how to help](CONTRIBUTING.md).

--- a/config/meza/LocalSettings.php
+++ b/config/meza/LocalSettings.php
@@ -850,16 +850,6 @@ $wgGroupPermissions['sysop']['interwiki'] = true;
 
 
 #
-# Extension:IMSQuery
-#
-require_once $egExtensionLoader->registerLegacyExtension(
-	"IMSQuery",
-	"https://github.com/jamesmontalvo3/IMSQuery.git",
-	"master"
-);
-
-
-#
 # Extension:MasonryMainPage
 #
 require_once $egExtensionLoader->registerLegacyExtension(
@@ -899,16 +889,6 @@ require_once $egExtensionLoader->registerLegacyExtension(
 	"Variables",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/Variables.git",
 	"REL1_25"
-);
-
-
-#
-# Extension:SummaryTimeline
-#
-require_once $egExtensionLoader->registerLegacyExtension(
-	"SummaryTimeline",
-	"https://github.com/darenwelsh/SummaryTimeline.git",
-	"tags/0.2.0"
 );
 
 

--- a/config/template/more-extensions.php
+++ b/config/template/more-extensions.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ *  Additional extensions for meza
+ *
+ *  While you can choose to load additional extensions into meza however you'd,
+ *  this is one method. Move this file into `/opt/meza/config/local` and rename
+ *  it to `overrides.php`. If you already have `overrides.php` and would prefer
+ *  not to add all this content to it, pick another name and `require_once` the
+ *  file.
+ *
+ *  In the file below five other extensions are loaded, one by default and four
+ *  only if certain variables are set to `true`. Enabling these four extensions
+ *  can be done in each wiki's `setup.php` file (not the all-wiki `setup.php`)
+ *
+ **/
+
+
+#
+# Extension:IMSQuery
+#
+require_once $egExtensionLoader->registerLegacyExtension(
+	"IMSQuery",
+	"https://github.com/jamesmontalvo3/IMSQuery.git",
+	"master"
+);
+
+
+if ( isset( $mezaLoadSummaryTimeline ) && $mezaLoadSummaryTimeline ) {
+
+	#
+	# Extension:SummaryTimeline
+	#
+	require_once $egExtensionLoader->registerLegacyExtension(
+		"SummaryTimeline",
+		"https://github.com/darenwelsh/SummaryTimeline.git",
+		"tags/0.2.0"
+	);
+
+}
+
+
+if ( isset( $mezaLoadTOPO ) && $mezaLoadTOPO ) {
+
+	#
+	# Extension:HideSubPage
+	#
+	require_once $egExtensionLoader->registerLegacyExtension(
+		"HideSubPage",
+		"https://github.com/emanspeaks/HideSubPage.git",
+		"master"
+	);
+
+	#
+	# Extension:CrossReference
+	#
+	require_once $egExtensionLoader->registerLegacyExtension(
+		"CrossReference",
+		"https://github.com/jamesmontalvo3/CrossReference.git",
+		"master"
+	);
+
+	#
+	# Extension:TreeAndMenu
+	#
+	require_once $egExtensionLoader->registerLegacyExtension(
+		"TreeAndMenu",
+		"https://github.com/jamesmontalvo3/TreeAndMenu.git",
+		"master"
+	);
+
+
+	$wgHooks['BeforePageDisplay'][] = 'wfAddSidebarTree';
+	function wfAddSidebarTree( $out, $skin ) {
+		$title = Title::newFromText( 'SidebarTree', NS_MEDIAWIKI );
+		$article = new Article( $title );
+		$html = $out->parse( $article->getContent() );
+		$out->addHTML( "<div id=\"wikitext-sidebar\">$html</div>" );
+		return true;
+	}
+
+}

--- a/config/template/more-extensions.php
+++ b/config/template/more-extensions.php
@@ -33,7 +33,7 @@ if ( isset( $mezaLoadSummaryTimeline ) && $mezaLoadSummaryTimeline ) {
 	require_once $egExtensionLoader->registerLegacyExtension(
 		"SummaryTimeline",
 		"https://github.com/darenwelsh/SummaryTimeline.git",
-		"tags/0.2.0"
+		"tags/v0.2.0"
 	);
 
 }

--- a/manual/installing-additional-extensions.md
+++ b/manual/installing-additional-extensions.md
@@ -1,0 +1,20 @@
+Installing additional extensions
+================================
+
+meza comes pre-built with many extensions, but if you need additional extensions you can add them to any configuration file. The recommended method for adding extensions to all wikis is to use your "overrides.php" file in `/opt/meza/config/local`. This file may not already exist, but if you add it meza will automatically start using it.
+
+An example file is located at `/opt/meza/config/template/more-extensions.php`. This shows a method to load extensions for all wikis or just for select wikis.
+
+After you've moved this file into `overrides.php`, or included it from `overrides.php`, you need to perform the installation. To do that run:
+
+```
+sudo WIKI=<wiki-id> php /opt/meza/htdocs/mediawiki/extensions/ExtensionLoader/updateExtensions.php
+```
+
+Replace `<wiki-id>` with any wiki ID. If the extensions you are installing require database updates (e.g. if their install instructions tell you to run `update.php`) then you will need to run `update.php` for **all wikis**. To do that, run the following:
+
+```
+sudo WIKI=<wiki-id> php /opt/meza/htdocs/mediawiki/maintenance/update.php
+```
+
+Do the command above for all wiki IDs.


### PR DESCRIPTION
Provide method for handling custom extensions.

### Testing

- [x] `curl -LO https://raw.githubusercontent.com/enterprisemediawiki/meza/custom-ext/scripts/install.sh`
- [x] `sudo bash install.sh`
- [x] `custom-ext` branch
- [x] Perform standard tests from [CONTRIBUTING.md](https://github.com/enterprisemediawiki/meza/blob/master/CONTRIBUTING.md)
- [x] Install extensions from `more-extensions.php`

### Changes

* Removes SummaryTimeline and IMSQuery as default meza extensions
* Adds `/opt/meza/config/template/more-extensions.sh` as a template for how to add non-meza extensions, which includes SummaryTimeline, IMSQuery, and three other FOD-required extensions
* Documentation on the most-mezaiatic method for adding extensions

### Issues

* Closes #150 
* Closes #151 

