### PR TITLE
Email

### DIFF
--- a/config/meza/LocalSettings.php
+++ b/config/meza/LocalSettings.php
@@ -218,12 +218,6 @@ $wgEnotifUserTalk = false; # UPO
 $wgEnotifWatchlist = false; # UPO
 $wgEmailAuthentication = true;
 
-// https://www.mediawiki.org/wiki/Manual:$wgEmergencyContact
-$wgEmergencyContact = "enterprisemediawiki@gmail.com"; // @todo: this should be in setup, but this is easier for now.
-
-// https://www.mediawiki.org/wiki/Manual:$wgPasswordSender
-$wgPasswordSender = "enterprisemediawiki@gmail.com"; // @todo: this should be in setup, but this is easier for now.
-
 
 
 

--- a/config/template/setup.php
+++ b/config/template/setup.php
@@ -11,8 +11,13 @@
  * Enables or disables wiki email capabilities for all wikis, regardless of
  * of what their individual settings say.
  *
- * @todo enable this when
  **/
 // disabled by default for now, should be enabled later for
 $mezaEnableAllWikiEmail = false;
+
+// https://www.mediawiki.org/wiki/Manual:$wgPasswordSender
+$wgPasswordSender = "admin@example.com";
+
+// https://www.mediawiki.org/wiki/Manual:$wgEmergencyContact
+$wgEmergencyContact = $wgPasswordSender
 

--- a/config/template/setup.php
+++ b/config/template/setup.php
@@ -19,5 +19,5 @@ $mezaEnableAllWikiEmail = false;
 $wgPasswordSender = "admin@example.com";
 
 // https://www.mediawiki.org/wiki/Manual:$wgEmergencyContact
-$wgEmergencyContact = $wgPasswordSender
+$wgEmergencyContact = $wgPasswordSender;
 

--- a/scripts/install-pear.sh
+++ b/scripts/install-pear.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/expect
+#
+# This script is using "expect" to script user inputs for PEAR
+# since PEAR requires user prompts...there is no way to pass the
+# information into the script another way (except expect!)
+#
+# This says when prompted for "1-11, 'all' or Enter to continue:"
+# just send the carriage return (e.g. "enter to continue")
+
+spawn wget -O /tmp/go-pear.phar http://pear.php.net/go-pear.phar
+expect eof
+
+spawn php /tmp/go-pear.phar
+
+expect "1-11, 'all' or Enter to continue:"
+send "\r"
+expect eof
+
+spawn rm /tmp/go-pear.phar

--- a/scripts/install-pear.sh
+++ b/scripts/install-pear.sh
@@ -12,7 +12,7 @@ expect eof
 
 spawn php /tmp/go-pear.phar
 
-expect "1-11, 'all' or Enter to continue:"
+expect "1-12, 'all' or Enter to continue:"
 send "\r"
 expect eof
 

--- a/scripts/php.sh
+++ b/scripts/php.sh
@@ -107,6 +107,6 @@ service httpd restart
 # Install PEAR and PEAR Mail
 chmod 744 "$m_meza/scripts/install-pear.sh"
 "$m_meza/scripts/install-pear.sh"
-pear install --alldeps Mail
+/usr/local/php/bin/pear install --alldeps Mail
 
 echo -e "\n\nPHP has been setup.\n\nPlease use the web browser on your host computer to navigate to http://192.168.56.56/info.php to verify php is being executed."

--- a/scripts/php.sh
+++ b/scripts/php.sh
@@ -104,5 +104,9 @@ chkconfig httpd on
 service httpd status
 service httpd restart
 
+# Install PEAR and PEAR Mail
+chmod 744 "$m_meza/scripts/install-pear.sh"
+"$m_meza/scripts/install-pear.sh"
+pear install --alldeps Mail
 
 echo -e "\n\nPHP has been setup.\n\nPlease use the web browser on your host computer to navigate to http://192.168.56.56/info.php to verify php is being executed."

--- a/scripts/yums.sh
+++ b/scripts/yums.sh
@@ -133,6 +133,7 @@ yum install -y \
     mod_proxy_html \
     net-tools \
     vim \
+    sendmail \
     ghostscript
 cmd_profile "END yum install dependency list"
 

--- a/scripts/yums.sh
+++ b/scripts/yums.sh
@@ -134,6 +134,8 @@ yum install -y \
     net-tools \
     vim \
     sendmail \
+    sendmail-cf \
+    m4 \
     ghostscript
 cmd_profile "END yum install dependency list"
 

--- a/scripts/yums.sh
+++ b/scripts/yums.sh
@@ -136,6 +136,8 @@ yum install -y \
     sendmail \
     sendmail-cf \
     m4 \
+    expect \
+    expectk \
     ghostscript
 cmd_profile "END yum install dependency list"
 


### PR DESCRIPTION
Changes to make email notifications work

### Testing

- [x] `curl -LO https://raw.githubusercontent.com/enterprisemediawiki/meza/email/scripts/install.sh`
- [x] `sudo bash install.sh`
- [x] `email` branch
- [x] Perform standard tests from [CONTRIBUTING.md](https://github.com/enterprisemediawiki/meza/blob/master/CONTRIBUTING.md)
- [x] `sudo vi /opt/meza/config/local/setup.php` and enable email:
  - `$mezaEnableAllWikiEmail = true;`
  - `$wgPasswordSender = "your.name@domain.com";`: this should be a real email address ideally originating from your domain
- [x] Alternatively, set `$wgSMTP` like the following (you need to know your mail server):

```php
$wgSMTP = array(
        'host'     => "our.mail.server.gov", // could also be an IP address
        'IDHost'   => "my.host.computer.name", // Generally the domain name of the website (aka mywiki.org)
        'port'     => 25,    // Port to use when connecting to the SMTP server
        'auth'     => false  // our mail server doesn't require auth
);
```

### Changes

* Move `$wgEmergencyContact` and `$wgPasswordSender` out of `LocalSettings.php` and into `/opt/meza/config/local/setup.php`
* Make `php.sh` install PEAR and PEAR Mail package in order to support `$wgSMTP`
* Yum-install sendmail, sendmail-cf and m4 to support email functions
* Yum-install expect and expectk in order to install PEAR without user interaction (e.g. no prompts)

### Issues

* Closes #302 
