### PR TITLE
Provide method to rebuild Elasticsearch index

### DIFF
--- a/scripts/elastic-build-index.sh
+++ b/scripts/elastic-build-index.sh
@@ -7,7 +7,7 @@ echo "\$wgDisableSearchUpdate = true;" >> "$m_htdocs/wikis/$wiki_id/config/overr
 
 # Run script to generate elasticsearch index
 cd "$m_mediawiki"
-WIKI="$wiki_id" php "$m_mediawiki/extensions/CirrusSearch/maintenance/updateSearchIndexConfig.php"
+WIKI="$wiki_id" php "$m_mediawiki/extensions/CirrusSearch/maintenance/updateSearchIndexConfig.php" --startOver
 
 # Remove search-update disable in wiki-specific overrides
 sed -r -i 's/\$wgDisableSearchUpdate = true;//g;' "$m_htdocs/wikis/$wiki_id/config/overrides.php"

--- a/scripts/elastic-rebuild-index.sh
+++ b/scripts/elastic-rebuild-index.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+#
+#
+
+# must be root or sudoer
+if [ "$(whoami)" != "root" ]; then
+	echo "Try running this script with sudo: \"sudo bash import-wiki.sh\""
+	exit 1
+fi
+
+
+# If /usr/local/bin is not in PATH then add it
+# Ref enterprisemediawiki/meza#68 "Run install.sh with non-root user"
+if [[ $PATH != *"/usr/local/bin"* ]]; then
+	PATH="/usr/local/bin:$PATH"
+fi
+
+
+#
+# For now this script is not called within the same shell as install.sh
+# and thus it needs to know how to get to the config.sh script on it's own
+#
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source "/opt/meza/config/meza/config.sh"
+
+
+while [ -z "$wiki_id" ]; do
+	echo "Please enter the ID of the wiki needing index rebuilding:"
+	read wiki_id_test
+	if [ ! -z "$wiki_id_test" ] && [ -d "$m_htdocs/wikis/$wiki_id_test" ]; then
+		wiki_id="$wiki_id_test"
+	fi
+done
+
+echo "Rebuilding index for $wiki_id"
+
+source "$m_meza/scripts/elastic-build-index.sh"


### PR DESCRIPTION
Provides method to rebuild an Elasticsearch index. Really this is just using all of the existing CirrusSearch scripts, but the `elastic-rebuild-index.sh` script handles all the finer points. This is as-opposed to the `elastic-build-index.sh` script that already exists for wiki create/import.

### Testing

- [x] `curl -LO https://raw.githubusercontent.com/enterprisemediawiki/meza/es-rebuild/scripts/install.sh`
- [x] `sudo bash install.sh`
- [x] `es-rebuild` branch
- [x] Perform standard tests from [CONTRIBUTING.md](https://github.com/enterprisemediawiki/meza/blob/master/CONTRIBUTING.md)
- [x] [Import](https://github.com/enterprisemediawiki/meza/blob/master/manual/AddingWikis.md#importing-existing-wikis) a large wiki
  - [x] Verify Elasticsearch works
  - [x] Add user to ES reverse proxy (`sudo htpasswd -c /etc/httpd/.htpasswd <username>`) and inspect cluster with Kopf at `http://<your-domain>:8008/_plugin/kopf`
  - [x] Run `sudo bash /opt/meza/scripts/elastic-rebuild-index.sh` and rebuild the index for that wiki
  - [x] Verify Elasticsearch still works

### Changes

* Added `--startOver` option to `updateSearchIndexConfig.php` so it'll "blow away" the current index(es).
* Added `/opt/meza/scripts/elastic-rebuild-index.sh` which is a wrapper for `elastic-build-index.sh` and rebuilds an index from scratch

### Issues

* Closes #70 