### PR TITLE
Miscellaneous fixes for release v0.9

### DIFF
--- a/config/meza/LocalSettings.php
+++ b/config/meza/LocalSettings.php
@@ -80,14 +80,15 @@ require_once "$m_htdocs/wikis/$wikiId/config/setup.php";
  *  chosen. Options are listed from least impact to most impact.
  *    1) Add to the URI you're requesting `requestDebug=true` to enable debug
  *       for just that request.
- *    2) Set `$mezaCommandLineDebug = true;` for debug on the command line
+ *    2) Set `$mezaCommandLineDebug = true;` for debug on the command line.
+ *       This is the default, which can be overriden in setup.php.
  *    3) Set `$mezaDebug = array( "NDC\Your-ndc", ... );` in a wiki's setup.sh
  *       to enable debug for just specific users on a single wiki.
  *    4) Set `$mezaDebug = true;` in a wiki's setup.sh to enable debug for all
  *       users of a single wiki.
  *    5) Set `$mezaForceDebug = true;` to turn on debug for all users and wikis
  **/
-$mezaCommandLineDebug = false;
+$mezaCommandLineDebug = true; // don't we always want debug on command line?
 $mezaForceDebug = false;
 
 

--- a/config/meza/LocalSettings.php
+++ b/config/meza/LocalSettings.php
@@ -321,8 +321,12 @@ $wgMainCacheType = CACHE_MEMCACHED;
 $wgParserCacheType = CACHE_NONE; // optional; if set to CACHE_MEMCACHED, templates used to format query results in generic footer don't work
 $wgMessageCacheType = CACHE_MEMCACHED; // optional
 $wgMemCachedServers = array( "127.0.0.1:11211" );
-$wgSessionsInObjectCache = true; // optional
-$wgSessionCacheType = CACHE_MEMCACHED; // optional
+
+// memcached is setup and will work for sessions with meza, unless you use
+// SimpleSamlPhp. For that reason memcached is disabled for sessions. This will
+// be fixed in a later version.
+$wgSessionsInObjectCache = false; // optional
+$wgSessionCacheType = CACHE_NONE; // optional
 
 
 ## To enable image uploads, make sure the 'images' directory

--- a/config/meza/LocalSettings.php
+++ b/config/meza/LocalSettings.php
@@ -277,7 +277,7 @@ if ( file_exists( "$m_config/local/primewiki" ) ) {
 
 	// grab prime wiki data using closure to encapsulate the data
 	// and not overwrite existing config ($wgSitename, etc)
-	$primewiki = call_user_func( function() use ( $m_htdocs ) {
+	$primewiki = call_user_func( function() use ( $m_htdocs, $m_config ) {
 
 		$primeWikiId = trim( file_get_contents( "$m_config/local/primewiki" ) );
 

--- a/config/template/BlenderSettings.php
+++ b/config/template/BlenderSettings.php
@@ -1,7 +1,7 @@
 <?php
 
 $blenderTitle = "Meza Wikis";
-$blenderServer = "https://" . $_SERVER['SERVER_ADDR'] . "/";
+$blenderServer = "https://" . trim( file_get_contents( '/opt/meza/config/local/domain' ) ) . "/";
 $blenderScriptPath = '/WikiBlender';
 
 $primeWikiFile = '/opt/meza/config/local/primewiki';

--- a/scripts/apache.sh
+++ b/scripts/apache.sh
@@ -16,7 +16,7 @@ mv httpd.conf httpd.default.conf
 ln -s "$m_config/meza/httpd.conf" "$m_apache/conf/httpd.conf"
 
 # replace INSERT-DOMAIN-OR-IP with domain...or IP address
-sed -r -i "s/INSERT-DOMAIN-OR-IP/$mw_api_domain/g;" ./httpd.conf
+sed -r -i "s/INSERT-DOMAIN-OR-IP/$mw_api_domain/g;" "$m_config/meza/httpd.conf"
 
 # create logrotate file
 ln -s " $m_config/meza/logrotated_httpd" /etc/logrotate.d/httpd

--- a/scripts/import-remote-wikis.sh
+++ b/scripts/import-remote-wikis.sh
@@ -139,7 +139,7 @@ do
 	echo "Starting import of wiki '$wiki'"
 
 	echo "  Getting files..."
-	rsync -rva "./$wiki" /root/wikis
+	rsync -rva "./$wiki" /root/wikis/
 
 	wiki_db=`php /opt/meza/scripts/getDatabaseNameFromSetup.php $full_remote_wikis_path/$wiki/config/setup.php`
 	if [ -z "$wiki_db" ]; then

--- a/scripts/import-remote-wikis.sh
+++ b/scripts/import-remote-wikis.sh
@@ -139,7 +139,7 @@ do
 	echo "Starting import of wiki '$wiki'"
 
 	echo "  Getting files..."
-	rsync -rva "./$wiki" "/root/wikis/$wiki"
+	rsync -rva "./$wiki/" "/root/wikis/$wiki"
 
 	wiki_db=`php /opt/meza/scripts/getDatabaseNameFromSetup.php $full_remote_wikis_path/$wiki/config/setup.php`
 	if [ -z "$wiki_db" ]; then

--- a/scripts/import-remote-wikis.sh
+++ b/scripts/import-remote-wikis.sh
@@ -139,7 +139,7 @@ do
 	echo "Starting import of wiki '$wiki'"
 
 	echo "  Getting files..."
-	rsync -rva "./$wiki" /root/wikis/
+	rsync -rva "./$wiki" "/root/wikis/$wiki"
 
 	wiki_db=`php /opt/meza/scripts/getDatabaseNameFromSetup.php $full_remote_wikis_path/$wiki/config/setup.php`
 	if [ -z "$wiki_db" ]; then

--- a/scripts/import-remote-wikis.sh
+++ b/scripts/import-remote-wikis.sh
@@ -133,8 +133,14 @@ echo -e "\n\n\nIMPORTING WIKIS: $which_wikis\n"
 cd "$full_remote_wikis_path"
 
 # copy each selected wiki directory, then get database
-for wiki in $which_wikis
+for wiki_dir in $which_wikis
 do
+
+	# trim trailing slash from directory name
+	# ref: http://stackoverflow.com/questions/1848415/remove-slash-from-the-end-of-a-variable
+	# ref: http://www.network-theory.co.uk/docs/bashref/ShellParameterExpansion.html
+	wiki=${wiki_dir%/}
+
 	# @todo: delete existing wiki data?
 	echo "Starting import of wiki '$wiki'"
 

--- a/scripts/import-remote-wikis.sh
+++ b/scripts/import-remote-wikis.sh
@@ -116,7 +116,6 @@ do
 	read -s remote_db_password
 done
 
-cd "$full_remote_wikis_path"
 
 
 echo
@@ -129,8 +128,9 @@ if [[ -z "$slackwebhook" ]]; then
 	slackwebhook="n"
 fi
 
-
 echo -e "\n\n\nIMPORTING WIKIS: $which_wikis\n"
+
+cd "$full_remote_wikis_path"
 
 # copy each selected wiki directory, then get database
 for wiki in $which_wikis
@@ -139,7 +139,7 @@ do
 	echo "Starting import of wiki '$wiki'"
 
 	echo "  Getting files..."
-	cp -r "./$wiki" /root/wikis
+	rsync -rva "./$wiki" /root/wikis
 
 	wiki_db=`php /opt/meza/scripts/getDatabaseNameFromSetup.php $full_remote_wikis_path/$wiki/config/setup.php`
 	if [ -z "$wiki_db" ]; then
@@ -147,7 +147,7 @@ do
 	fi
 
 	echo "  Getting database..."
-	mysqldump -h $remote_db_server -u $remote_db_username -p$remote_db_password $wiki_db > "/root/wikis/$wiki/wiki.sql"
+	mysqldump -v -h $remote_db_server -u $remote_db_username -p$remote_db_password $wiki_db > "/root/wikis/$wiki/wiki.sql"
 
 done
 

--- a/scripts/import-wikis.sh
+++ b/scripts/import-wikis.sh
@@ -145,7 +145,7 @@ for d in */ ; do
 		mkdir "$wiki_install_path/config"
 	fi
 
-	# check if logo.png, favicon.ico, setup.php and CustomSettings.php exist. Else use defaults
+	# check if logo.png, favicon.ico, setup.php and overrides.php exist. Else use defaults
 	if [ ! -f "$wiki_install_path/config/logo.png" ]; then
 		cp "$m_config/template/wiki-init/config/logo.png" "$wiki_install_path/config/logo.png"
 	fi
@@ -153,7 +153,7 @@ for d in */ ; do
 		cp "$m_config/template/wiki-init/config/favicon.ico" "$wiki_install_path/config/favicon.ico"
 	fi
 	if [ ! -f "$wiki_install_path/config/overrides.php" ]; then
-		cp "$m_config/template/wiki-init/config/overrides.php" "$wiki_install_path/config/CustomSettings.php"
+		cp "$m_config/template/wiki-init/config/overrides.php" "$wiki_install_path/config/overrides.php"
 	fi
 	if [ ! -f "$wiki_install_path/config/setup.php" ]; then
 		cp "$m_config/template/wiki-init/config/setup.php" "$wiki_install_path/config/setup.php"

--- a/scripts/saml.sh
+++ b/scripts/saml.sh
@@ -125,7 +125,7 @@ sed -r -i "s/'technicalcontact_email'.*$/'technicalcontact_email' => '$saml_admi
 # in httpd.conf. See link below for more info:
 # http://unix.stackexchange.com/questions/32908/how-to-insert-the-content-of-a-file-into-another-file-before-a-pattern-marker
 # FIXME: httpd.conf should not be modified
-sed -i -e "/ADD SPECIAL CONFIG BELOW/r $m_meza/scripts/config/SAML/saml_httpd.conf" "$m_apache/conf/httpd.conf"
+sed -i -e "/ADD SPECIAL CONFIG BELOW/r $m_config/template/saml_httpd.conf" "$m_apache/conf/httpd.conf"
 
 # restart apache
 service httpd restart

--- a/scripts/saml.sh
+++ b/scripts/saml.sh
@@ -125,7 +125,7 @@ sed -r -i "s/'technicalcontact_email'.*$/'technicalcontact_email' => '$saml_admi
 # in httpd.conf. See link below for more info:
 # http://unix.stackexchange.com/questions/32908/how-to-insert-the-content-of-a-file-into-another-file-before-a-pattern-marker
 # FIXME: httpd.conf should not be modified
-sed -i -e "/ADD SPECIAL CONFIG BELOW/r $m_config/template/saml_httpd.conf" "$m_apache/conf/httpd.conf"
+sed -i -e "/ADD SPECIAL CONFIG BELOW/r $m_config/template/saml_httpd.conf" "$m_config/meza/httpd.conf"
 
 # restart apache
 service httpd restart

--- a/scripts/saml.sh
+++ b/scripts/saml.sh
@@ -177,6 +177,9 @@ sed -r -i "s/realname_attr/$realname_attr/g;" ~/SAML-LocalSettings-Additions.php
 sed -r -i "s/email_attr/$email_attr/g;" ~/SAML-LocalSettings-Additions.php
 
 # Add these lines to the bottom of LocalSettings.php, then remove the temp file
+if [ ! -f "$m_config/local/overrides.php" ]; then
+    echo -e "<?php\n\n" > "$m_config/local/overrides.php"
+fi
 cat ~/SAML-LocalSettings-Additions.php >> "$m_config/local/overrides.php";
 rm ~/SAML-LocalSettings-Additions.php
 

--- a/scripts/unifyUserTables.php
+++ b/scripts/unifyUserTables.php
@@ -82,7 +82,7 @@ class MezaUnifyUserTables extends Maintenance {
 			"userNameField" => "log_user_text"
 		),
 		"oldimage"      => array(
-			"unique" => "oi_sha1",
+			"unique" => "oi_archive_name",
 			"idField" => "oi_user",
 			"userNameField" => "oi_user_text"
 		),

--- a/scripts/unifyUserTables.php
+++ b/scripts/unifyUserTables.php
@@ -82,7 +82,8 @@ class MezaUnifyUserTables extends Maintenance {
 			"userNameField" => "log_user_text"
 		),
 		"oldimage"      => array(
-			"unique" => "oi_archive_name",
+			// tried oi_sha1 (not unique) and oi_archive_name (sometimes blank)
+			"unique" => array('oi_name','oi_timestamp'),
 			"idField" => "oi_user",
 			"userNameField" => "oi_user_text"
 		),
@@ -129,7 +130,6 @@ class MezaUnifyUserTables extends Maintenance {
 	public function __construct() {
 		parent::__construct();
 
-		$this->recordDir = __DIR__ . '/record';
 		$this->mDescription = "This combines all user tables into one. This is potentially very destructive. Make a backup first.";
 
 		// addOption ($name, $description, $required=false, $withArg=false, $shortName=false)
@@ -195,7 +195,7 @@ class MezaUnifyUserTables extends Maintenance {
 
 	public function checkSetup () {
 
-		global $m_htdocs, $m_config;
+		global $m_htdocs, $m_config, $m_meza;
 
 		if ( is_file( "$m_config/local/primewiki" ) ) {
 			die( "A prime wiki is already set in $m_config/local/primewiki. You cannot run this script." );
@@ -203,6 +203,8 @@ class MezaUnifyUserTables extends Maintenance {
 
 		// prime wiki ID and database name
 		$this->primeWiki = trim( $this->getOption( "prime-wiki" ) );
+
+		$this->recordDir = "$m_meza/logs/user-unify-" . date( "YmdHis" );
 
 	}
 
@@ -724,9 +726,6 @@ class MezaUnifyUserTables extends Maintenance {
 				);
 			}
 			unset( $result );
-
-			// asdfasdfasdf FIXME
-			file_put_contents( $this->recordDir . "/AAA.$filename.log" , print_r( $tester, true ) );
 
 			// loop through all previously recorded rows
 			$records = explode("\n", file_get_contents( $filepath ) );


### PR DESCRIPTION
Several miscellaneous fixes for release v0.9

### Testing

- [x] `curl -LO https://raw.githubusercontent.com/enterprisemediawiki/meza/fixes/scripts/install.sh`
- [x] `sudo bash install.sh`
- [x] `fixes` branch
- [x] Perform standard tests from [CONTRIBUTING.md](https://github.com/enterprisemediawiki/meza/blob/master/CONTRIBUTING.md)
- [x] [Import wikis directly from another server](https://github.com/enterprisemediawiki/meza/blob/master/manual/AddingWikis.md#importing-wikis-directly-from-another-server)
- [x] Run saml.sh
- [x] Run `sudo WIKI=demo php unifyUserTables.php --prime-wiki=somewiki`

### Changes

* Debug is now always on for MW maintenance scripts
* Memcached is disabled for sessions because it conflicts with SimpleSamlPhp
* Fixed domain name for WikiBlender
* Fixed `sed` on `httpd.conf`, which was breaking the symlink (#353)
* `import-remote-wikis.sh` now uses `rsync` to get files and is more verbose. It also is more verbose when doing `mysqldump`.
* `saml.sh` makes sure to generate `overrides.php` if it doesn't exist, so the file starts with `<?php`
* `unifyUserTables.php` now does self-tests to confirm changes are applied properly

### Issues

* Closes #205
* Closes #353
* Closes #350
