### PR TITLE
UploadWizard LocalSettings default generic license

### DIFF
--- a/config/core/LocalSettings.php
+++ b/config/core/LocalSettings.php
@@ -1168,14 +1168,27 @@ $wgUploadWizardConfig = array(
 	'enableMultipleFiles' => true,
 	'enableMultiFileSelect' => true,
 	'tutorial' => array('skip' => true),
-	'fileExtensions' => $wgFileExtensions //omitting this can cause errors
-    	'licensing' => array(
-		'ownWorkDefault' => 'own',
+	'fileExtensions' => $wgFileExtensions, //omitting this can cause errors
+	'licensing' => array(
+		'defaultType' => 'thirdparty',
+
 		'ownWork' => array(
 			'type' => 'or',
-			'template' => 'licensing', // this adds a link to Template:Licensing to the file info page
-			'licenses' => array(
-				'generic',
+			// Use [[Template:Licensing]] instead of default [[Template:Generic]]
+			'template' => 'Licensing',
+			'defaults' => 'generic',
+			'licenses' => array( 'generic' )
+		),
+
+		'thirdParty' => array(
+			'type' => 'or',
+			'defaults' => array( 'generic' ),
+			'licenseGroups' => array(
+				array(
+					'head' => 'mwe-upwiz-license-generic-head',
+					'template' => 'Licensing', // again, use [[Template:Licensing]]
+					'licenses' => array( 'generic' ),
+				),
 			)
 		),
 	),

--- a/config/core/LocalSettings.php
+++ b/config/core/LocalSettings.php
@@ -1170,13 +1170,15 @@ $wgUploadWizardConfig = array(
 	'tutorial' => array('skip' => true),
 	'fileExtensions' => $wgFileExtensions, //omitting this can cause errors
 	'licensing' => array(
-		'defaultType' => 'thirdparty',
+		// alternatively, use "thirdparty". Set in postLocalSettings.php like:
+		// $wgUploadWizardConfig['licensing']['defaultType'] = 'thirdparty';
+		'defaultType' => 'ownwork',
 
 		'ownWork' => array(
 			'type' => 'or',
-			// Use [[Template:Licensing]] instead of default [[Template:Generic]]
-			'template' => 'Licensing',
-			'defaults' => 'generic',
+			// Use [[Project:General disclaimer]] instead of default [[Template:Generic]]
+			'template' => 'Project:General disclaimer',
+			'defaults' => array( 'generic' ),
 			'licenses' => array( 'generic' )
 		),
 
@@ -1186,7 +1188,7 @@ $wgUploadWizardConfig = array(
 			'licenseGroups' => array(
 				array(
 					'head' => 'mwe-upwiz-license-generic-head',
-					'template' => 'Licensing', // again, use [[Template:Licensing]]
+					'template' => 'Project:General disclaimer', // again, use General disclaimer
 					'licenses' => array( 'generic' ),
 				),
 			)

--- a/config/core/LocalSettings.php
+++ b/config/core/LocalSettings.php
@@ -1157,7 +1157,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 $wgApiFrameOptions = 'SAMEORIGIN';
 
 // Use UploadWizard by default in navigation bar
-$wgUploadNavigationUrl = "$wgScriptPath/index.php/Special:UploadWizard"; //Update with #156
+$wgUploadNavigationUrl = "$wgScriptPath/index.php/Special:UploadWizard"; 
 $wgUploadWizardConfig = array(
 	'debug' => false,
 	'autoCategory' => 'Uploaded with UploadWizard',
@@ -1169,6 +1169,16 @@ $wgUploadWizardConfig = array(
 	'enableMultiFileSelect' => true,
 	'tutorial' => array('skip' => true),
 	'fileExtensions' => $wgFileExtensions //omitting this can cause errors
+    	'licensing' => array(
+		'ownWorkDefault' => 'own',
+		'ownWork' => array(
+			'type' => 'or',
+			'template' => 'licensing', // this adds a link to Template:Licensing to the file info page
+			'licenses' => array(
+				'generic',
+			)
+		),
+	),
 );
 
 


### PR DESCRIPTION
This PR mods LocalSettings.php in order to modify UploadWizard, limiting the licensing options to a single default generic option.

### Changes

* Remove comment to issue that is now closed and no longer seems applicable
* Add config to LocalSettings.php to make use of generic default licensing option

### Issues

* Closes #251

#156 seems to be closed/abandoned, so I'm removing reference from code

Add licensing config based on https://gerrit.wikimedia.org/r/#/c/283110/5/README