### PR TITLE
EPEL now 7.6 vs 7.5 for CentOS 7, hotfix #374

### DIFF
--- a/scripts/yums.sh
+++ b/scripts/yums.sh
@@ -27,7 +27,7 @@ elif [ "$architecture" = "64" ]; then
 	    epel_version="6/x86_64/epel-release-6-8.noarch.rpm"
 	else
 		echo "Downloading EPEL for 64-bit Enterprise Linux v7"
-		epel_version="7/x86_64/e/epel-release-7-5.noarch.rpm"
+		epel_version="7/x86_64/e/epel-release-7-6.noarch.rpm"
 	fi
 
 else


### PR DESCRIPTION
EPEL for CentOS 7 no longer is at version 7.5. It is now 7.6. The URL for 7.5 no longer works and must be fixed immediately. Without this libmcrypt cannot be installed (via `yum`) which makes it impossible to build PHP.

### Testing

- [x] `curl -LO https://raw.githubusercontent.com/enterprisemediawiki/meza/hotfix374/scripts/install.sh`
- [x] `sudo bash install.sh`
- [x] `hotfix374` branch
- [x] Verify successful build. Full testing not required.


### Changes

* Fixes URL for CentOS 7 EPEL repository

### Issues

* Closes #374 