### PR TITLE
Move elasticsearch and mysql data to /opt/meza/data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,13 @@ logs/*
 config/local/*
 !config/local/README.md
 
+# data directory used to hold MySQL and Elasticsearch data
+# which should not be added to this repo. However, there are
+# some README files as placeholders in this directory which
+# have been explicitly added to the repo.
+data/*
+
+
 # ignore wiki blender landing page
 htdocs/WikiBlender
 
@@ -13,3 +20,4 @@ htdocs/mediawiki
 htdocs/wikis/*
 
 simplesamlphp/
+

--- a/config/core/elasticsearch.yml
+++ b/config/core/elasticsearch.yml
@@ -146,7 +146,7 @@ path.conf: /etc/elasticsearch
 
 # Path to directory where to store index data allocated for this node.
 #
-path.data: /var/data/elasticsearch
+path.data: /opt/meza/data/elasticsearch/data
 #
 # Can optionally include more than one location, causing data to be striped across
 # the locations (a la RAID 0) on a file level, favouring locations with most free
@@ -156,7 +156,7 @@ path.data: /var/data/elasticsearch
 
 # Path to temporary files:
 #
-path.work: /var/work/elasticsearch
+path.work: /opt/meza/data/elasticsearch/work
 
 # Path to log files:
 #
@@ -164,7 +164,7 @@ path.logs: /var/log/elasticsearch
 
 # Path to where plugins are installed:
 #
-#path.plugins: /path/to/plugins
+path.plugins: /opt/meza/data/elasticsearch/plugins
 
 
 #################################### Plugin ###################################
@@ -298,7 +298,7 @@ path.logs: /var/log/elasticsearch
 # and master node is elected. Multicast discovery is the default.
 
 # Set to ensure a node sees N other master eligible nodes to be considered
-# operational within the cluster. This should be set to a quorum/majority of 
+# operational within the cluster. This should be set to a quorum/majority of
 # the master-eligible nodes in the cluster.
 #
 #discovery.zen.minimum_master_nodes: 1

--- a/config/core/my.cnf
+++ b/config/core/my.cnf
@@ -1,0 +1,24 @@
+# For advice on how to change settings please see
+# http://dev.mysql.com/doc/refman/5.6/en/server-configuration-defaults.html
+#
+
+[client]
+
+port                           = 3306
+socket                         = /var/lib/mysql/mysql.sock
+
+
+[mysqld]
+
+# Connection and Thread variables
+
+port                           = 3306
+socket                         = /var/lib/mysql/mysql.sock
+datadir                        = /opt/meza/data/mysql
+
+# Recommended in standard MySQL setup
+sql_mode=NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES
+
+[mysqld_safe]
+log-error=/var/log/mysqld.log
+pid-file=/var/run/mysqld/mysqld.pid

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,3 @@
+# meza data
+
+This directory will contain data files for meza operations. This includes MySQL and Elasticsearch data.

--- a/data/elasticsearch/README.md
+++ b/data/elasticsearch/README.md
@@ -1,0 +1,3 @@
+# meza data/elasticsearch
+
+This directory will contain data files for elasticsearch

--- a/data/mysql/README.md
+++ b/data/mysql/README.md
@@ -1,0 +1,3 @@
+# meza data/mysql
+
+This directory will contain data files for MySQL

--- a/scripts/ElasticSearch.sh
+++ b/scripts/ElasticSearch.sh
@@ -91,18 +91,14 @@ ln -s "$m_config/core/elasticsearch.yml" /etc/elasticsearch/elasticsearch.yml
 
 # Make directories called out in elasticsearch.yml
 # ref: http://elasticsearch-users.115913.n3.nabble.com/Elasticsearch-Not-Working-td4059398.html
-cd /var
-mkdir data
-cd data
-mkdir elasticsearch
-cd /var
-mkdir work
-cd work
-mkdir elasticsearch
-cd /var
+mkdir "$m_meza/data/elasticsearch/data"
+mkdir "$m_meza/data/elasticsearch/work"
+mkdir "$m_meza/data/elasticsearch/plugins"
+
 # Grant elasticsearch user ownership of these new directories
-chown -R elasticsearch /var/data/elasticsearch
-chown -R elasticsearch /var/work/elasticsearch
+chown -R elasticsearch "$m_meza/data/elasticsearch/data"
+chown -R elasticsearch "$m_meza/data/elasticsearch/work"
+chown -R elasticsearch "$m_meza/data/elasticsearch/plugins"
 
 
 # Start Elasticsearch

--- a/scripts/imagemagick.sh
+++ b/scripts/imagemagick.sh
@@ -42,7 +42,7 @@ ldconfig /usr/local/lib
 # Get xpdf-utils
 echo "Download xpdf-utils"
 cd ~/mezadownloads
-wget ftp://ftp.foolabs.com/pub/xpdf/xpdfbin-linux-3.04.tar.gz
+wget http://mirror.unl.edu/ctan/support/xpdf/xpdfbin-linux-3.04.tar.gz
 tar xvzf xpdfbin-linux-3.04.tar.gz
 
 cd xpdfbin-linux-3.04

--- a/scripts/mysql.sh
+++ b/scripts/mysql.sh
@@ -34,6 +34,14 @@ yum -y install mysql-community-server
 
 
 #
+# Setup storage of MySQL data in /opt/meza/data/mysql
+#
+chown mysql:mysql "$m_meza/data/mysql"
+rm /etc/my.cnf
+ln -s "$m_config/core/my.cnf" /etc/my.cnf
+
+
+#
 # Start MySQL service
 #
 chkconfig mysqld on


### PR DESCRIPTION
Move elasticsearch and mysql data to `/opt/meza/data` rather than locations in `/var`. This was done for some security compliance reasons.

### Testing

- [x] `curl -LO https://raw.githubusercontent.com/enterprisemediawiki/meza/otf-compliant/scripts/install.sh`
- [x] `sudo bash install.sh`
- [x] `otf-compliant` branch
- [x] Perform standard tests from [CONTRIBUTING.md](https://github.com/enterprisemediawiki/meza/blob/master/CONTRIBUTING.md)


### Changes

* Create `/opt/meza/data` directory (gitignore all) and required placeholder READMEs to make space for MySQL and Elasticsearch data.
* Adjust path config for Elasticsearch in `elasticsearch.yml` (also auto-whitespace fixes)
* Modify `ElasticSearch.sh` to create necessary sub-directories of `/opt/meza/data/elasticsearch` and properly `chown` them.
* Create `/opt/meza/config/core/my.cnf`. Previously was using the default `/etc/my.cnf` file provided by `yum` install. This file is no symlinked from `/etc/my.cnf`. This file specifies the `/opt/meza/data/mysql` directory for data, and maintains the socket location in `/var/lib/mysql/mysql.sock` due to unresolved conflicts.
* Modify `mysql.sh` to `chown` data directory and symlink settings file


### Issues

* Ref #314 "Set SELinux to Enforcing"
* Ref #380 "Handle /opt/meza/logs better"

