### PR TITLE
Update all extensions

### DIFF
--- a/scripts/extensions.sh
+++ b/scripts/extensions.sh
@@ -30,7 +30,7 @@ echo -e "\n\n## meza: Install ExtensionLoader and apply changes to MW settings"
 cd "$m_mediawiki/extensions"
 git clone https://github.com/jamesmontalvo3/ExtensionLoader.git
 cd ./ExtensionLoader
-git checkout tags/v0.2.3
+git checkout tags/v0.3.0
 cd "$m_mediawiki"
 
 

--- a/scripts/updateExtensions.sh
+++ b/scripts/updateExtensions.sh
@@ -32,10 +32,10 @@ for d in */ ; do
 	echo "Starting $wiki_id"
 
 	echo "Running ExtensionLoader updateExtensions.php for $wiki_id"
-	php "WIKI=$wiki_id" "$m_mediawiki/extensions/ExtensionLoader/updateExtensions.php" --skip-log="$skiplog"
+	"WIKI=$wiki_id" php "$m_mediawiki/extensions/ExtensionLoader/updateExtensions.php" --skip-log="$skiplog"
 
 	echo "Running MediaWiki update.php for $wikiId"
-	php "WIKI=$wiki_id" "$m_mediawiki/maintenance/update.php" --quick
+	"WIKI=$wiki_id" php "$m_mediawiki/maintenance/update.php" --quick
 
 done
 

--- a/scripts/updateExtensions.sh
+++ b/scripts/updateExtensions.sh
@@ -32,10 +32,10 @@ for d in */ ; do
 	echo "Starting $wiki_id"
 
 	echo "Running ExtensionLoader updateExtensions.php for $wiki_id"
-	"WIKI=$wiki_id" php "$m_mediawiki/extensions/ExtensionLoader/updateExtensions.php" --skip-log="$skiplog"
+	WIKI="$wiki_id" php "$m_mediawiki/extensions/ExtensionLoader/updateExtensions.php" --skip-log="$skiplog"
 
 	echo "Running MediaWiki update.php for $wikiId"
-	"WIKI=$wiki_id" php "$m_mediawiki/maintenance/update.php" --quick
+	WIKI="$wiki_id" php "$m_mediawiki/maintenance/update.php" --quick
 
 done
 

--- a/scripts/updateExtensions.sh
+++ b/scripts/updateExtensions.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+#
+# Run updateExtensions.php and update.php on all wikis
+
+
+if [ "$(whoami)" != "root" ]; then
+	echo "Try running this script with sudo: \"sudo bash install.sh\""
+	exit 1
+fi
+
+# If /usr/local/bin is not in PATH then add it
+# Ref enterprisemediawiki/meza#68 "Run install.sh with non-root user"
+if [[ $PATH != *"/usr/local/bin"* ]]; then
+	PATH="/usr/local/bin:$PATH"
+fi
+
+source /opt/meza/config/core/config.sh
+
+timestamp=$( date +"%Y%m%d%H%M%S" )
+skiplog="$m_meza/logs/skiplog$timestamp"
+
+echo "Using skiplog $skiplog"
+
+cd "$m_htdocs/wikis"
+for d in */ ; do
+
+	# trim trailing slash from directory name
+	# ref: http://stackoverflow.com/questions/1848415/remove-slash-from-the-end-of-a-variable
+	# ref: http://www.network-theory.co.uk/docs/bashref/ShellParameterExpansion.html
+	wiki_id=${d%/}
+
+	echo "Starting $wiki_id"
+
+	echo "Running ExtensionLoader updateExtensions.php for $wiki_id"
+	php "WIKI=$wiki_id" "$m_mediawiki/extensions/ExtensionLoader/updateExtensions.php" --skip-log="$skiplog"
+
+	echo "Running MediaWiki update.php for $wikiId"
+	php "WIKI=$wiki_id" "$m_mediawiki/maintenance/update.php" --quick
+
+done
+
+echo
+echo "Complete updating extensions for all wikis"


### PR DESCRIPTION
Pulls a new version of ExtensionLoader in order to make it possible to run the new script `/opt/meza/scripts/updateExtensions.sh`, which updates extensions on all wikis.

### Testing

- [x] `curl -LO https://raw.githubusercontent.com/enterprisemediawiki/meza/update-all-extensions/scripts/install.sh`
- [x] `sudo bash install.sh`
- [x] `update-all-extensions` branch
- [x] Perform standard tests from [CONTRIBUTING.md](https://github.com/enterprisemediawiki/meza/blob/master/CONTRIBUTING.md)
- [x] Create several wikis with some different extensions, and then run `sudo bash /opt/meza/scripts/updateExtensions.sh` to update all wikis' extensions


### Changes

* Pull newest version of ExtensionLoader
* New script that does ExtensionLoader's `updateExtensions.php` then MediaWiki's `update.php` for each wiki.