### PR TITLE
add policies to imagemagick to prevent remote code execution

### DIFF
--- a/config/template/imagick-secure-policy.xml
+++ b/config/template/imagick-secure-policy.xml
@@ -1,0 +1,17 @@
+
+  <!--
+    Policies to prevent remote code execution.
+
+    imagemagick.org description of vulnerability
+    https://www.imagemagick.org/discourse-server/viewtopic.php?t=29588
+
+    imagemagick.org policy configuration:
+    https://www.imagemagick.org/discourse-server/viewtopic.php?f=4&t=26801
+
+    https://imagetragick.com/
+  -->
+  <policy domain="coder" rights="none" pattern="EPHEMERAL" />
+  <policy domain="coder" rights="none" pattern="URL" />
+  <policy domain="coder" rights="none" pattern="HTTPS" />
+  <policy domain="coder" rights="none" pattern="MVG" />
+  <policy domain="coder" rights="none" pattern="MSL" />

--- a/scripts/imagemagick.sh
+++ b/scripts/imagemagick.sh
@@ -36,6 +36,11 @@ cmd_profile "END build ImageMagick"
 echo "Configure dynamic linker"
 ldconfig /usr/local/lib
 
+# Add to policy.xml to prevent remote code execution. See
+# imagick-secure-policy.xml for more details
+sed -i -e "/<policymap>/r $m_config/template/imagick-secure-policy.xml" /usr/local/etc/ImageMagick-6/policy.xml
+
+
 # For testing should run: `make check`
 
 


### PR DESCRIPTION
Adds policies to Imagemagick to prevent remote code execution which was discovered on 03-May-2016. See:

* [imagemagick.org description of vulnerability](https://www.imagemagick.org/discourse-server/viewtopic.php?t=29588)
* https://imagetragick.com/
* [imagemagick.org policy configuration](https://www.imagemagick.org/discourse-server/viewtopic.php?f=4&t=26801)
* [Wikitech mailing list](http://www.gossamer-threads.com/lists/wiki/wikitech/706628)

### Testing

- [x] `curl -LO https://raw.githubusercontent.com/enterprisemediawiki/meza/imagick-secure/scripts/install.sh`
- [x] `sudo bash install.sh`
- [x] `imagick-secure` branch
- [x] Perform standard tests from [CONTRIBUTING.md](https://github.com/enterprisemediawiki/meza/blob/master/CONTRIBUTING.md)
- [x] Really make sure thumbnailing works



