### PR TITLE
Improve importing wikis and updating extensions

### DIFF
--- a/config/template/local-import-config.sh
+++ b/config/template/local-import-config.sh
@@ -1,0 +1,12 @@
+#/bin/sh
+#
+# Config file example for import-wikis.sh
+
+# MySQL root password for local database
+mysql_root_pass="mypassword"
+
+# path to your wiki imports
+imports_dir="/path/to/wikis"
+
+# Use a webhook, or just put "n" for now
+slackwebhook="https://hooks.slack.com/your-slack-webhook"

--- a/scripts/extensions.sh
+++ b/scripts/extensions.sh
@@ -30,7 +30,7 @@ echo -e "\n\n## meza: Install ExtensionLoader and apply changes to MW settings"
 cd "$m_mediawiki/extensions"
 git clone https://github.com/jamesmontalvo3/ExtensionLoader.git
 cd ./ExtensionLoader
-git checkout tags/v0.2.3
+git checkout tags/v0.3.0
 cd "$m_mediawiki"
 
 

--- a/scripts/import-remote-wikis.sh
+++ b/scripts/import-remote-wikis.sh
@@ -40,8 +40,16 @@ mkdir "/mnt/$mount_name"
 mount.cifs "$remote_share" "/mnt/$mount_name" -o "user=$remote_username"
 
 
+# if not set by remote-wiki-config.sh, then put the wiki data in /opt/mezawikis
+# Chose to put in /opt since most likely this directory has lots of space
+# regardless of partitioning, since it's where all the wiki data will end up
+# anyway.
+if [[ -z "$local_wiki_tmp" ]]; then
+	local_wiki_tmp="/opt/mezawikis"
+fi
+
 # make directory to copy to
-mkdir /root/wikis
+mkdir "$local_wiki_tmp"
 
 
 # list directory of mount point
@@ -145,7 +153,7 @@ do
 	echo "Starting import of wiki '$wiki'"
 
 	echo "  Getting files..."
-	rsync -rva "./$wiki/" "/root/wikis/$wiki"
+	rsync -rva "./$wiki/" "$local_wiki_tmp/$wiki"
 
 	wiki_pre_localsettings="$full_remote_wikis_path/$wiki/config/preLocalSettings.php"
 	if [ ! -f "$wiki_pre_localsettings" ]; then
@@ -160,10 +168,10 @@ do
 	fi
 
 	echo "  Getting database..."
-	mysqldump -v -h $remote_db_server -u $remote_db_username -p$remote_db_password $wiki_db > "/root/wikis/$wiki/wiki.sql"
+	mysqldump -v -h $remote_db_server -u $remote_db_username -p$remote_db_password $wiki_db > "$local_wiki_tmp/$wiki/wiki.sql"
 
 done
 
-imports_dir=/root/wikis
+imports_dir="$local_wiki_tmp"
 source /opt/meza/scripts/import-wikis.sh
 

--- a/scripts/import-wikis.sh
+++ b/scripts/import-wikis.sh
@@ -9,6 +9,11 @@ if [ "$(whoami)" != "root" ]; then
 fi
 
 
+if [ -f "/opt/meza/config/local/local-import-config.sh" ]; then
+	source "/opt/meza/config/local/local-import-config.sh"
+fi
+
+
 # print title of script
 bash printTitle.sh "Begin import-wikis.sh"
 

--- a/scripts/updateExtensions.sh
+++ b/scripts/updateExtensions.sh
@@ -32,10 +32,10 @@ for d in */ ; do
 	echo "Starting $wiki_id"
 
 	echo "Running ExtensionLoader updateExtensions.php for $wiki_id"
-	php "WIKI=$wiki_id" "$m_mediawiki/extensions/ExtensionLoader/updateExtensions.php" --skip-log="$skiplog"
+	"WIKI=$wiki_id" php "$m_mediawiki/extensions/ExtensionLoader/updateExtensions.php" --skip-log="$skiplog"
 
 	echo "Running MediaWiki update.php for $wikiId"
-	php "WIKI=$wiki_id" "$m_mediawiki/maintenance/update.php" --quick
+	"WIKI=$wiki_id" php "$m_mediawiki/maintenance/update.php" --quick
 
 done
 

--- a/scripts/updateExtensions.sh
+++ b/scripts/updateExtensions.sh
@@ -32,10 +32,10 @@ for d in */ ; do
 	echo "Starting $wiki_id"
 
 	echo "Running ExtensionLoader updateExtensions.php for $wiki_id"
-	"WIKI=$wiki_id" php "$m_mediawiki/extensions/ExtensionLoader/updateExtensions.php" --skip-log="$skiplog"
+	WIKI="$wiki_id" php "$m_mediawiki/extensions/ExtensionLoader/updateExtensions.php" --skip-log="$skiplog"
 
 	echo "Running MediaWiki update.php for $wikiId"
-	"WIKI=$wiki_id" php "$m_mediawiki/maintenance/update.php" --quick
+	WIKI="$wiki_id" php "$m_mediawiki/maintenance/update.php" --quick
 
 done
 

--- a/scripts/updateExtensions.sh
+++ b/scripts/updateExtensions.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+#
+# Run updateExtensions.php and update.php on all wikis
+
+
+if [ "$(whoami)" != "root" ]; then
+	echo "Try running this script with sudo: \"sudo bash install.sh\""
+	exit 1
+fi
+
+# If /usr/local/bin is not in PATH then add it
+# Ref enterprisemediawiki/meza#68 "Run install.sh with non-root user"
+if [[ $PATH != *"/usr/local/bin"* ]]; then
+	PATH="/usr/local/bin:$PATH"
+fi
+
+source /opt/meza/config/core/config.sh
+
+timestamp=$( date +"%Y%m%d%H%M%S" )
+skiplog="$m_meza/logs/skiplog$timestamp"
+
+echo "Using skiplog $skiplog"
+
+cd "$m_htdocs/wikis"
+for d in */ ; do
+
+	# trim trailing slash from directory name
+	# ref: http://stackoverflow.com/questions/1848415/remove-slash-from-the-end-of-a-variable
+	# ref: http://www.network-theory.co.uk/docs/bashref/ShellParameterExpansion.html
+	wiki_id=${d%/}
+
+	echo "Starting $wiki_id"
+
+	echo "Running ExtensionLoader updateExtensions.php for $wiki_id"
+	php "WIKI=$wiki_id" "$m_mediawiki/extensions/ExtensionLoader/updateExtensions.php" --skip-log="$skiplog"
+
+	echo "Running MediaWiki update.php for $wikiId"
+	php "WIKI=$wiki_id" "$m_mediawiki/maintenance/update.php" --quick
+
+done
+
+echo
+echo "Complete updating extensions for all wikis"


### PR DESCRIPTION
Several changes associated with importing wikis and updating extensions based on each new wiki's requirements.

### Testing

- [x] `curl -LO https://raw.githubusercontent.com/enterprisemediawiki/meza/update-all-extensions/scripts/install.sh`
- [x] `sudo bash install.sh`
- [x] `update-all-extensions` branch
- [x] Perform standard tests from [CONTRIBUTING.md](https://github.com/enterprisemediawiki/meza/blob/master/CONTRIBUTING.md)
- [x] Create several wikis with some different extensions, and then run `sudo bash /opt/meza/scripts/updateExtensions.sh` to update all wikis' extensions


### Changes

* Pull newest version of ExtensionLoader
* New script that does ExtensionLoader's `updateExtensions.php` then MediaWiki's `update.php` for each wiki.
* Allows specifying which directory `import-remote-wikis.sh` puts temporary import data. This way when you have different partitions that are sized differently, you can pick where you put the files such that you don't run out of space.
* Allow `local-import-config.sh` script so you don't need prompts when running `import-wikis.sh`.