### PR TITLE
Fix composer api version conflict

### DIFF
--- a/scripts/mediawiki.sh
+++ b/scripts/mediawiki.sh
@@ -63,6 +63,20 @@ else
 fi
 
 
+# Hotfix
+#
+# Before composer-merge-plugin v1.2.0, MW incorrectly required
+# v1.0.0 of the Composer internal composer-plugin-api component.
+# Composer recently bumped this internal version to v1.1.0 [0].
+# A patch to MW is in work, but this is required to keep meza
+# building properly.
+#
+# [0]: https://github.com/composer/composer/commit/aeafe2fe59992efd1bc3f890b760f1a9c4874e1c
+#
+# Replace v1.0.0 with v1.3.1 of wikimedia/composer-merge-plugin in composer.json
+sed -r -i 's/"wikimedia\/composer-merge-plugin": "1.0.0",/"wikimedia\/composer-merge-plugin": "1.3.1",/;' "$m_mediawiki/composer.json"
+
+
 #
 # Update Composer dependencies
 #


### PR DESCRIPTION
Before composer-merge-plugin v1.2.0 [0], MediaWiki incorrectly required v1.0.0 of the Composer internal composer-plugin-api component. Composer recently bumped this internal version to v1.1.0 [1]. A patch to MediaWiki is in work, but until it is in place this change to meza is required to prevent failed builds.

[0]: https://github.com/wikimedia/composer-merge-plugin/releases/tag/v1.2.0
[1]: https://github.com/composer/composer/commit/aeafe2fe59992efd1bc3f890b760f1a9c4874e1c

According to WMF's Bryan Davis, the quick fix is to edit $IP/composer.json and change the `"wikimedia/composer-merge-plugin": "1.0.0",` line to read `"wikimedia/composer-merge-plugin": "1.3.1",``.

### Testing

- [x] `curl -LO https://raw.githubusercontent.com/enterprisemediawiki/meza/hotfix-composer-api/scripts/install.sh`
- [x] `sudo bash install.sh`
- [x] `hotfix-composer-api` branch
- [x] Perform standard tests from [CONTRIBUTING.md](https://github.com/enterprisemediawiki/meza/blob/master/CONTRIBUTING.md)

### Changes

* Manually modify MediaWiki's `composer.json` so proper version of composer-merge-plugin is pulled