### PR TITLE
Remove TCHB namespace def from extensions

### DIFF
--- a/config/template/more-extensions.php
+++ b/config/template/more-extensions.php
@@ -61,12 +61,6 @@ if ( isset( $mezaLoadTOPO ) && $mezaLoadTOPO ) {
 		"master"
 	);
 
-	// Creating TCHB namespace
-	define("NS_TCHB", 3000);
-	define("NS_TCHB_TALK", 3001);
-	$wgExtraNamespaces[NS_TCHB] = "TCHB";
-	$wgExtraNamespaces[NS_TCHB_TALK] = "TCHB_talk";
-	$wgContentNamespaces[] = NS_TCHB;
 	$wgExtCollapsibleSectionsNamespaces[] = NS_TCHB;
 	$wgExtCollapsibleSectionsClasses = "tchb-box";    
 

--- a/config/template/preLocalSettings_allWikis.php
+++ b/config/template/preLocalSettings_allWikis.php
@@ -23,3 +23,13 @@ $wgEmergencyContact = $wgPasswordSender;
 
 // set a default $mezaAuthType for all wikis that don't specify one
 // $mezaAuthType = 'viewer-read';
+
+// Creating custom namespace
+/*
+	define("NS_TCHB", 3000);
+	define("NS_TCHB_TALK", 3001);
+	$wgExtraNamespaces[NS_TCHB] = "TCHB";
+	$wgExtraNamespaces[NS_TCHB_TALK] = "TCHB_talk";
+	$wgContentNamespaces[] = NS_TCHB;
+*/
+	


### PR DESCRIPTION
Moved TCHB custom namespace definition to preLocalSettings.php instead of defining with CollapsibleSections in the more-extensions.php file.

### Testing

- [x] `curl -LO https://raw.githubusercontent.com/emanspeaks/meza/remove-tchb-ns-def/scripts/install.sh`
- [x] `sudo bash install.sh`
- [x] `remove-tchb-ns-def` branch
- [x] Perform standard tests from [CONTRIBUTING.md](https://github.com/enterprisemediawiki/meza/blob/master/CONTRIBUTING.md)
- [x] Uncomment lines in a wiki config and verify namespace exists


### Changes

* Moved TCHB definition from extensions settings to template for preLocalSettings

