### PR TITLE
Tie SMW to the 2.4 branch. Getting install failures due to 2.5-dev

### DIFF
--- a/scripts/extensions.sh
+++ b/scripts/extensions.sh
@@ -59,7 +59,7 @@ echo -e "\n\n## meza: Install composer-supported extensions"
 cd "$m_mediawiki"
 cmd_profile "START extensions composer require"
 composer require \
-	mediawiki/semantic-media-wiki:dev-master#787d70fb7f1c1db800e02e0dde0eee8ccc4b7e95 \
+	mediawiki/semantic-media-wiki:~2.4 \
 	mediawiki/semantic-result-formats:~2.0 \
 	mediawiki/sub-page-list:~1.1 \
 	mediawiki/semantic-meeting-minutes:~0.3 \


### PR DESCRIPTION
Hotfix. Tie SMW to a stable release
