### PR TITLE
Use composer.local.json to avoid composer errors

### DIFF
--- a/config/template/composer.local.json
+++ b/config/template/composer.local.json
@@ -1,0 +1,9 @@
+{
+	"require": {
+		"mediawiki/semantic-media-wiki": "~2.4",
+		"mediawiki/semantic-result-formats": "~2.0",
+		"mediawiki/sub-page-list": "~1.1",
+		"mediawiki/semantic-meeting-minutes": "~0.3",
+		"mediawiki/semantic-maps": "~3.2"
+	}
+}

--- a/scripts/extensions.sh
+++ b/scripts/extensions.sh
@@ -58,12 +58,8 @@ composer install
 echo -e "\n\n## meza: Install composer-supported extensions"
 cd "$m_mediawiki"
 cmd_profile "START extensions composer require"
-composer require \
-	mediawiki/semantic-media-wiki:~2.4 \
-	mediawiki/semantic-result-formats:~2.0 \
-	mediawiki/sub-page-list:~1.1 \
-	mediawiki/semantic-meeting-minutes:~0.3 \
-	mediawiki/semantic-maps:~3.2
+cp "$m_config/template/composer.local.json" "$m_mediawiki/composer.local.json"
+composer update
 cmd_profile "END extensions composer require"
 
 


### PR DESCRIPTION
Without migrating to the new method of putting Composer-based extensions into `composer.local.json` instead of `composer.json`, was getting the following error:

> Notice: Undefined index: hash in /opt/meza/htdocs/mediawiki/includes/libs/composer/ComposerLock.php on line 19

I don't understand why this suddenly broke. The same versions of MediaWiki are being pulled in both the MW 1.25 branches tested (`master`, `rpm`) and the MW 1.27 branches (`mw1.27`, `modules`) as were being pulled the last time we were getting successful installs. It must therefore be an issue with either the extensions using Composer (those now in `composer.local.json`) or the libraries that MW Core uses (those defined in `composer.json`).

Ref: https://www.mediawiki.org/wiki/Composer/For_extensions