### PR TITLE
Cleanup development: `mw1.27` branch merged into `dev` branch

### DIFF
--- a/config/core/LocalSettings.php
+++ b/config/core/LocalSettings.php
@@ -1090,11 +1090,15 @@ $wgHiddenPrefs[] = 'visualeditor-enable';
 #$wgDefaultUserOptions['visualeditor-enable-experimental'] = 1;
 
 // URL to the Parsoid instance MUST NOT end in a slash due to Parsoid bug
-// domain is localhost
-// Interwiki prefix to pass to the Parsoid instance
 $wgVirtualRestConfig['modules']['parsoid'] = array(
 	'url' => 'http://127.0.0.1:8000',
-	'domain' => 'localhost',
+
+	// domain here is not really the domain. It needs to be unique to each wiki
+	// and both domain and prefix must match settings in Parsoid's settings in
+	// /opt/meza/config/core/localsettings.js
+	// ref:
+	// https://www.mediawiki.org/wiki/Parsoid/Setup#Multiple_wikis_sharing_the_same_parsoid_service
+	'domain' => $wikiId,
 	'prefix' => $wikiId
 );
 

--- a/config/core/LocalSettings.php
+++ b/config/core/LocalSettings.php
@@ -661,7 +661,7 @@ $egExtensionLoader = new ExtensionLoader();
 require_once $egExtensionLoader->registerLegacyExtension(
 	"ParserFunctions",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/ParserFunctions.git",
-	"REL1_25"
+	"REL1_27"
 );
 $wgPFEnableStringFunctions = true;
 
@@ -672,7 +672,7 @@ $wgPFEnableStringFunctions = true;
 require_once $egExtensionLoader->registerLegacyExtension(
 	"StringFunctionsEscaped",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/StringFunctionsEscaped.git",
-	"REL1_25"
+	"REL1_27"
 );
 
 
@@ -682,7 +682,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"ExternalData",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/ExternalData.git",
-	"REL1_25"
+	"REL1_27"
 );
 
 
@@ -692,7 +692,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"LabeledSectionTransclusion",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/LabeledSectionTransclusion.git",
-	"REL1_25"
+	"REL1_27"
 );
 
 
@@ -702,7 +702,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"Cite",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/Cite.git",
-	"REL1_25"
+	"REL1_27"
 );
 $wgCiteEnablePopups = true;
 
@@ -723,7 +723,7 @@ $wgCiteEnablePopups = true;
 require_once $egExtensionLoader->registerLegacyExtension(
 	"WhoIsWatching",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/WhoIsWatching.git",
-	"REL1_25"
+	"REL1_27"
 );
 $wgPageShowWatchingUsers = true;
 
@@ -734,7 +734,7 @@ $wgPageShowWatchingUsers = true;
 require_once $egExtensionLoader->registerLegacyExtension(
 	"CharInsert",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/CharInsert.git",
-	"REL1_25"
+	"REL1_27"
 );
 
 
@@ -754,7 +754,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"SemanticInternalObjects",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/SemanticInternalObjects.git",
-	"REL1_25"
+	"REL1_27"
 );
 
 
@@ -764,7 +764,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"SemanticCompoundQueries",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/SemanticCompoundQueries.git",
-	"REL1_25"
+	"REL1_27"
 );
 
 
@@ -774,7 +774,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"Arrays",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/Arrays.git",
-	"REL1_25"
+	"REL1_27"
 );
 
 
@@ -784,7 +784,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"TitleKey",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/TitleKey.git",
-	"REL1_25"
+	"REL1_27"
 );
 
 
@@ -804,7 +804,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"AdminLinks",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/AdminLinks.git",
-	"REL1_25"
+	"REL1_27"
 );
 $wgGroupPermissions['sysop']['adminlinks'] = true;
 
@@ -815,7 +815,7 @@ $wgGroupPermissions['sysop']['adminlinks'] = true;
 require_once $egExtensionLoader->registerLegacyExtension(
 	"DismissableSiteNotice",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/DismissableSiteNotice.git",
-	"REL1_25"
+	"REL1_27"
 );
 
 
@@ -825,7 +825,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"BatchUserRights",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/BatchUserRights.git",
-	"REL1_25"
+	"REL1_27"
 );
 
 
@@ -835,7 +835,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"HeaderTabs",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/HeaderTabs.git",
-	"REL1_25"
+	"REL1_27"
 );
 $htEditTabLink = false;
 $htRenderSingleTab = true;
@@ -847,7 +847,7 @@ $htRenderSingleTab = true;
 require_once $egExtensionLoader->registerLegacyExtension(
 	"WikiEditor",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/WikiEditor.git",
-	"REL1_25"
+	"REL1_27"
 );
 $wgDefaultUserOptions['usebetatoolbar'] = 1;
 $wgDefaultUserOptions['usebetatoolbar-cgd'] = 1;
@@ -878,7 +878,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"SyntaxHighlight_GeSHi",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/SyntaxHighlight_GeSHi.git",
-	"REL1_25"
+	"REL1_27"
 );
 
 
@@ -909,7 +909,7 @@ $egApprovedRevsAutomaticApprovals = false;
 require_once $egExtensionLoader->registerLegacyExtension(
 	"InputBox",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/InputBox.git",
-	"REL1_25"
+	"REL1_27"
 );
 
 
@@ -919,7 +919,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"ReplaceText",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/ReplaceText.git",
-	"REL1_25"
+	"REL1_27"
 );
 
 
@@ -929,7 +929,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"Interwiki",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/Interwiki.git",
-	"REL1_25"
+	"REL1_27"
 );
 $wgGroupPermissions['sysop']['interwiki'] = true;
 
@@ -973,7 +973,7 @@ $egPendingReviewsEmphasizeDays = 10;
 require_once $egExtensionLoader->registerLegacyExtension(
 	"Variables",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/Variables.git",
-	"REL1_25"
+	"REL1_27"
 );
 
 
@@ -983,7 +983,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"YouTube",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/YouTube.git",
-	"REL1_25"
+	"REL1_27"
 );
 
 
@@ -993,7 +993,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"ContributionScores",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/ContributionScores.git",
-	"REL1_25"
+	"REL1_27"
 );
 // Exclude Bots from the reporting - Can be omitted.
 $wgContribScoreIgnoreBots = true;
@@ -1036,7 +1036,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 // require_once $egExtensionLoader->registerLegacyExtension(
 // 	"PdfHandler",
 // 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/PdfHandler",
-// 	"REL1_25"
+// 	"REL1_27"
 // );
 // Location of PdfHandler dependencies
 // $wgPdfProcessor = '/usr/bin/gs'; // installed via yum
@@ -1050,7 +1050,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"UniversalLanguageSelector",
 	"https://gerrit.wikimedia.org/r/p/mediawiki/extensions/UniversalLanguageSelector.git",
-	"REL1_25"
+	"REL1_27"
 );
 
 
@@ -1060,7 +1060,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"VisualEditor",
 	"https://gerrit.wikimedia.org/r/p/mediawiki/extensions/VisualEditor.git",
-	"REL1_25"
+	"REL1_27"
 );
 // Allow read and edit permission for requests from the server (e.g. Parsoid)
 // Ref: https://www.mediawiki.org/wiki/Talk:Parsoid/Archive#Running_Parsoid_on_a_.22private.22_wiki_-_AccessDeniedError
@@ -1082,13 +1082,14 @@ $wgHiddenPrefs[] = 'visualeditor-enable';
 // OPTIONAL: Enable VisualEditor's experimental code features
 #$wgDefaultUserOptions['visualeditor-enable-experimental'] = 1;
 
-// URL to the Parsoid instance
-// MUST NOT end in a slash due to Parsoid bug
-$wgVisualEditorParsoidURL = 'http://127.0.0.1:8000';
-
+// URL to the Parsoid instance MUST NOT end in a slash due to Parsoid bug
+// domain is localhost
 // Interwiki prefix to pass to the Parsoid instance
-// Parsoid will be called as $url/$prefix/$pagename
-$wgVisualEditorParsoidPrefix = $wikiId;
+$wgVirtualRestConfig['modules']['parsoid'] = array(
+	'url' => 'http://127.0.0.1:8000',
+	'domain' => 'localhost',
+	'prefix' => $wikiId
+);
 
 // Define which namespaces will use VE
 $wgVisualEditorNamespaces = array_merge(
@@ -1105,7 +1106,7 @@ $wgVisualEditorNamespaces = array_merge(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"Elastica",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/Elastica.git",
-	"REL1_25"
+	"REL1_27"
 );
 
 
@@ -1115,7 +1116,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"CirrusSearch",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/CirrusSearch.git",
-	"REL1_25"
+	"REL1_27"
 );
 $wgSearchType = 'CirrusSearch';
 //$wgCirrusSearchServers = array( 'search01', 'search02' );
@@ -1127,7 +1128,7 @@ $wgSearchType = 'CirrusSearch';
 require_once $egExtensionLoader->registerLegacyExtension(
 	"Echo",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/Echo.git",
-	"REL1_25"
+	"REL1_27"
 );
 $wgEchoEmailFooterAddress = $wgPasswordSender;
 
@@ -1138,7 +1139,7 @@ $wgEchoEmailFooterAddress = $wgPasswordSender;
 require_once $egExtensionLoader->registerLegacyExtension(
 	"Thanks",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/Thanks.git",
-	"REL1_25"
+	"REL1_27"
 );
 $wgThanksConfirmationRequired = false;
 
@@ -1149,7 +1150,7 @@ $wgThanksConfirmationRequired = false;
 require_once $egExtensionLoader->registerLegacyExtension(
 	'UploadWizard',
 	'https://gerrit.wikimedia.org/r/mediawiki/extensions/UploadWizard',
-	'REL1_25'
+	'REL1_27'
 );
 
 // Needed to make UploadWizard work in IE, see bug 39877
@@ -1203,7 +1204,7 @@ $wgUploadWizardConfig = array(
 require_once $egExtensionLoader->registerLegacyExtension(
 	'CollapsibleVector',
 	'https://gerrit.wikimedia.org/r/mediawiki/extensions/CollapsibleVector',
-	'REL1_25'
+	'REL1_27'
 );
 
 
@@ -1213,7 +1214,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	'Math',
 	'https://gerrit.wikimedia.org/r/mediawiki/extensions/Math.git',
-	'REL1_25'
+	'REL1_27'
 );
 
 $wgMathValidModes[] = MW_MATH_MATHJAX; // Define MathJax as one of the valid math rendering modes
@@ -1233,7 +1234,7 @@ $wgDefaultUserOptions['mathJax'] = true; // Enable the MathJax checkbox option
 // require_once $egExtensionLoader->registerLegacyExtension(
 // 	'Flow',
 // 	'https://gerrit.wikimedia.org/r/mediawiki/extensions/Flow.git',
-// 	'REL1_25'
+// 	'REL1_27'
 // );
 
 // // only allow sysops to create new flow boards

--- a/config/core/LocalSettings.php
+++ b/config/core/LocalSettings.php
@@ -637,13 +637,6 @@ $smwgNamespacesWithSemanticLinks[NS_TALK] = true;
 require_once "$IP/extensions/ExtensionLoader/ExtensionLoader.php";
 $egExtensionLoader = new ExtensionLoader();
 
-/**
- * May want to include ParserFunctionHelper in order to extension-ify templates
- */
-// 'ParserFunctionHelper' => array(
-// 	'git' => 'https://github.com/enterprisemediawiki/ParserFunctionHelper.git',
-// 	'branch' => 'master',
-// ),
 
 /**
  * ImportUsers is not in wikimedia git, now in github/kghbln. Also, it seems it
@@ -725,9 +718,19 @@ $wgCiteEnablePopups = true;
 
 
 #
-# Extension:WhoIsWatching
+# Extension:ParserFunctionHelper
 #
 $egExtensionLoader->load(
+	'ParserFunctionHelper',
+	'https://github.com/enterprisemediawiki/ParserFunctionHelper.git',
+	'master'
+);
+
+
+#
+# Extension:WhoIsWatching
+#
+require_once $egExtensionLoader->registerLegacyExtension(
 	"WhoIsWatching",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/WhoIsWatching.git",
 	"REL1_27"
@@ -953,7 +956,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"WatchAnalytics",
 	"https://github.com/enterprisemediawiki/WatchAnalytics.git",
-	"extreg"
+	"master"
 );
 
 // makes Pending Reviews shake after X days
@@ -1151,7 +1154,7 @@ $wgThanksConfirmationRequired = false;
 #
 # Extension:Upload Wizard
 #
-$egExtensionLoader->load(
+require_once $egExtensionLoader->registerLegacyExtension(
 	'UploadWizard',
 	'https://gerrit.wikimedia.org/r/mediawiki/extensions/UploadWizard',
 	'REL1_27'

--- a/config/core/LocalSettings.php
+++ b/config/core/LocalSettings.php
@@ -319,16 +319,22 @@ if ( file_exists( "$m_config/local/primewiki" ) ) {
  **/
 // memcached settings
 $wgMainCacheType = CACHE_MEMCACHED;
-$wgParserCacheType = CACHE_NONE; // optional; if set to CACHE_MEMCACHED, templates used to format query results in generic footer don't work
-$wgMessageCacheType = CACHE_MEMCACHED; // optional
+// If parser cache set to CACHE_MEMCACHED, templates used to format SMW query
+// results in generic footer don't work. This is a limitation of
+// Extension:HeaderFooter which may or may not be able to be worked around.
+$wgParserCacheType = CACHE_NONE;
+$wgMessageCacheType = CACHE_MEMCACHED;
 $wgMemCachedServers = array( "127.0.0.1:11211" );
 
 // memcached is setup and will work for sessions with meza, unless you use
-// SimpleSamlPhp. For that reason memcached is disabled for sessions. This will
-// be fixed in a later version.
-$wgSessionsInObjectCache = false; // optional
-$wgSessionCacheType = CACHE_NONE; // optional
-
+// SimpleSamlPhp. Previous versions of meza had this set to CACHE_NONE, but
+// MW 1.27 requires a session cache. Setting this to CACHE_MEMCACHED as it
+// is the ultimate goal. A separate branch contains pulling PHP from the
+// IUS repository, which should simplify integrating PHP and memcached in a
+// way that SimpleSamlPhp likes. So this may be temporarily breaking for
+// SAML, but MW 1.27 may be breaking for SAML anyway due to changes in
+// AuthPlugin/AuthManager.
+$wgSessionCacheType = CACHE_MEMCACHED;
 
 ## To enable image uploads, make sure the 'images' directory
 ## is writable, then set this to true:
@@ -658,7 +664,7 @@ $egExtensionLoader = new ExtensionLoader();
 #
 # Extension:ParserFunctions
 #
-require_once $egExtensionLoader->registerLegacyExtension(
+$egExtensionLoader->load(
 	"ParserFunctions",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/ParserFunctions.git",
 	"REL1_27"
@@ -668,6 +674,7 @@ $wgPFEnableStringFunctions = true;
 
 #
 # Extension:StringFunctionsEscaped
+# No extension.json
 #
 require_once $egExtensionLoader->registerLegacyExtension(
 	"StringFunctionsEscaped",
@@ -679,7 +686,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 #
 # Extension:ExternalData
 #
-require_once $egExtensionLoader->registerLegacyExtension(
+$egExtensionLoader->load(
 	"ExternalData",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/ExternalData.git",
 	"REL1_27"
@@ -689,7 +696,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 #
 # Extension:LabeledSectionTransclusion
 #
-require_once $egExtensionLoader->registerLegacyExtension(
+$egExtensionLoader->load(
 	"LabeledSectionTransclusion",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/LabeledSectionTransclusion.git",
 	"REL1_27"
@@ -699,7 +706,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 #
 # Extension:Cite
 #
-require_once $egExtensionLoader->registerLegacyExtension(
+$egExtensionLoader->load(
 	"Cite",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/Cite.git",
 	"REL1_27"
@@ -720,7 +727,7 @@ $wgCiteEnablePopups = true;
 #
 # Extension:WhoIsWatching
 #
-require_once $egExtensionLoader->registerLegacyExtension(
+$egExtensionLoader->load(
 	"WhoIsWatching",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/WhoIsWatching.git",
 	"REL1_27"
@@ -731,7 +738,7 @@ $wgPageShowWatchingUsers = true;
 #
 # Extension:CharInsert
 #
-require_once $egExtensionLoader->registerLegacyExtension(
+$egExtensionLoader->load(
 	"CharInsert",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/CharInsert.git",
 	"REL1_27"
@@ -741,7 +748,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 #
 # Extension:SemanticForms
 #
-require_once $egExtensionLoader->registerLegacyExtension(
+$egExtensionLoader->load(
 	"SemanticForms",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/SemanticForms.git",
 	"tags/3.5"
@@ -750,6 +757,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 
 #
 # Extension:SemanticInternalObjects
+# No extension.json
 #
 require_once $egExtensionLoader->registerLegacyExtension(
 	"SemanticInternalObjects",
@@ -760,6 +768,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 
 #
 # Extension:SemanticCompoundQueries
+# No extension.json
 #
 require_once $egExtensionLoader->registerLegacyExtension(
 	"SemanticCompoundQueries",
@@ -770,20 +779,11 @@ require_once $egExtensionLoader->registerLegacyExtension(
 
 #
 # Extension:Arrays
+# No extension.json
 #
 require_once $egExtensionLoader->registerLegacyExtension(
 	"Arrays",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/Arrays.git",
-	"REL1_27"
-);
-
-
-#
-# Extension:TitleKey
-#
-require_once $egExtensionLoader->registerLegacyExtension(
-	"TitleKey",
-	"https://gerrit.wikimedia.org/r/mediawiki/extensions/TitleKey.git",
 	"REL1_27"
 );
 
@@ -794,12 +794,13 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"TalkRight",
 	"https://github.com/enterprisemediawiki/TalkRight.git",
-	"master"
+	"extreg"
 );
 
 
 #
 # Extension:AdminLinks
+# No extension.json
 #
 require_once $egExtensionLoader->registerLegacyExtension(
 	"AdminLinks",
@@ -812,7 +813,7 @@ $wgGroupPermissions['sysop']['adminlinks'] = true;
 #
 # Extension:DismissableSiteNotice
 #
-require_once $egExtensionLoader->registerLegacyExtension(
+$egExtensionLoader->load(
 	"DismissableSiteNotice",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/DismissableSiteNotice.git",
 	"REL1_27"
@@ -821,6 +822,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 
 #
 # Extension:BatchUserRights
+# No extension.json
 #
 require_once $egExtensionLoader->registerLegacyExtension(
 	"BatchUserRights",
@@ -832,7 +834,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 #
 # Extension:HeaderTabs
 #
-require_once $egExtensionLoader->registerLegacyExtension(
+$egExtensionLoader->load(
 	"HeaderTabs",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/HeaderTabs.git",
 	"REL1_27"
@@ -844,7 +846,7 @@ $htRenderSingleTab = true;
 #
 # Extension:WikiEditor
 #
-require_once $egExtensionLoader->registerLegacyExtension(
+$egExtensionLoader->load(
 	"WikiEditor",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/WikiEditor.git",
 	"REL1_27"
@@ -865,7 +867,7 @@ $wgDefaultUserOptions['wikieditor-preview'] = 1;
 require_once $egExtensionLoader->registerLegacyExtension(
 	"CopyWatchers",
 	"https://github.com/jamesmontalvo3/MediaWiki-CopyWatchers.git",
-	"master"
+	"extreg"
 );
 
 
@@ -875,7 +877,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 # consider replacing with SyntaxHighlight_Pygments
 # https://gerrit.wikimedia.org/r/mediawiki/extensions/SyntaxHighlight_Pygments.git
 #
-require_once $egExtensionLoader->registerLegacyExtension(
+$egExtensionLoader->load(
 	"SyntaxHighlight_GeSHi",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/SyntaxHighlight_GeSHi.git",
 	"REL1_27"
@@ -888,12 +890,13 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"Wiretap",
 	"https://github.com/enterprisemediawiki/Wiretap.git",
-	"master"
+	"extreg"
 );
 
 
 #
 # Extension:ApprovedRevs
+# No extension.json
 #
 require_once $egExtensionLoader->registerLegacyExtension(
 	"ApprovedRevs",
@@ -906,7 +909,7 @@ $egApprovedRevsAutomaticApprovals = false;
 #
 # Extension:InputBox
 #
-require_once $egExtensionLoader->registerLegacyExtension(
+$egExtensionLoader->load(
 	"InputBox",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/InputBox.git",
 	"REL1_27"
@@ -916,7 +919,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 #
 # Extension:ReplaceText
 #
-require_once $egExtensionLoader->registerLegacyExtension(
+$egExtensionLoader->load(
 	"ReplaceText",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/ReplaceText.git",
 	"REL1_27"
@@ -926,7 +929,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 #
 # Extension:Interwiki
 #
-require_once $egExtensionLoader->registerLegacyExtension(
+$egExtensionLoader->load(
 	"Interwiki",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/Interwiki.git",
 	"REL1_27"
@@ -940,7 +943,7 @@ $wgGroupPermissions['sysop']['interwiki'] = true;
 require_once $egExtensionLoader->registerLegacyExtension(
 	"MasonryMainPage",
 	"https://github.com/enterprisemediawiki/MasonryMainPage.git",
-	"master"
+	"extreg"
 );
 
 
@@ -950,7 +953,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"WatchAnalytics",
 	"https://github.com/enterprisemediawiki/WatchAnalytics.git",
-	"master"
+	"extreg"
 );
 
 // makes Pending Reviews shake after X days
@@ -969,6 +972,7 @@ $egPendingReviewsEmphasizeDays = 10;
 
 #
 # Extension:Variables
+# No extension.json
 #
 require_once $egExtensionLoader->registerLegacyExtension(
 	"Variables",
@@ -980,7 +984,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 #
 # Extension:YouTube
 #
-require_once $egExtensionLoader->registerLegacyExtension(
+$egExtensionLoader->load(
 	"YouTube",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/YouTube.git",
 	"REL1_27"
@@ -989,7 +993,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 
 #
 # Extension:ContributionScores
-#
+# No extension.json
 require_once $egExtensionLoader->registerLegacyExtension(
 	"ContributionScores",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/ContributionScores.git",
@@ -1026,14 +1030,14 @@ $wgContribScoreReports = array(
 require_once $egExtensionLoader->registerLegacyExtension(
 	"PipeEscape",
 	"https://github.com/jamesmontalvo3/MediaWiki-PipeEscape.git",
-	"master"
+	"extreg"
 );
 
 
 #
 # Extension:PdfHandler
 #
-// require_once $egExtensionLoader->registerLegacyExtension(
+// $egExtensionLoader->load(
 // 	"PdfHandler",
 // 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/PdfHandler",
 // 	"REL1_27"
@@ -1047,7 +1051,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 #
 # Extension:UniversalLanguageSelector
 #
-require_once $egExtensionLoader->registerLegacyExtension(
+$egExtensionLoader->load(
 	"UniversalLanguageSelector",
 	"https://gerrit.wikimedia.org/r/p/mediawiki/extensions/UniversalLanguageSelector.git",
 	"REL1_27"
@@ -1057,7 +1061,7 @@ require_once $egExtensionLoader->registerLegacyExtension(
 #
 # Extension:VisualEditor
 #
-require_once $egExtensionLoader->registerLegacyExtension(
+$egExtensionLoader->load(
 	"VisualEditor",
 	"https://gerrit.wikimedia.org/r/p/mediawiki/extensions/VisualEditor.git",
 	"REL1_27"
@@ -1103,7 +1107,7 @@ $wgVisualEditorNamespaces = array_merge(
 #
 # Extension:Elastica
 #
-require_once $egExtensionLoader->registerLegacyExtension(
+$egExtensionLoader->load(
 	"Elastica",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/Elastica.git",
 	"REL1_27"
@@ -1136,7 +1140,7 @@ $wgEchoEmailFooterAddress = $wgPasswordSender;
 #
 # Extension:Thanks
 #
-require_once $egExtensionLoader->registerLegacyExtension(
+$egExtensionLoader->load(
 	"Thanks",
 	"https://gerrit.wikimedia.org/r/mediawiki/extensions/Thanks.git",
 	"REL1_27"
@@ -1147,7 +1151,7 @@ $wgThanksConfirmationRequired = false;
 #
 # Extension:Upload Wizard
 #
-require_once $egExtensionLoader->registerLegacyExtension(
+$egExtensionLoader->load(
 	'UploadWizard',
 	'https://gerrit.wikimedia.org/r/mediawiki/extensions/UploadWizard',
 	'REL1_27'
@@ -1201,7 +1205,7 @@ $wgUploadWizardConfig = array(
 #
 # Extension:CollapsibleVector
 #
-require_once $egExtensionLoader->registerLegacyExtension(
+$egExtensionLoader->load(
 	'CollapsibleVector',
 	'https://gerrit.wikimedia.org/r/mediawiki/extensions/CollapsibleVector',
 	'REL1_27'
@@ -1211,15 +1215,15 @@ require_once $egExtensionLoader->registerLegacyExtension(
 #
 # Extension:Math
 #
-require_once $egExtensionLoader->registerLegacyExtension(
+$egExtensionLoader->load(
 	'Math',
 	'https://gerrit.wikimedia.org/r/mediawiki/extensions/Math.git',
 	'REL1_27'
 );
 
-$wgMathValidModes[] = MW_MATH_MATHJAX; // Define MathJax as one of the valid math rendering modes
+$wgMathValidModes[] = 'MW_MATH_MATHJAX'; // Define MathJax as one of the valid math rendering modes
 $wgUseMathJax = true; // Enable MathJax as a math rendering option for users to pick
-$wgDefaultUserOptions['math'] = MW_MATH_MATHJAX; // Set MathJax as the default rendering option for all users (optional)
+$wgDefaultUserOptions['math'] = 'MW_MATH_MATHJAX'; // Set MathJax as the default rendering option for all users (optional)
 $wgMathDisableTexFilter = true; // or compile "texvccheck"
 $wgDefaultUserOptions['mathJax'] = true; // Enable the MathJax checkbox option
 
@@ -1231,7 +1235,7 @@ $wgDefaultUserOptions['mathJax'] = true; // Enable the MathJax checkbox option
 # improved interface is great, it's useless if we can't search our old content.
 # See issues #272.
 #
-// require_once $egExtensionLoader->registerLegacyExtension(
+// $egExtensionLoader->load(
 // 	'Flow',
 // 	'https://gerrit.wikimedia.org/r/mediawiki/extensions/Flow.git',
 // 	'REL1_27'
@@ -1266,6 +1270,7 @@ $wgDefaultUserOptions['mathJax'] = true; // Enable the MathJax checkbox option
 
 #
 # Extension:Data Transfer
+# No extension.json
 #
 require_once $egExtensionLoader->registerLegacyExtension(
 	'DataTransfer',

--- a/config/core/initd_parsoid.sh
+++ b/config/core/initd_parsoid.sh
@@ -11,10 +11,10 @@
 USER="parsoid"
 
 DAEMON="/usr/local/bin/node"
-ROOT_DIR="/etc/parsoid/api"
+ROOT_DIR="/etc/parsoid/bin"
 
 SERVER="$ROOT_DIR/server.js"
-LOG_FILE="$ROOT_DIR/server.js.log"
+LOG_FILE="$ROOT_DIR/../server.js.log"
 
 LOCK_FILE="/var/lock/subsys/node-server"
 

--- a/config/core/localsettings.js
+++ b/config/core/localsettings.js
@@ -28,7 +28,9 @@ exports.setup = function(parsoidConfig) {
 		parsoidConfig.setMwApi( {
 			prefix: wikis[i],
 			uri: domain + wikis[i] + '/api.php',
-			domain: "localhost"
+
+			// not really the domain, needs to be specific to each wiki
+			domain: wikis[i]
 		} );
 	}
 

--- a/config/core/localsettings.js
+++ b/config/core/localsettings.js
@@ -27,7 +27,8 @@ exports.setup = function(parsoidConfig) {
 	for ( var i = 0; i < wikis.length; i++ ) {
 		parsoidConfig.setMwApi( {
 			prefix: wikis[i],
-			uri: domain + wikis[i] + '/api.php'
+			uri: domain + wikis[i] + '/api.php',
+			domain: "localhost"
 		} );
 	}
 

--- a/scripts/VE.sh
+++ b/scripts/VE.sh
@@ -82,7 +82,7 @@ echo "******* Downloading configuration files *******"
 cd "$m_meza/scripts"
 
 # Copy Parsoid settings from Meza to Parsoid install
-ln -s "$m_config/core/localsettings.js" /etc/parsoid/api/localsettings.js
+ln -s "$m_config/core/localsettings.js" /etc/parsoid/localsettings.js
 
 # MediaWiki's API URI, for parsoid. Parsoid communicates with MediaWiki PHP API
 # via Apache httpd over port 9000. Note: protocol was $mw_api_protocol, but was

--- a/scripts/extensions.sh
+++ b/scripts/extensions.sh
@@ -95,7 +95,7 @@ WIKI=demo php extensions/TitleKey/rebuildTitleKeys.php
 # Other extensions could cause similar issues, so it's best that this go after
 # loading extensions.
 #
-WIKI=demo php "$m_meza/scripts/mezaCreateUser.php" --username=Admin --password=1234 --groups=sysop,bureaucrat
+WIKI=demo php "$m_meza/scripts/mezaCreateUser.php" --username=Admin --password=adminpass --groups=sysop,bureaucrat
 
 #
 # Generate ES index, since it is skipped in the initial create-wiki.sh

--- a/scripts/extensions.sh
+++ b/scripts/extensions.sh
@@ -51,7 +51,9 @@ cd "$m_mediawiki/extensions/Elastica"
 composer install
 
 
-
+# Install SyntaxHighlight dependencies
+cd "$m_mediawiki/extensions/SyntaxHighlight_GeSHi"
+composer install
 
 
 # Install extensions installed via Composer

--- a/scripts/extensions.sh
+++ b/scripts/extensions.sh
@@ -30,7 +30,7 @@ echo -e "\n\n## meza: Install ExtensionLoader and apply changes to MW settings"
 cd "$m_mediawiki/extensions"
 git clone https://github.com/jamesmontalvo3/ExtensionLoader.git
 cd ./ExtensionLoader
-git checkout tags/v0.3.0
+git checkout tags/v0.3.1
 cd "$m_mediawiki"
 
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -190,7 +190,7 @@ fi
 #   9260e5d       (a sha1 hash)
 #   tags/v0.4.1   (a tag name)
 #   master        (a branch name)
-parsoid_version="ba26a55"
+parsoid_version="dd8e644d320aec076f76da4e2bd70a8527e0dfd8" # closest to MW 1.27 release date of 28 June 2016
 
 phpversion="5.6.14"
 

--- a/scripts/mediawiki.sh
+++ b/scripts/mediawiki.sh
@@ -50,14 +50,14 @@ if [ "$mediawiki_git_install" = "y" ]; then
 	cd mediawiki
 
 	# Checkout latest released version
-	git checkout tags/1.25.5
+	git checkout tags/1.27.1
 	cmd_profile "END mediawiki git clone"
 else
 	cmd_profile "START mediawiki get from tarball"
-	wget http://releases.wikimedia.org/mediawiki/1.25/mediawiki-core-1.25.5.tar.gz
+	wget http://releases.wikimedia.org/mediawiki/1.27/mediawiki-core-1.27.1.tar.gz
 
 	mkdir mediawiki
-	tar xpvf mediawiki-core-1.25.5.tar.gz -C ./mediawiki --strip-components 1
+	tar xpvf mediawiki-core-1.27.1.tar.gz -C ./mediawiki --strip-components 1
 	cd mediawiki
 	cmd_profile "END mediawiki get from tarball"
 fi
@@ -95,12 +95,12 @@ if [ "$mediawiki_git_install" = "y" ]; then
 	# git clone https://github.com/wikimedia/mediawiki-skins-Vector.git Vector
 	git clone https://gerrit.wikimedia.org/r/p/mediawiki/skins/Vector.git Vector
 	cd Vector
-	git checkout REL1_25
+	git checkout REL1_27
 	cd ..
 else
-	wget https://github.com/wikimedia/mediawiki-skins-Vector/archive/REL1_25.tar.gz
+	wget https://github.com/wikimedia/mediawiki-skins-Vector/archive/REL1_27.tar.gz
 	mkdir Vector
-	tar xpvf REL1_25.tar.gz -C ./Vector --strip-components 1
+	tar xpvf REL1_27.tar.gz -C ./Vector --strip-components 1
 fi
 
 #

--- a/scripts/php.sh
+++ b/scripts/php.sh
@@ -26,6 +26,7 @@ yum install -y \
 	php56u-xmlrpc \
 	php56u-mysqlnd \
 	php56u-pdo \
+	php56u-odbc \
 	php56u-pear \
 	php56u-pecl-jsonc \
 	php56u-process \


### PR DESCRIPTION
Much development has been going on to make meza support a multi-server environment. This has created a chain of development branches all building off of each other. Rather than maintain this confusing chain, I'm merging them all into a `dev` branch.

The `mw1.27` branch started using MediaWiki 1.27.

Ref #462 for more cleanup