### PR TITLE
Make `meza install monolith` work again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 .DS_Store
 logs/*
 !logs/README.md
-config/local/*
-!config/local/README.md
+config/config.local.sh
 
 # data directory used to hold MariaDB and Elasticsearch data
 # which should not be added to this repo. However, there are

--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ Login to your server and run the following:
 ```bash
 curl -L getmeza.org > doit
 sudo bash doit
-sudo vi /opt/meza/ansible/env/example/hosts # make IP addresses match your server
-sudo meza deploy example
+sudo meza install monolith
 ```
 
 ## See Also

--- a/ansible/env/example/hosts
+++ b/ansible/env/example/hosts
@@ -1,22 +1,22 @@
 # Example hosts file
 
 [load-balancers]
-192.168.56.80
+IP_ADDR
 
 [app-servers]
-192.168.56.80
+IP_ADDR
 
 [memcached-servers]
-192.168.56.80
+IP_ADDR
 
 [db-master]
-192.168.56.80
+IP_ADDR
 
 [db-slaves]
-# 192.168.56.60   mysql_server_id=2
+# IP_ADDR   mysql_server_id=2
 
 [parsoid-servers]
-192.168.56.80
+IP_ADDR
 
 [elastic-servers]
-192.168.56.80
+IP_ADDR

--- a/config/core/config.sh
+++ b/config/core/config.sh
@@ -27,11 +27,14 @@ m_mediawiki="$m_htdocs/mediawiki"
 m_apache="/etc/httpd"
 
 # files
-m_local_config_file="$m_config/local/config.local.sh"
 m_i18n="$m_config/core/i18n"
 m_db_replication_dump_file="/opt/meza/data/db_master_for_replication.sql"
 m_db_replication_log_file="/opt/meza/data/db_master_log_file"
 m_db_replication_log_pos="/opt/meza/data/db_master_log_pos"
+
+# FIXME: This needs to be handled another way
+m_local_config_file="$m_config/config.local.sh"
+
 
 #
 # Installation configuration

--- a/scripts/meza.sh
+++ b/scripts/meza.sh
@@ -50,6 +50,9 @@
 
 source "/opt/meza/config/core/config.sh"
 
+# Make sure this file exists
+touch "$m_local_config_file"
+
 # meza requires a command parameter. No first param, no command. Display help
 if [ -z "$1" ]; then
 	cat "$m_meza/manual/meza-cmd/base.txt"

--- a/scripts/meza.sh
+++ b/scripts/meza.sh
@@ -103,11 +103,18 @@ case "$1" in
 				# Create a "monolith" environment
 				cp -r "$m_meza/ansible/env/example" "$m_meza/ansible/env/monolith"
 
-				# Prompt for IP/domain
-				meza prompt monolith_ip "Type the domain or IP address for this server"
+				# get domain from third arg if available, else prompt
+				if [ ! -z "$3" ]; then
+					monolith_ip="$3"
+				else
+					# Prompt for IP/domain
+					meza prompt monolith_ip "Type the domain or IP address for this server"
 
-				# Re-source after prompt
-				source "$m_local_config_file"
+					# Re-source after prompt
+					source "$m_local_config_file"
+				fi
+
+				ssh-keyscan -H "$monolith_ip" >> /home/meza-ansible/.ssh/known_hosts
 
 				# Make the IP/domain for every part of meza be the monolith IP
 				sed -r -i "s/IP_ADDR/${monolith_ip}/g;" "$m_meza/ansible/env/monolith/hosts"

--- a/scripts/meza.sh
+++ b/scripts/meza.sh
@@ -208,9 +208,10 @@ case "$1" in
 			exit 1;
 		fi
 
-		echo
-		echo "You are about to deploy to the $ansible_env environment"
-		read -p "Do you want to proceed? " -n 1 -r
+		# This breaks continuous integration. FIXME to get it back.
+		# echo
+		# echo "You are about to deploy to the $ansible_env environment"
+		# read -p "Do you want to proceed? " -n 1 -r
 		echo
 		if [[ $REPLY =~ ^[Yy]$ ]]
 		then

--- a/scripts/meza.sh
+++ b/scripts/meza.sh
@@ -212,21 +212,24 @@ case "$1" in
 		# echo
 		# echo "You are about to deploy to the $ansible_env environment"
 		# read -p "Do you want to proceed? " -n 1 -r
-		echo
-		if [[ $REPLY =~ ^[Yy]$ ]]
-		then
+		# echo
+		# if [[ $REPLY =~ ^[Yy]$ ]]
+		# then
 			# do dangerous stuff
 
-			# Get errors with user meza-ansible trying to write to the calling-user's
-			# home directory if don't cd to a neutral location. FIXME.
-			starting_wd=`pwd`
-			cd /opt
+			# stuff below was in here
+		# fi
 
-			sudo -u meza-ansible ansible-playbook /opt/meza/ansible/site.yml -i "$host_file" ${@:3}
 
-			cd "$starting_wd"
+		# Get errors with user meza-ansible trying to write to the calling-user's
+		# home directory if don't cd to a neutral location. FIXME.
+		starting_wd=`pwd`
+		cd /opt
 
-		fi
+		sudo -u meza-ansible ansible-playbook /opt/meza/ansible/site.yml -i "$host_file" ${@:3}
+
+		cd "$starting_wd"
+
 		;;
 
 	setup)

--- a/scripts/meza.sh
+++ b/scripts/meza.sh
@@ -97,18 +97,20 @@ case "$1" in
 				;;
 			"monolith")
 
-				# All modules, unmodified
-				modules="$mod_base thisisappserver $mod_app_initial $mod_memcached $mod_db $mod_parsoid $mod_elastic $mod_app_final $mod_security"
-				meza config modules "$modules"
+				# Create a "monolith" environment
+				cp -r "$m_meza/ansible/env/example" "$m_meza/ansible/env/monolith"
 
-				# Don't prompt for list of app-server IP addresses, since the
-				# monolith is the only server.
-				meza config app_server_ips "localhost"
+				# Prompt for IP/domain
+				meza prompt monolith_ip "Type the domain or IP address for this server"
 
-				# Don't prompt for a list of db-server IP addresses, either
-				meza config db_server_ips "localhost"
+				# Re-source after prompt
+				source "$m_local_config_file"
 
-				"$m_scripts/install.sh"
+				# Make the IP/domain for every part of meza be the monolith IP
+				sed -r -i "s/IP_ADDR/${monolith_ip}/g;" "$m_meza/ansible/env/monolith/hosts"
+
+				meza deploy monolith
+
 				exit 0;
 				;;
 			"app-with-remote-db")


### PR DESCRIPTION
Allows running command `meza install monolith`. This will prompt for the IP address or domain of the server you're running the command on, and then install everything upon it. Alternatively, do `meza install monolith IPADDR` (with IPADDR = the desired IP or domain) to avoid prompts. This will be used by TravisCI.