### PR TITLE
Allow ansible local connections

### DIFF
--- a/ansible/env/example/hosts
+++ b/ansible/env/example/hosts
@@ -1,5 +1,7 @@
 # Example hosts file
 
+localhost ansible_connection=local
+
 [load-balancers]
 IP_ADDR
 

--- a/ansible/roles/firewalld/tasks/main.yml
+++ b/ansible/roles/firewalld/tasks/main.yml
@@ -61,7 +61,7 @@
     state: enabled
     zone: "{{firewalld_zone|default('public')}}"
   with_items: "{{ firewalld_servers }}"
-  when: firewalld_service is defined and item != inventory_hostname
+  when: firewalld_service is defined and item != inventory_hostname and item != "localhost"
   # FIXME: add condtional like "and item != inventory_hostname". Not 100% certain
   # that works with with_items. Also need to make sure the required logic in place
   # such that when item==inventory_hostname, it gets converted to localhost or
@@ -75,5 +75,5 @@
     state: enabled
     zone: "{{firewalld_zone|default('public')}}"
   with_items: "{{ firewalld_servers }}"
-  when: firewalld_port is defined and firewalld_protocol is defined
+  when: firewalld_port is defined and firewalld_protocol is defined and item != inventory_hostname and item != "localhost"
   # FIXME: add condtional like "and item != inventory_hostname". see same comment above.

--- a/ansible/roles/firewalld/tasks/main.yml
+++ b/ansible/roles/firewalld/tasks/main.yml
@@ -60,12 +60,9 @@
     immediate: true
     state: enabled
     zone: "{{firewalld_zone|default('public')}}"
-  with_items: "{{ firewalld_servers }}"
-  when: firewalld_service is defined and item != inventory_hostname and item != "localhost"
-  # FIXME: add condtional like "and item != inventory_hostname". Not 100% certain
-  # that works with with_items. Also need to make sure the required logic in place
-  # such that when item==inventory_hostname, it gets converted to localhost or
-  # 127.0.0.1 wherever it's used.
+  # strip "localhost" or inventory_hostname from list of servers to configure
+  with_items: "{{ firewalld_servers | difference([ 'localhost', inventory_hostname ]) }}"
+  when: firewalld_service is defined
 
 - name: set firewalld allow port {{ firewalld_port }} for list of servers
   firewalld:
@@ -74,6 +71,6 @@
     immediate: true
     state: enabled
     zone: "{{firewalld_zone|default('public')}}"
-  with_items: "{{ firewalld_servers }}"
-  when: firewalld_port is defined and firewalld_protocol is defined and item != inventory_hostname and item != "localhost"
-  # FIXME: add condtional like "and item != inventory_hostname". see same comment above.
+  # strip "localhost" or inventory_hostname from list of servers to configure
+  with_items: "{{ firewalld_servers | difference([ 'localhost', inventory_hostname ]) }}"
+  when: firewalld_port is defined and firewalld_protocol is defined

--- a/ansible/roles/haproxy/templates/haproxy.cfg.j2
+++ b/ansible/roles/haproxy/templates/haproxy.cfg.j2
@@ -56,12 +56,12 @@ defaults
 	option http-server-close
 
 frontend www-http
-	bind {{ inventory_hostname }}:80
+	bind *:80
 	reqadd X-Forwarded-Proto:\ http
 	default_backend www-backend
 
 frontend www-https
-	bind {{ inventory_hostname }}:443 ssl crt /etc/haproxy/certs/meza.pem
+	bind *:443 ssl crt /etc/haproxy/certs/meza.pem
 	reqadd X-Forwarded-Proto:\ https
 	# Keep letsencrypt stuff here for now. Probably add it back later.
 	# acl letsencrypt-acl path_beg /.well-known/acme-challenge/

--- a/scripts/meza.sh
+++ b/scripts/meza.sh
@@ -103,21 +103,21 @@ case "$1" in
 				# Create a "monolith" environment
 				cp -r "$m_meza/ansible/env/example" "$m_meza/ansible/env/monolith"
 
-				# get domain from third arg if available, else prompt
-				if [ ! -z "$3" ]; then
-					monolith_ip="$3"
-				else
-					# Prompt for IP/domain
-					meza prompt monolith_ip "Type the domain or IP address for this server"
+				# # get domain from third arg if available, else prompt
+				# if [ ! -z "$3" ]; then
+				# 	monolith_ip="$3"
+				# else
+				# 	# Prompt for IP/domain
+				# 	meza prompt monolith_ip "Type the domain or IP address for this server"
 
-					# Re-source after prompt
-					source "$m_local_config_file"
-				fi
+				# 	# Re-source after prompt
+				# 	source "$m_local_config_file"
+				# fi
 
-				ssh-keyscan -H "$monolith_ip" >> /home/meza-ansible/.ssh/known_hosts
+				# ssh-keyscan -H "$monolith_ip" >> /home/meza-ansible/.ssh/known_hosts
 
 				# Make the IP/domain for every part of meza be the monolith IP
-				sed -r -i "s/IP_ADDR/${monolith_ip}/g;" "$m_meza/ansible/env/monolith/hosts"
+				sed -r -i "s/IP_ADDR/localhost/g;" "$m_meza/ansible/env/monolith/hosts"
 
 				meza deploy monolith
 

--- a/scripts/meza.sh
+++ b/scripts/meza.sh
@@ -103,20 +103,7 @@ case "$1" in
 				# Create a "monolith" environment
 				cp -r "$m_meza/ansible/env/example" "$m_meza/ansible/env/monolith"
 
-				# # get domain from third arg if available, else prompt
-				# if [ ! -z "$3" ]; then
-				# 	monolith_ip="$3"
-				# else
-				# 	# Prompt for IP/domain
-				# 	meza prompt monolith_ip "Type the domain or IP address for this server"
-
-				# 	# Re-source after prompt
-				# 	source "$m_local_config_file"
-				# fi
-
-				# ssh-keyscan -H "$monolith_ip" >> /home/meza-ansible/.ssh/known_hosts
-
-				# Make the IP/domain for every part of meza be the monolith IP
+				# Make the IP/domain for every part of meza be localhost
 				sed -r -i "s/IP_ADDR/localhost/g;" "$m_meza/ansible/env/monolith/hosts"
 
 				meza deploy monolith


### PR DESCRIPTION
Allow ansible localhost connections such that a server doesn't have to SSH into itself. Also this makes it so on `meza install monolith` you don't need to type the IP address of the server. It now listens to all IP addresses.