### PR TITLE
Start using Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,14 @@ script:
 
   # Install meza command
   - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm bash /opt/meza/scripts/getmeza.sh'
-  #- 'docker_ip=$(docker inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}" "$(cat ${container_id})")'
+  - 'docker_ip=$(docker inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}" "$(cat ${container_id})")'
 
-  # - 'echo "IP address = ${docker_ip}"'
-  # - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm meza create env local ${docker_ip}'
+  # Since we want to make the monolith environment without prompts, need to do
+  # `meza setup env monolith` with values for required args included (fqdn,
+  # db_pass, email, private_net_zone).
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm fqdn=${docker_ip} db_pass=1234 email=false private_net_zone=public meza setup env monolith'
+
+  # Now that environment monolith is setup, deploy/install it
   - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm meza install monolith -vv'
 
   # TEST: role.

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,16 +36,10 @@ script:
   - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm bash /etc/ansible/roles/role_under_test/scripts/getmeza.sh'
   - 'docker_ip=$(docker inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}" "$(cat ${container_id})")'
 
-  # Accept key for this server to SSH into itself
-  # (yes, this should instead use an ansible local connection)
-  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ssh-keyscan -H ${docker_ip} >> /home/meza-ansible/.ssh/known_hosts'
-
-  # Change the ip address in env/example/hosts to this IP address
-  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm sed -r -i "s/IP_ADDR/${docker_ip}/g;" /opt/meza/ansible/env/example/hosts'
 
   # - 'echo "IP address = ${docker_ip}"'
   # - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm meza create env local ${docker_ip}'
-  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm meza deploy example'
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm meza install monolith "$(docker_ip)"'
 
   # TEST: role.
   # - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml'
@@ -60,14 +54,16 @@ script:
   #   || (echo 'Idempotence test: fail' && exit 1)
 
 
-  # # Ensure Node.js is installed.
-  # - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm which node'
-  # - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm node -v'
+  # Ensure Node.js is installed.
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm which node'
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm node -v'
 
-  # # Ensure PHP is installed.
-  # - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm which php'
-  # - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm php --version'
+  # Ensure PHP is installed.
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm which php'
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm php --version'
 
+  # See if demo wiki is installed
+  # - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm curl https://${docker_ip}/demo/api.php?action=query&meta=siteinfo | grep "Demo Wiki"'
 
 # notifications:
 #   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ script:
 
   # Install meza command
   - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm bash /etc/ansible/roles/role_under_test/scripts/getmeza.sh'
-  - 'docker_ip=$(docker-machine ip "$(cat ${container_id})")'
+  - 'docker inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}" "$(cat ${container_id})"'
 
   # - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm meza create env local ${docker_ip}'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
 script:
   - container_id=$(mktemp)
   # Run container in detached state.
-  - 'docker run --detach --volume="${PWD}":/opt/meza ${run_opts} geerlingguy/docker-${distro}-ansible:latest "${init}" > "${container_id}"'
+  - 'docker run --detach --volume="${PWD}":/opt/meza --add-host="127.0.0.1 localhost meza" ${run_opts} geerlingguy/docker-${distro}-ansible:latest "${init}" > "${container_id}"'
 
   # TEST: Ansible syntax.
   - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /opt/meza/ansible/site.yml --syntax-check'

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,13 @@ before_install:
 script:
   - container_id=$(mktemp)
   # Run container in detached state.
-  - 'docker run --detach --volume="${PWD}":/etc/ansible/roles/role_under_test:ro ${run_opts} geerlingguy/docker-${distro}-ansible:latest "${init}" > "${container_id}"'
+  - 'docker run --detach --volume="${PWD}":/opt/meza:ro ${run_opts} geerlingguy/docker-${distro}-ansible:latest "${init}" > "${container_id}"'
 
   # TEST: Ansible syntax.
-  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/ansible/site.yml --syntax-check'
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /opt/meza/ansible/site.yml --syntax-check'
 
   # Install meza command
-  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm bash /etc/ansible/roles/role_under_test/scripts/getmeza.sh'
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm bash /opt/meza/scripts/getmeza.sh'
   - 'docker_ip=$(docker inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}" "$(cat ${container_id})")'
 
   # - 'echo "IP address = ${docker_ip}"'

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
 script:
   - container_id=$(mktemp)
   # Run container in detached state.
-  - 'docker run --detach --volume="${PWD}":/opt/meza:ro ${run_opts} geerlingguy/docker-${distro}-ansible:latest "${init}" > "${container_id}"'
+  - 'docker run --detach --volume="${PWD}":/opt/meza ${run_opts} geerlingguy/docker-${distro}-ansible:latest "${init}" > "${container_id}"'
 
   # TEST: Ansible syntax.
   - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /opt/meza/ansible/site.yml --syntax-check'

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ script:
 
   # - 'echo "IP address = ${docker_ip}"'
   # - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm meza create env local ${docker_ip}'
-  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm meza install monolith "$(docker_ip)"'
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm meza install monolith "${docker_ip}"'
 
   # TEST: role.
   # - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml'

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ script:
 
   # - 'echo "IP address = ${docker_ip}"'
   # - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm meza create env local ${docker_ip}'
-  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm meza install monolith -vvv'
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm meza install monolith -vv'
 
   # TEST: role.
   # - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml'
@@ -63,6 +63,27 @@ script:
 
   # See if demo wiki is installed
   # - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm curl https://${docker_ip}/demo/api.php?action=query&meta=siteinfo | grep "Demo Wiki"'
+
+  # HAProxy 302 redirect test
+  - >
+    docker exec -tty "$(cat ${container_id})" env TERM=xterm curl --write-out %{http_code} --silent --output /dev/null http://127.0.0.1
+    | grep -q '302'
+    && (echo 'HAProxy 302 redirect test: pass' && exit 0)
+    || (echo 'HAProxy 302 redirect test: fail' && exit 1)
+
+  # Apache (over port 8080) 200 OK test
+  - >
+    docker exec -tty "$(cat ${container_id})" env TERM=xterm curl --write-out %{http_code} --silent --output /dev/null http://127.0.0.1:8080
+    | grep -q '200'
+    && (echo 'Apache 200 test: pass' && exit 0)
+    || (echo 'Apache 200 test: fail' && exit 1)
+
+  # Demo Wiki API test
+  - >
+    docker exec -tty "$(cat ${container_id})" env TERM=xterm curl --write-out %{http_code} --silent --output /dev/null http://127.0.0.1:8080/demo/api.php
+    | grep -q '200'
+    && (echo 'Demo Wiki API test: pass' && exit 0)
+    || (echo 'Demo Wiki API test: fail' && exit 1)
 
 # notifications:
 #   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,11 +34,11 @@ script:
 
   # Install meza command
   - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm bash /opt/meza/scripts/getmeza.sh'
-  - 'docker_ip=$(docker inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}" "$(cat ${container_id})")'
+  #- 'docker_ip=$(docker inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}" "$(cat ${container_id})")'
 
   # - 'echo "IP address = ${docker_ip}"'
   # - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm meza create env local ${docker_ip}'
-  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm meza install monolith'
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm meza install monolith -vvv'
 
   # TEST: role.
   # - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,64 @@
+---
+# Copied, with great appreciation, from geerlingguy/ansible-role-nodejs
+
+services: docker
+
+env:
+  - distro: centos7
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  # - distro: centos6
+  #   init: /sbin/init
+  #   run_opts: ""
+  # - distro: ubuntu1604
+  #   init: /lib/systemd/systemd
+  #   run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  # - distro: ubuntu1404
+  #   init: /sbin/init
+  #   run_opts: ""
+  # - distro: ubuntu1204
+  #   init: /sbin/init
+  #   run_opts: ""
+
+before_install:
+  # Pull container.
+  - 'docker pull geerlingguy/docker-${distro}-ansible:latest'
+
+script:
+  - container_id=$(mktemp)
+  # Run container in detached state.
+  - 'docker run --detach --volume="${PWD}":/etc/ansible/roles/role_under_test:ro ${run_opts} geerlingguy/docker-${distro}-ansible:latest "${init}" > "${container_id}"'
+
+  # TEST: Ansible syntax.
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/ansible/site.yml --syntax-check'
+
+  # Install meza command
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm bash /etc/ansible/roles/role_under_test/scripts/getmeza.sh'
+  - 'docker_ip=$(docker-machine ip "$(cat ${container_id})")'
+
+  # - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm meza create env local ${docker_ip}'
+
+  # TEST: role.
+  # - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml'
+
+  # Test role idempotence.
+  # - idempotence=$(mktemp)
+  # - docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml | tee -a ${idempotence}
+  # - >
+  #   tail ${idempotence}
+  #   | grep -q 'changed=0.*failed=0'
+  #   && (echo 'Idempotence test: pass' && exit 0)
+  #   || (echo 'Idempotence test: fail' && exit 1)
+
+
+  # # Ensure Node.js is installed.
+  # - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm which node'
+  # - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm node -v'
+
+  # # Ensure PHP is installed.
+  # - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm which php'
+  # - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm php --version'
+
+
+# notifications:
+#   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,10 @@ script:
   - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm bash /etc/ansible/roles/role_under_test/scripts/getmeza.sh'
   - 'docker_ip=$(docker inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}" "$(cat ${container_id})")'
 
+  # Make sure ssh installed, enabled, and firewall allows it
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm yum install -y openssh-server openssh-clients'
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm systemctl enable sshd && systemctl start sshd'
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm firewall-cmd --enable --service=ssh'
 
   # - 'echo "IP address = ${docker_ip}"'
   # - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm meza create env local ${docker_ip}'

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,17 @@ script:
   # Install meza command
   - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm bash /etc/ansible/roles/role_under_test/scripts/getmeza.sh'
   - 'docker_ip=$(docker inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}" "$(cat ${container_id})")'
-  - 'echo "IP address = ${docker_ip}"'
 
+  # Accept key for this server to SSH into itself
+  # (yes, this should instead use an ansible local connection)
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ssh-keyscan -H ${docker_ip} >> /home/meza-ansible/.ssh/known_hosts'
+
+  # Change the ip address in env/example/hosts to this IP address
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm sed -r -i "s/IP_ADDR/${docker_ip}/g;" /opt/meza/ansible/env/example/hosts'
+
+  # - 'echo "IP address = ${docker_ip}"'
   # - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm meza create env local ${docker_ip}'
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm meza deploy example'
 
   # TEST: role.
   # - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml'

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,8 @@ script:
 
   # Install meza command
   - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm bash /etc/ansible/roles/role_under_test/scripts/getmeza.sh'
-  - 'docker inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}" "$(cat ${container_id})"'
+  - 'docker_ip=$(docker inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}" "$(cat ${container_id})")'
+  - 'echo "IP address = ${docker_ip}"'
 
   # - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm meza create env local ${docker_ip}'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
 script:
   - container_id=$(mktemp)
   # Run container in detached state.
-  - 'docker run --detach --volume="${PWD}":/opt/meza --add-host="127.0.0.1 localhost meza" ${run_opts} geerlingguy/docker-${distro}-ansible:latest "${init}" > "${container_id}"'
+  - 'docker run --detach --volume="${PWD}":/opt/meza --add-host="localhost:127.0.0.1" ${run_opts} geerlingguy/docker-${distro}-ansible:latest "${init}" > "${container_id}"'
 
   # TEST: Ansible syntax.
   - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /opt/meza/ansible/site.yml --syntax-check'

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,21 +66,21 @@ script:
 
   # HAProxy 302 redirect test
   - >
-    docker exec -tty "$(cat ${container_id})" env TERM=xterm curl --write-out %{http_code} --silent --output /dev/null http://127.0.0.1
+    docker exec --tty "$(cat ${container_id})" env TERM=xterm curl --write-out %{http_code} --silent --output /dev/null http://127.0.0.1
     | grep -q '302'
     && (echo 'HAProxy 302 redirect test: pass' && exit 0)
     || (echo 'HAProxy 302 redirect test: fail' && exit 1)
 
   # Apache (over port 8080) 200 OK test
   - >
-    docker exec -tty "$(cat ${container_id})" env TERM=xterm curl --write-out %{http_code} --silent --output /dev/null http://127.0.0.1:8080
+    docker exec --tty "$(cat ${container_id})" env TERM=xterm curl --write-out %{http_code} --silent --output /dev/null http://127.0.0.1:8080
     | grep -q '200'
     && (echo 'Apache 200 test: pass' && exit 0)
     || (echo 'Apache 200 test: fail' && exit 1)
 
   # Demo Wiki API test
   - >
-    docker exec -tty "$(cat ${container_id})" env TERM=xterm curl --write-out %{http_code} --silent --output /dev/null http://127.0.0.1:8080/demo/api.php
+    docker exec --tty "$(cat ${container_id})" env TERM=xterm curl --write-out %{http_code} --silent --output /dev/null http://127.0.0.1:8080/demo/api.php
     | grep -q '200'
     && (echo 'Demo Wiki API test: pass' && exit 0)
     || (echo 'Demo Wiki API test: fail' && exit 1)

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,14 +36,9 @@ script:
   - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm bash /etc/ansible/roles/role_under_test/scripts/getmeza.sh'
   - 'docker_ip=$(docker inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}" "$(cat ${container_id})")'
 
-  # Make sure ssh installed, enabled, and firewall allows it
-  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm yum install -y openssh-server openssh-clients'
-  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm systemctl enable sshd && systemctl start sshd'
-  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm firewall-cmd --enable --service=ssh'
-
   # - 'echo "IP address = ${docker_ip}"'
   # - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm meza create env local ${docker_ip}'
-  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm meza install monolith "${docker_ip}"'
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm meza install monolith'
 
   # TEST: role.
   # - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # meza
 
-[![Build Status](https://travis-ci.org/enterprisemediawiki/meza.svg?branch=travis)](https://travis-ci.org/SemanticMediaWiki/SemanticMediaWiki)
+[![Build Status](https://travis-ci.org/enterprisemediawiki/meza.svg?branch=travis)](https://travis-ci.org/enterprisemediawiki/meza)
 
 meza configures a CentOS/RedHat server with a complete enterprise MediaWiki installation.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# meza v0.9
+# meza
+
+[![Build Status](https://travis-ci.org/enterprisemediawiki/meza.svg?branch=travis)](https://travis-ci.org/SemanticMediaWiki/SemanticMediaWiki)
 
 meza configures a CentOS/RedHat server with a complete enterprise MediaWiki installation.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # meza
 
-[![Build Status](https://travis-ci.org/enterprisemediawiki/meza.svg?branch=travis)](https://travis-ci.org/enterprisemediawiki/meza)
+[![Build Status](https://travis-ci.org/enterprisemediawiki/meza.svg?branch=dev)](https://travis-ci.org/enterprisemediawiki/meza)
 
 meza configures a CentOS/RedHat server with a complete enterprise MediaWiki installation.
 

--- a/ansible/roles/apache-php/tasks/php.yml
+++ b/ansible/roles/apache-php/tasks/php.yml
@@ -27,6 +27,7 @@
     - sendmail-cf
     - m4
     - xz-libs
+    - mariadb-libs
 - name: Get IUS repository
   include: ius.yml
 - name: Ensure PHP IUS packages installed

--- a/ansible/roles/base/tasks/main.yml
+++ b/ansible/roles/base/tasks/main.yml
@@ -20,6 +20,7 @@
     - net-tools
     - firewalld
     - selinux-policy
+    - rsyslog
 # - name: put SELinux in permissive mode
 #   selinux:
 #     policy: targeted

--- a/ansible/roles/base/tasks/main.yml
+++ b/ansible/roles/base/tasks/main.yml
@@ -8,10 +8,6 @@
   yum: name=epel-release state=installed
 - name: ensure libselinux-python installed prior to SELinux
   yum: name=libselinux-python state=installed
-- name: put SELinux in permissive mode
-  selinux:
-    policy: targeted
-    state: permissive # log actions that would be blocked if state=enforcing
 - name: Install base packages
   yum: name={{item}} state=installed
   with_items:
@@ -23,6 +19,11 @@
     - vim
     - net-tools
     - firewalld
+    - selinux-policy
+- name: put SELinux in permissive mode
+  selinux:
+    policy: targeted
+    state: permissive # log actions that would be blocked if state=enforcing
 - name: ensure firewalld is running (and enable it at boot)
   service: name=firewalld state=started enabled=yes
 

--- a/ansible/roles/base/tasks/main.yml
+++ b/ansible/roles/base/tasks/main.yml
@@ -21,10 +21,10 @@
     - firewalld
     - selinux-policy
     - rsyslog
-# - name: put SELinux in permissive mode
-#   selinux:
-#     policy: targeted
-#     state: permissive # log actions that would be blocked if state=enforcing
+- name: put SELinux in permissive mode
+  selinux:
+    policy: targeted
+    state: permissive # log actions that would be blocked if state=enforcing
 - name: ensure firewalld is running (and enable it at boot)
   service: name=firewalld state=started enabled=yes
 

--- a/ansible/roles/base/tasks/main.yml
+++ b/ansible/roles/base/tasks/main.yml
@@ -20,10 +20,10 @@
     - net-tools
     - firewalld
     - selinux-policy
-- name: put SELinux in permissive mode
-  selinux:
-    policy: targeted
-    state: permissive # log actions that would be blocked if state=enforcing
+# - name: put SELinux in permissive mode
+#   selinux:
+#     policy: targeted
+#     state: permissive # log actions that would be blocked if state=enforcing
 - name: ensure firewalld is running (and enable it at boot)
   service: name=firewalld state=started enabled=yes
 

--- a/ansible/roles/elasticsearch/tasks/main.yml
+++ b/ansible/roles/elasticsearch/tasks/main.yml
@@ -29,15 +29,26 @@
     name: elasticsearch
     state: installed
 
-# SETUP DIRECTORIES AND FILES
+# Need to perform this check so `lineinfile` doesn't run in Docker. /etc/hosts
+# is special in Docker.
+# ref: https://docs.docker.com/engine/userguide/networking/default_network/dockerlinks/#updating-the-etchosts-file
+# ref: http://stackoverflow.com/questions/28327458/how-to-add-my-containers-hostname-to-etc-hosts
+- name: Check whether /etc/hosts contains "127.0.0.1"
+  command: awk /^127.0.0.1$/ /etc/hosts
+  register: checkhostsfile
+  changed_when: False
+
 # Add host name per https://github.com/elastic/elasticsearch/issues/6611
-- lineinfile:
+- name: Add localhost to /etc/hosts if needed
+  lineinfile:
     dest: /etc/hosts
     regexp: '^127\.0\.0\.1'
     line: '127.0.0.1 localhost meza'
     owner: root
     group: root
     mode: 0644
+  when: '"127.0.0.1" not in checkhostsfile.stdout'
+
 # ref: http://elasticsearch-users.115913.n3.nabble.com/Elasticsearch-Not-Working-td4059398.html
 - name: Ensure dirs from elasticsearch.yml exist and set ownership
   file:

--- a/ansible/roles/elasticsearch/tasks/main.yml
+++ b/ansible/roles/elasticsearch/tasks/main.yml
@@ -34,7 +34,7 @@
 # ref: https://docs.docker.com/engine/userguide/networking/default_network/dockerlinks/#updating-the-etchosts-file
 # ref: http://stackoverflow.com/questions/28327458/how-to-add-my-containers-hostname-to-etc-hosts
 - name: Check whether /etc/hosts contains "127.0.0.1"
-  command: awk /^127.0.0.1$/ /etc/hosts
+  command: awk /127.0.0.1/ /etc/hosts
   register: checkhostsfile
   changed_when: False
 

--- a/ansible/roles/haproxy/tasks/main.yml
+++ b/ansible/roles/haproxy/tasks/main.yml
@@ -10,6 +10,7 @@
   yum: name={{item}} state=installed
   with_items:
     - haproxy
+    - openssl
     # - keepalived ?
 
 # Generate self-signed cert if one doesn't exist (note: trusting an article

--- a/scripts/getmeza.sh
+++ b/scripts/getmeza.sh
@@ -12,19 +12,34 @@ fi
 yum install -y epel-release
 yum install -y git ansible
 
-# Get meza
-cd /opt
-git clone https://github.com/enterprisemediawiki/meza.git
+if [ ! -d "/opt/meza" ]; then
 
-# For now, use the dev branch
-cd /opt/meza
-git checkout dev
+	# Get meza
+	cd /opt
+	git clone https://github.com/enterprisemediawiki/meza.git
 
-ln -s "/opt/meza/scripts/meza.sh" "/usr/bin/meza"
+	# For now, use the dev branch
+	cd /opt/meza
+	git checkout dev
 
-echo
-echo "Add ansible master user"
-source "/opt/meza/scripts/ssh-users/setup-master-user.sh"
+fi
+
+if [ ! -f "/usr/bin/meza" ]; then
+	ln -s "/opt/meza/scripts/meza.sh" "/usr/bin/meza"
+fi
+
+ret=false
+getent passwd $1 >/dev/null 2>&1 && ret=true
+
+if $ret; then
+    echo "meza-ansible already exists"
+else
+	echo
+	echo "Add ansible master user"
+	source "/opt/meza/scripts/ssh-users/setup-master-user.sh"
+fi
+
+
 
 echo "meza command installed. Use it:"
 echo "  sudo meza install monolith"

--- a/scripts/getmeza.sh
+++ b/scripts/getmeza.sh
@@ -29,7 +29,7 @@ if [ ! -f "/usr/bin/meza" ]; then
 fi
 
 ret=false
-getent passwd $1 >/dev/null 2>&1 && ret=true
+getent passwd meza-ansible >/dev/null 2>&1 && ret=true
 
 if $ret; then
     echo "meza-ansible already exists"

--- a/scripts/getmeza.sh
+++ b/scripts/getmeza.sh
@@ -25,7 +25,7 @@ ret=false
 getent passwd meza-ansible >/dev/null 2>&1 && ret=true
 
 if $ret; then
-    echo "meza-ansible already exists"
+	echo "meza-ansible already exists"
 else
 	echo
 	echo "Add ansible master user"

--- a/scripts/getmeza.sh
+++ b/scripts/getmeza.sh
@@ -12,16 +12,9 @@ fi
 yum install -y epel-release
 yum install -y git ansible
 
+# if /opt/meza doesn't exist, clone into and switch to dev branch (for now)
 if [ ! -d "/opt/meza" ]; then
-
-	# Get meza
-	cd /opt
-	git clone https://github.com/enterprisemediawiki/meza.git
-
-	# For now, use the dev branch
-	cd /opt/meza
-	git checkout dev
-
+	git clone https://github.com/enterprisemediawiki/meza.git /opt/meza --branch dev
 fi
 
 if [ ! -f "/usr/bin/meza" ]; then

--- a/scripts/meza.sh
+++ b/scripts/meza.sh
@@ -175,7 +175,7 @@ case "$1" in
 
 				fi
 
-				meza deploy monolith
+				meza deploy monolith ${@:3}
 
 				exit 0;
 				;;


### PR DESCRIPTION
Start running tests on TravisCI. 

### Testing

On a VM with a clean CentOS 7 min install:

- [x] `sudo ifup enp0s3`
- [x] `curl -L getmeza.org > doit`
- [x] `sudo bash doit`
- [x] `cd /opt/meza && sudo git checkout travis`
- [x] `sudo meza install dev-networking`
- [x] `sudo meza install monolith`
- [x] Perform standard tests from [CONTRIBUTING.md](https://github.com/enterprisemediawiki/meza/blob/master/CONTRIBUTING.md)

### Changes

* Show "build status" badge on main README. Note, this looks at the build status of the `dev` branch for now, since this won't likely be merged into `master` soon. That will need to be fixed when it is merged into `master`. Created issue TBD to track.
* Added package `mariadb-libs` to app-server installations. This package comes with CentOS 7 min install, so it is not required for most installations, but it does not come with the Docker image being used in TravisCI. This package is a dependency for some portion of PHP, which `yum` will detect and attempt to fulfill if not explicitly called out, so in theory it shouldn't be required. However, due to the fact that we're using the IUS repository for PHP 5.6 (e.g. using packages like `php` and `php-mysqlnd` we get `php56u` and `php56u-mysqlnd`) instead of yum trying to get `mariadb-libs` it tries to get `mariadb101u-libs`. This causes errors.
* In `base` role, moved "put SELinux in permissive mode" after yum-installs, and explicitly installed `selinux-policy`. Again, this Docker image didn't come with it.
* In `base` role, explicitly installed rsyslog. Again, Docker.
* In `elasticsearch` role, perform explicit check for `127.0.0.1` in `/etc/hosts` using `awk` command prior to using Ansible's `lineinfile` module. `lineinfile` edits the file, and Docker is very protective of `/etc/hosts`. Ref [1] and [2].
* In `haproxy` role, explicitly install `openssl` in order to generate self-signed certs (and probably other reasons, but that was the first error). Reason needed: Docker.
* Make `getmeza.sh` idempotent: Only clone if it's not there, only setup `/usr/bin/meza` symlink if not present, only create `meza-ansible` user if not present.
* Within `meza install monolith` pass along additional args to `meza deploy monolith` so you can change verbosity (e.g. `-vvvv`) or filter with tags (`--tags "mediawiki"`).

### References

[1] https://docs.docker.com/engine/userguide/networking/default_network/dockerlinks/#updating-the-etchosts-file
[2] http://stackoverflow.com/questions/28327458/how-to-add-my-containers-hostname-to-etc-hosts
