### PR TITLE
Add create-backup functionality, integrate with `meza deploy`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ config/local_app
 # have been explicitly added to the repo.
 data/*
 
+# backups directory
+backups/*
 
 # ignore wiki blender landing page
 htdocs/WikiBlender

--- a/ansible/backup.yml
+++ b/ansible/backup.yml
@@ -1,0 +1,48 @@
+---
+# FIXME: remove all this planning doc stuff
+#
+# Thinking this could be used like:
+#   $ meza backup prod && meza deploy stage --source=prod --force --clean
+#     1. Backup to production
+#     2. Deploy "stage" environment
+#        1. Source from production backup
+#        2. --force --> remove existing database/uploads and overwrite
+#        3. --clean --> remove /uploads rather than just rsyncing on top of them
+#
+# Consider supporting method like this
+#   [backups]
+#   192.168.56.90
+#   192.168.56.100 backup_wikis=['eva','robo','oso']
+#
+# Consider supporting alternate backups like:
+#   - backup-db-all
+#   - backup-db-all-incremental
+#
+
+# Define a timestamp fact to persist throughout this playbook
+- hosts: all
+  tasks:
+    - set_fact:
+        backup_timestamp: "{{lookup('pipe','date +%Y%m%d%H%M%S')}}"
+
+
+# FIXME: If a slave is available, should pull from there
+- hosts: db-master
+  become: yes
+  vars_files:
+    - ["paths.yml","/opt/meza/config/local_control/deploy-config.yml"]
+
+  roles:
+    - dump-db-wikis
+
+
+- hosts: backup-servers
+  become: yes
+  vars_files:
+    - ["paths.yml","/opt/meza/config/local_control/deploy-config.yml"]
+  roles:
+    - backup-db-wikis
+    - backup-uploads
+    # FIXME: add role to specify current configuration state, such that it's
+    #        possible to redeploy entirely from backup.
+    # - backup-config-state

--- a/ansible/paths.yml
+++ b/ansible/paths.yml
@@ -19,6 +19,22 @@ m_test: /opt/meza/test"
 # data dir
 m_meza_data: /opt/meza/data
 
+# uploads dir. This currently also keeps config info sort of, in
+# /opt/meza/htdocs/wikis/{{ wiki_id }}/config [1], and uploads in
+# /opt/meza/htdocs/wikis/{{ wiki_id }}/images [2]. Ultimately [2] should be
+# moved to something like /opt/meza/data/uploads/{{ wiki_id }} (no specific
+# dir inside each wiki's dir for uploads). In order to support app-server-based
+# uploads and GlusterFS-based uploads (or other alternatives) it may be
+# necessary to be able to specify this path, with options like:
+#   - /opt/meza/data/uploads    (app-server based)
+#   - /opt/meza/data/glusterfs  (GlusterFS based)
+#   - /opt/meza/data/other-alts (something really cool that I don't even know about)
+m_uploads_dir: /opt/meza/htdocs/wikis
+
+# Location where backups will go, specified by environment, e.g.
+# /opt/meza/backups/prod for "prod" environment
+m_backups: /opt/meza/backups
+
 # webserver variables
 m_htdocs: /opt/meza/htdocs
 m_mediawiki: /opt/meza/htdocs/mediawiki

--- a/ansible/paths.yml
+++ b/ansible/paths.yml
@@ -19,17 +19,13 @@ m_test: /opt/meza/test"
 # data dir
 m_meza_data: /opt/meza/data
 
-# uploads dir. This currently also keeps config info sort of, in
-# /opt/meza/htdocs/wikis/{{ wiki_id }}/config [1], and uploads in
-# /opt/meza/htdocs/wikis/{{ wiki_id }}/images [2]. Ultimately [2] should be
-# moved to something like /opt/meza/data/uploads/{{ wiki_id }} (no specific
-# dir inside each wiki's dir for uploads). In order to support app-server-based
-# uploads and GlusterFS-based uploads (or other alternatives) it may be
-# necessary to be able to specify this path, with options like:
+# uploads dir. In order to support both app-server-based uploads and
+# GlusterFS-based uploads (or other alternatives) it may be necessary to be
+# able to specify this path, with options like:
 #   - /opt/meza/data/uploads    (app-server based)
 #   - /opt/meza/data/glusterfs  (GlusterFS based)
-#   - /opt/meza/data/other-alts (something really cool that I don't even know about)
-m_uploads_dir: /opt/meza/htdocs/wikis
+#   - /opt/meza/data/other (something really cool that I don't even know about)
+m_uploads_dir: /opt/meza/data/uploads
 
 # Location where backups will go, specified by environment, e.g.
 # /opt/meza/backups/prod for "prod" environment

--- a/ansible/roles/backup-db-wikis/tasks/main.yml
+++ b/ansible/roles/backup-db-wikis/tasks/main.yml
@@ -1,0 +1,46 @@
+---
+
+
+- name: Get individual wikis from controller config
+  find:
+    paths: "{{ m_local_control }}/wikis/"
+    file_type: directory
+  register: wiki_dirs
+  delegate_to: localhost
+
+- name: Ensure backups directory exists for environment
+  file:
+    path: "{{ m_backups }}/{{ env }}"
+    state: directory
+    mode: 0755
+    owner: root
+    group: root
+
+- name: Ensure backups directory exists for each wiki
+  file:
+    path: "{{ m_backups }}/{{ env }}/{{ item }}"
+    state: directory
+    mode: 0755
+    owner: root
+    group: root
+  with_items: "{{ wiki_dirs.files | map(attribute='path') | map('basename') | list }}"
+
+# copy from server A (db-master) to server B (backups)
+- name: Copy SQL files to backups
+  synchronize:
+    # copy from server A
+    src: "/tmp/{{ env }}_{{ item }}.sql"
+    # copy to server B
+    dest: "{{ m_backups }}/{{ env }}/{{ item }}/{{ backup_timestamp }}_wiki.sql"
+  # server A
+  delegate_to: "{{ groups['db-master'][0] }}"
+  with_items: "{{ wiki_dirs.files | map(attribute='path') | map('basename') | list }}"
+
+# Remove temp SQL files, only needs to be done on first backup server
+- name: Remove SQL files from DB master /tmp
+  file:
+    path: "/tmp/{{ env }}_{{ item }}.sql"
+    state: absent
+  delegate_to: "{{ groups['db-master'][0] }}"
+  with_items: "{{ wiki_dirs.files | map(attribute='path') | map('basename') | list }}"
+  run_once: true

--- a/ansible/roles/backup-uploads/tasks/main.yml
+++ b/ansible/roles/backup-uploads/tasks/main.yml
@@ -1,0 +1,51 @@
+---
+
+
+- name: Get individual wikis from controller config
+  find:
+    paths: "{{ m_local_control }}/wikis/"
+    file_type: directory
+  register: wiki_dirs
+  delegate_to: localhost
+
+# FIXME: option to wipe files clean before sync? If so, do it before pulling SQL file
+
+- name: Ensure backups directory exists for environment
+  file:
+    path: "{{ m_backups }}/{{ env }}"
+    state: directory
+    mode: 0755
+    owner: root
+    group: root
+
+- name: Ensure backups directory exists for each wiki
+  file:
+    path: "{{ m_backups }}/{{ env }}/{{ item }}"
+    state: directory
+    mode: 0755
+    owner: root
+    group: root
+  with_items: "{{ wiki_dirs.files | map(attribute='path') | map('basename') | list }}"
+
+- name: Ensure backups uploads directory exists for each wiki
+  file:
+    path: "{{ m_backups }}/{{ env }}/{{ item }}/uploads"
+    state: directory
+    mode: 0755
+    owner: root
+    group: root
+  with_items: "{{ wiki_dirs.files | map(attribute='path') | map('basename') | list }}"
+
+# copy from server A (app.0) to server B (backups)
+- name: Copy uploads directories to backups
+  synchronize:
+    # copy from server A
+    src: "{{ m_uploads_dir }}/{{ item }}/"
+    # copy to server B
+    dest: "{{ m_backups }}/{{ env }}/{{ item }}/uploads"
+    recursive: yes
+  # server A
+  delegate_to: "{{ groups['app-servers'][0] }}"
+  with_items: "{{ wiki_dirs.files | map(attribute='path') | map('basename') | list }}"
+
+

--- a/ansible/roles/dump-db-wikis/tasks/main.yml
+++ b/ansible/roles/dump-db-wikis/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+- name: Get individual wikis from controller config
+  find:
+    paths: "{{ m_local_control }}/wikis/"
+    file_type: directory
+  register: wiki_dirs
+  delegate_to: localhost
+
+# FIXME: should maybe lock DB first
+# - name: Set wiki read-only
+# - name: Lock DB
+
+- name: Remove any existing database dumps
+  file:
+    path: "/tmp/{{ env }}_{{ item }}.sql"
+    state: absent
+  # see role "mediawiki" for explanation of filters below
+  with_items: "{{ wiki_dirs.files | map(attribute='path') | map('basename') | list }}"
+
+- name: Dump wiki databases
+  mysql_db:
+    state: dump
+    name: "wiki_{{ item }}"
+    target: "/tmp/{{ env }}_{{ item }}.sql"
+  with_items: "{{ wiki_dirs.files | map(attribute='path') | map('basename') | list }}"

--- a/ansible/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/ansible/roles/mediawiki/templates/LocalSettings.php.j2
@@ -181,7 +181,7 @@ $wgScriptPath = "/$wikiId";
 $wgUploadPath = "$wgScriptPath/img_auth.php";
 
 // https://www.mediawiki.org/wiki/Manual:$wgUploadDirectory
-$wgUploadDirectory = "$m_htdocs/wikis/$wikiId/images";
+$wgUploadDirectory = "$m_meza/data/uploads/$wikiId";
 
 // https://www.mediawiki.org/wiki/Manual:$wgLogo
 $wgLogo = "/wikis/$wikiId/config/logo.png";

--- a/ansible/roles/update.php/tasks/main.yml
+++ b/ansible/roles/update.php/tasks/main.yml
@@ -1,12 +1,13 @@
 ---
 
-# Tell database master to update all databases
+- debug: { msg: "Running role:update.php for {{ wiki_id }}" }
+
 # FIXME: This shouldn't go to /tmp. Also it should be pushed to a backup server
 #        and maybe we should use incremental backups (patches) to limit size.
-- name: Backup all databases prior to running update.php
+- name: Backup wiki database prior to running update.php
   mysql_db:
     state: dump
-    name: all
+    name: "wiki_{{ wiki_id }}"
     target: "/tmp/backup_{{ wiki_id }}_{{ ansible_date_time.iso8601 }}.sql"
   delegate_to: "{{ groups['db-master'][0] }}"
 
@@ -14,7 +15,7 @@
   #     but just in case we'll add it here, too. Apply to all tasks
   run_once: true
 
-- name: Run update.php on all wikis
+- name: Run update.php on this wiki
   shell: >
     WIKI="{{ wiki_id }}" php "/opt/meza/htdocs/mediawiki/maintenance/update.php" --quick
   # run_once see [1]

--- a/ansible/roles/verify-wiki/tasks/main.yml
+++ b/ansible/roles/verify-wiki/tasks/main.yml
@@ -39,7 +39,7 @@
     path: "{{ m_backups }}/{{ env }}/{{ wiki_id }}"
   register: backups_dir
   when: wiki_exists is defined and wiki_exists.rc == 1
-  delegate_to: localhost
+  delegate_to: "{{ groups['backup-servers'][0] }}"
 
 
 # This will find the latest sql file by name, or wiki.sql over any timestamped one
@@ -47,16 +47,46 @@
 - name: Find SQL file if it exists
   shell: 'find {{ m_backups }}/{{ env }}/{{ wiki_id }} -maxdepth 1 -type f -iname "*.sql" | sort -r | head -n +1'
   register: wiki_sql_file
-  delegate_to: localhost
+  delegate_to: "{{ groups['backup-servers'][0] }}"
   run_once: true
   when:
     wiki_exists is defined
     and wiki_exists.rc == 1
     and backups_dir.stat.exists == true
 
-- name: If wiki_sql_file defined, send file to master db
-  copy:
+
+  #
+  # Since backup-servers[0], master-db[0] and controller (localhost) are three
+  # different servers, and the current Ansible play is being run against app-
+  # servers, there's no way to send from backup-servers[0] to master-db[0]
+  # directly. Instead, pass to controller, then form controller to master-db
+  #
+- name: if wiki_sql_file defined, FIRST remove preexisting SQL file from controller
+  file:
+    path: /tmp/controller-wiki.sql
+    state: absent
+  run_once: true
+  delegate_to: localhost
+  when:
+    wiki_sql_file is defined
+    and wiki_sql_file.rc == 0
+- name: if wiki_sql_file defined, NEXT send SQL file to controller
+  fetch:
     src: "{{ wiki_sql_file.stdout }}"
+    dest: /tmp/controller-wiki.sql
+    fail_on_missing: yes
+    flat: yes
+  # note: don't run fetch with become on large files. ref bottom of this page:
+  # http://docs.ansible.com/ansible/fetch_module.html
+  become: no
+  run_once: true
+  delegate_to: "{{ groups['backup-servers'][0] }}"
+  when:
+    wiki_sql_file is defined
+    and wiki_sql_file.rc == 0
+- name: if wiki_sql_file defined, NEXT send file from controller to master-db
+  copy:
+    src: /tmp/controller-wiki.sql
     dest: /tmp/wiki.sql
     force: yes
   run_once: true
@@ -64,6 +94,8 @@
   when:
     wiki_sql_file is defined
     and wiki_sql_file.rc == 0
+
+
 
 - name: If wiki_sql_file NOT defined, send generic file to master db
   copy:

--- a/ansible/roles/verify-wiki/tasks/main.yml
+++ b/ansible/roles/verify-wiki/tasks/main.yml
@@ -36,7 +36,7 @@
 
 - name: Check if backups dir exists
   stat:
-    path: "/opt/meza/backups/{{ wiki_id }}"
+    path: "{{ m_backups }}/{{ env }}/{{ wiki_id }}"
   register: backups_dir
   when: wiki_exists is defined and wiki_exists.rc == 1
   delegate_to: localhost
@@ -45,7 +45,7 @@
 # This will find the latest sql file by name, or wiki.sql over any timestamped one
 # assuming timestamp-named files like 20170220000002_wiki.sql
 - name: Find SQL file if it exists
-  shell: 'find /opt/meza/backups/{{ wiki_id }} -maxdepth 1 -type f -iname "*.sql" | sort -r | head -n +1'
+  shell: 'find {{ m_backups }}/{{ env }}/{{ wiki_id }} -maxdepth 1 -type f -iname "*.sql" | sort -r | head -n +1'
   register: wiki_sql_file
   delegate_to: localhost
   run_once: true
@@ -85,9 +85,19 @@
   delegate_to: "{{ groups['db-master'][0] }}"
   when: wiki_exists is defined and wiki_exists.rc == 1
 
+- name: Remove SQL file from master DB
+  file:
+    path: /tmp/wiki.sql
+    state: absent
+  run_once: true
+  delegate_to: "{{ groups['db-master'][0] }}"
+  when: wiki_exists is defined and wiki_exists.rc == 1
+
 
 #
-# Make sure wiki's htdocs directory in place
+# Make sure wiki's htdocs directory in place, and symlink to config. Symlink
+# required so logo and favicon accessible via HTTP. Consider creating other
+# method to allow HTTP access to these files (HAProxy rule? httpd rule? PHP?)
 #
 - name: Ensure wiki htdocs directory in place
   file:
@@ -96,13 +106,6 @@
     owner: apache
     group: apache
     mode: 0755
-
-
-
-
-#
-# Make sure wiki's config directory is properly symlinked
-#
 - name: Ensure wiki config symlink in place
   file:
     # dest = symlink, src = dir linked to
@@ -116,35 +119,35 @@
 
 
 #
-# Make sure wiki's images directory is properly setup
+# Make sure wiki's uploads directory is properly setup
 #
-- name: Check if wiki's images dir exists ON APP SERVER
+- name: Check if wiki's uploads dir exists ON APP SERVER
   stat:
-    path: "{{ m_htdocs }}/wikis/{{ wiki_id }}/images"
-  register: images_dir
+    path: "{{ m_uploads_dir }}/{{ wiki_id }}"
+  register: uploads_dir
 
-- name: Check if wiki's images backup dir exists ON CONTROLLER
+- name: Check if wiki's uploads backup dir exists ON CONTROLLER
   stat:
-    path: "/opt/meza/backups/{{ wiki_id }}/images"
+    path: "{{ m_backups }}/{{ env }}/{{ wiki_id }}/uploads"
   register: images_backup_dir
   delegate_to: localhost
 
 
-- name: If no images dir, but there is a backup dir
+- name: If no uploads dir, but there is a backup dir
   copy:
-    src: "/opt/meza/backups/{{ wiki_id }}/images"
-    dest: "{{ m_htdocs }}/wikis/{{ wiki_id }}/images"
+    src: "{{ m_backups }}/{{ env }}/{{ wiki_id }}/uploads/"
+    dest: "{{ m_uploads_dir }}/{{ wiki_id }}"
     mode: 0755
     owner: apache
     group: apache
   when:
-    not images_dir.stat.exists
+    not uploads_dir.stat.exists
     and images_backup_dir.stat.exists
 
-# Either way (existing backup or no) make sure images dir is configured
-- name: Ensure wiki's images dir is configured
+# Either way (existing backup or no) make sure uploads dir is configured
+- name: Ensure wiki's uploads dir is configured
   file:
-    path: "{{ m_htdocs }}/wikis/{{ wiki_id }}/images"
+    path: "{{ m_uploads_dir }}/{{ wiki_id }}"
     state: directory
     mode: 0755
     owner: apache

--- a/ansible/template-env/blank/hosts
+++ b/ansible/template-env/blank/hosts
@@ -29,3 +29,6 @@ localhost ansible_connection=local
 
 [elastic-servers]
 # INSERT_ES
+
+[backup-servers]
+# INSERT_BACKUP

--- a/scripts/meza.sh
+++ b/scripts/meza.sh
@@ -416,7 +416,14 @@ case "$1" in
 		check_environment "$environment"
 		host_file="/opt/meza/ansible/env/$environment/hosts"
 
+		# Get errors with user meza-ansible trying to write to the calling-user's
+		# home directory if don't cd to a neutral location. FIXME.
+		starting_wd=`pwd`
+		cd /opt/meza/config
 		sudo -u meza-ansible ansible-playbook "/opt/meza/ansible/backup.yml" -i "$host_file" --extra-vars "env=$environment" ${@:3}
+		cd "$starting_wd"
+		exit 0;
+
 		;;
 
 	destroy)

--- a/scripts/meza.sh
+++ b/scripts/meza.sh
@@ -245,7 +245,7 @@ case "$1" in
 		starting_wd=`pwd`
 		cd /opt/meza/config
 
-		sudo -u meza-ansible ansible-playbook /opt/meza/ansible/site.yml -i "$host_file" ${@:3}
+		sudo -u meza-ansible ansible-playbook /opt/meza/ansible/site.yml -i "$host_file" --extra-vars "env=$2" ${@:3}
 
 		cd "$starting_wd"
 		exit $?;
@@ -322,13 +322,13 @@ case "$1" in
 					# NOTE: "INSERT_SLAVE" not in monolith list, so as not to
 					#       configure the monolith as DB master _and_ slave
 					if [ "$3" = "monolith" ]; then
-						for part in INSERT_LB INSERT_APP INSERT_MEM INSERT_MASTER INSERT_PARSOID INSERT_ES; do
+						for part in INSERT_LB INSERT_APP INSERT_MEM INSERT_MASTER INSERT_PARSOID INSERT_ES INSERT_BACKUP; do
 							sed -r -i "s/# $part/localhost/g;" "$m_meza/ansible/env/$3/hosts"
 						done
 					else
 
 						# If any of these variables are defined, put them into inventory file
-						for INVENTORY_VARNAME in INSERT_LB INSERT_APP INSERT_MEM INSERT_MASTER INSERT_SLAVE INSERT_PARSOID INSERT_ES; do
+						for INVENTORY_VARNAME in INSERT_LB INSERT_APP INSERT_MEM INSERT_MASTER INSERT_SLAVE INSERT_PARSOID INSERT_ES INSERT_BACKUP; do
 
 							# Make INVENTORY_VALUE be the value of a variable with the name in INVENTORY_VARNAME
 							# printf -v "${INVENTORY_VARNAME}" '%s' "${INVENTORY_VARNAME}"
@@ -385,10 +385,10 @@ case "$1" in
 					if [ -z "$4" ]; then echo "Please specify a wiki ID"; exit 1; fi
 					if [ -z "$5" ]; then echo "Please specify a wiki name"; exit 1; fi
 					playbook="create-wiki-promptless.yml"
-					sudo -u meza-ansible ansible-playbook "/opt/meza/ansible/$playbook" -i "$host_file" --extra-vars  "wiki_id=$4 wiki_name='$5'" ${@:6}
+					sudo -u meza-ansible ansible-playbook "/opt/meza/ansible/$playbook" -i "$host_file" --extra-vars "env=$environment wiki_id=$4 wiki_name='$5'" ${@:6}
 				else
 					playbook="create-wiki.yml"
-					sudo -u meza-ansible ansible-playbook "/opt/meza/ansible/$playbook" -i "$host_file" ${@:4}
+					sudo -u meza-ansible ansible-playbook "/opt/meza/ansible/$playbook" -i "$host_file" --extra-vars "env=$environment" ${@:4}
 				fi
 
 				cd "$starting_wd"
@@ -401,6 +401,22 @@ case "$1" in
 				exit 1;
 				;;
 		esac
+		;;
+
+	backup)
+
+		if [ ! -z "$2" ]; then
+			environment="$2"
+		else
+			echo
+			echo "You must specify an environment: 'meza backup ENV'"
+			exit 1;
+		fi
+
+		check_environment "$environment"
+		host_file="/opt/meza/ansible/env/$environment/hosts"
+
+		sudo -u meza-ansible ansible-playbook "/opt/meza/ansible/backup.yml" -i "$host_file" --extra-vars "env=$environment" ${@:3}
 		;;
 
 	destroy)

--- a/test/travis/run-tests.sh
+++ b/test/travis/run-tests.sh
@@ -133,7 +133,10 @@ if [ "$test_type" == "monolith_from_scratch" ]; then
 	${docker_exec[@]} meza backup monolith
 
 	${docker_exec[@]} ls /opt/meza/backups/monolith/demo
-	${docker_exec[@]} ls /opt/meza/backups/monolith/demo/*_wiki.sql
+
+	# find any files matching *_wiki.sql in demo backups. egrep command will
+	# exit-0 if something found, exit-1 (fail) if nothing found.
+	${docker_exec[@]} find /opt/meza/backups/monolith/demo -name "*_wiki.sql" | egrep '.*'
 
 elif [ "$test_type" == "monolith_from_import" ]; then
 

--- a/test/travis/run-tests.sh
+++ b/test/travis/run-tests.sh
@@ -152,9 +152,6 @@ elif [ "$test_type" == "monolith_from_import" ]; then
 	# config setting we can't know ahead of time)
 	${docker_exec[@]} sed -r -i "s/INSERT_FQDN/$docker_ip/g;" "/opt/meza/ansible/env/imported/group_vars/all.yml"
 
-	# Get test non-secret config
-	${docker_exec[@]} git clone https://github.com/enterprisemediawiki/meza-test-config.git /opt/meza/config/local_control
-
 	# FIXME: get backup files for test
 
 	# Deploy "imported" environment with test config

--- a/test/travis/run-tests.sh
+++ b/test/travis/run-tests.sh
@@ -130,6 +130,11 @@ if [ "$test_type" == "monolith_from_scratch" ]; then
 	wiki_name="Created Wiki"
 	wiki_check
 
+	${docker_exec[@]} meza backup monolith
+
+	${docker_exec[@]} ls /opt/meza/backups/monolith/demo
+	${docker_exec[@]} ls /opt/meza/backups/monolith/demo/*_wiki.sql
+
 elif [ "$test_type" == "monolith_from_import" ]; then
 
 	echo "TEST TYPE = monolith_from_import"


### PR DESCRIPTION
Now can do `sudo meza backup <environment>`. And then when another environment does `sudo meza deploy <another environment>` it can pull from that backup.

* Moves images/uploads from `$m_htdocs/wikis/$wikiId/images` to `$m_meza/data/uploads/$wikiId`
* Backups sent to and pulled from `/opt/meza/backups/{{ wiki_id }}`
* Added tests to `run-tests.sh` to have backup database/uploads, then uses API to find an image from that backup, and verify it is present (was imported correctly).
