### PR TITLE
Commands for setting up docker (on CentOS) and executing commands on container

### DIFF
--- a/ansible/getdocker.yml
+++ b/ansible/getdocker.yml
@@ -1,0 +1,70 @@
+---
+# Setup docker-engine on CentOS 7
+#
+# ref: https://docs.docker.com/engine/installation/linux/centos/
+
+- hosts: localhost
+  become: yes
+
+  handlers:
+    - name: Restart Docker
+      service:
+        name: docker
+        state: restarted
+
+  tasks:
+    - name: Ensure CentOS-provided Docker repos are removed
+      yum:
+        name: "{{ item }}"
+        state: absent
+      with_items:
+        - docker
+        - docker-common
+        - container-selinux
+        - docker-selinux
+        - docker-engine
+
+    - name: Ensure yum-utils present
+      yum:
+        name: yum-utils
+        state: present
+
+    - name: Get docker-ce repo
+      shell: yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+
+    # - name: Add docker repo
+    #   yum_repository:
+    #     name: docker-ce
+    #     description: Docker repository
+    #     baseurl: https://download.docker.com/linux/centos/docker-ce.repo
+    #     gpgkey: https://download.docker.com/linux/centos/gpg
+    #     gpgcheck: yes
+
+
+    - name: yum makecache fast
+      shell: yum makecache fast
+
+    # or specify docker-ce-{{ docker_version }}
+    - name: Ensure docker-ce package installed
+      yum:
+        name: "docker-ce"
+        state: latest
+      notify: Restart Docker
+
+    - name: Ensure Docker is running (and enable it at boot)
+      service:
+        name: docker
+        state: started
+        enabled: yes
+
+
+# http://docs.ansible.com/ansible/docker_module.html
+
+# sudo git clone meza
+# cd meza
+# docker build -t meza-docker .
+
+    - name: Test docker
+      shell: docker run hello-world
+
+

--- a/ansible/getdocker.yml
+++ b/ansible/getdocker.yml
@@ -58,13 +58,13 @@
         enabled: yes
 
 
-# http://docs.ansible.com/ansible/docker_module.html
+    # http://docs.ansible.com/ansible/docker_module.html
 
-# sudo git clone meza
-# cd meza
-# docker build -t meza-docker .
+    # sudo git clone meza
+    # cd meza
+    # docker build -t meza-docker .
 
-    - name: Test docker
-      shell: docker run hello-world
+    # - name: Test docker
+    #   shell: docker run hello-world
 
 

--- a/manual/meza-cmd/docker.txt
+++ b/manual/meza-cmd/docker.txt
@@ -1,0 +1,7 @@
+Mediawiki EZ Admin
+
+Usage: meza docker [directives]
+
+List of directives:
+
+run   run a particular docker image and install meza

--- a/scripts/build-docker-container.sh
+++ b/scripts/build-docker-container.sh
@@ -4,8 +4,14 @@
 
 docker_repo="$1"
 
-echo "pulling image $docker_repo"
-docker pull ${docker_repo}
+if [[ "$(docker images -q $docker_repo 2> /dev/null)" == "" ]]; then
+	echo "pulling image $docker_repo"
+	docker pull ${docker_repo}
+fi
+
+
+init=/usr/lib/systemd/systemd
+run_opts="--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
 
 
 container_id=$(mktemp)
@@ -22,6 +28,8 @@ docker_exec=( docker exec --tty "$container_id" env TERM=xterm )
 curl_args=( curl --write-out %{http_code} --silent --output /dev/null )
 
 ${docker_exec[@]} bash /opt/meza/scripts/getmeza.sh
+
+${docker_exec[@]} mv /opt/mediawiki /opt/meza/htdocs/mediawiki || true
 
 # Get IP of docker image
 docker_ip=$(docker inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}" "$container_id")

--- a/scripts/meza.sh
+++ b/scripts/meza.sh
@@ -584,12 +584,29 @@ case "$1" in
 		case "$2" in
 			"run")
 				if [ -z "$3" ]; then
-					docker_repo="jamesmontalvo3/jamesmontalvo3/meza-docker-test-max:latest"
+					docker_repo="jamesmontalvo3/meza-docker-test-max:latest"
 				else
 					docker_repo="$3"
 				fi
 				bash /opt/meza/scripts/build-docker-container.sh "$docker_repo"
 				exit 0;
+				;;
+			"exec")
+				if [ -z "$3" ]; then
+					echo "Please provide docker container id"
+					docker ps
+					exit 1;
+				else
+					container_id="$3"
+				fi
+
+				if [ -z "$4" ]; then
+					echo "Please supply a command for your container"
+					exit 1;
+				fi
+
+				docker_exec=( docker exec --tty "$container_id" env TERM=xterm )
+				${docker_exec[@]} ${@:4}
 				;;
 			*)
 				echo "$2 not a valid command"

--- a/scripts/meza.sh
+++ b/scripts/meza.sh
@@ -348,6 +348,10 @@ case "$1" in
 			"dev")
 				/opt/meza/scripts/setup-dev.sh
 				;;
+			"docker")
+				# Local playbook only, doesn't need to be run by meza-ansible user
+				ansible-playbook /opt/meza/ansible/getdocker.yml
+				;;
 			*)
 				echo "NOT A VALID SETUP COMMAND"
 				exit 1;
@@ -574,6 +578,24 @@ case "$1" in
 	import)
 		echo "This function not created yet"
 		exit 1;
+		;;
+
+	docker)
+		case "$2" in
+			"run")
+				if [ -z "$3" ]; then
+					docker_repo="jamesmontalvo3/jamesmontalvo3/meza-docker-test-max:latest"
+				else
+					docker_repo="$3"
+				fi
+				bash /opt/meza/scripts/build-docker-container.sh "$docker_repo"
+				exit 0;
+				;;
+			*)
+				echo "$2 not a valid command"
+				exit 1;
+				;;
+		esac
 		;;
 
 	# not a valid command, show help and exit with error code

--- a/scripts/meza.sh
+++ b/scripts/meza.sh
@@ -205,6 +205,11 @@ case "$1" in
 				exit $?;
 				;;
 
+			"docker")
+				# Local playbook only, doesn't need to be run by meza-ansible user
+				ansible-playbook /opt/meza/ansible/getdocker.yml
+				;;
+
 			# Perhaps consider common setups like:
 			# "monolith-with-remote-db-master")
 			# "monolith-with-remote-db-slave")
@@ -347,10 +352,6 @@ case "$1" in
 				;;
 			"dev")
 				/opt/meza/scripts/setup-dev.sh
-				;;
-			"docker")
-				# Local playbook only, doesn't need to be run by meza-ansible user
-				ansible-playbook /opt/meza/ansible/getdocker.yml
 				;;
 			*)
 				echo "NOT A VALID SETUP COMMAND"


### PR DESCRIPTION
Adds commands:

* `meza install docker`: install Docker on CentOS 7
* `meza docker run [optionally specify repo for base image]`: Downloads image from Docker Hub (if not already present), boots it, runs `build-docker-container.sh` to make a monolith.
* `meza docker exec <container-id> [whatever command you want to run]`: run arbitrary commands against the container

