### PR TITLE
Fix references to 'dev' branch, point to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # meza
 
-[![Build Status](https://travis-ci.org/enterprisemediawiki/meza.svg?branch=dev)](https://travis-ci.org/enterprisemediawiki/meza)
+[![Build Status](https://travis-ci.org/enterprisemediawiki/meza.svg?branch=master)](https://travis-ci.org/enterprisemediawiki/meza)
 
-<img src="https://raw.githubusercontent.com/enterprisemediawiki/meza/dev/manual/commands.gif">
+<img src="https://raw.githubusercontent.com/enterprisemediawiki/meza/master/manual/commands.gif">
 
 Setup an enterprise MediaWiki server with simple commands. Put all components on a single monolithic server or split load balancer, web server, memcached, master and replica databases, Parsoid, Elasticsearch and backups all onto separate servers. Deploy to multiple environments. Run backups. Just use the `meza` command. `meza --help` for more info.
 

--- a/scripts/getmeza.sh
+++ b/scripts/getmeza.sh
@@ -12,9 +12,10 @@ fi
 yum install -y epel-release
 yum install -y git ansible
 
-# if /opt/meza doesn't exist, clone into and switch to dev branch (for now)
+# if /opt/meza doesn't exist, clone into and use master branch (which is the
+# default, but should we make this configurable?)
 if [ ! -d "/opt/meza" ]; then
-	git clone https://github.com/enterprisemediawiki/meza.git /opt/meza --branch dev
+	git clone https://github.com/enterprisemediawiki/meza.git /opt/meza --branch master
 fi
 
 if [ ! -f "/usr/bin/meza" ]; then


### PR DESCRIPTION
Fixes some references to `dev` branch in README, plus tells the `getmeza.sh` to get the `master` branch instead of  `dev`.