### PR TITLE
Improve meza command help files

### DIFF
--- a/manual/meza-cmd/backup.txt
+++ b/manual/meza-cmd/backup.txt
@@ -1,0 +1,5 @@
+Mediawiki EZ Admin
+
+Usage: meza backup <environment name>
+
+No directives. Backup the entirety of an environment.

--- a/manual/meza-cmd/base.txt
+++ b/manual/meza-cmd/base.txt
@@ -2,15 +2,28 @@ Mediawiki EZ Admin
 
 Usage: meza COMMAND [directives]
 
-List of commands:
+To setup a multi-server environment, do:
 
-install                   Used to install meza or portions of meza
-create                    Used to create new things, like wikis and users
-config                    Get or set config items
-prompt                    (dev only) Create a prompt for user input
-prompt_default_on_blank   (dev only) Create a prompt for user input
-prompt_secure             (dev only) Create a password prompt for user input
-maint                     Perform maintenance activities like running jobs
+$ meza setup env # Setup the environment, following prompts
+# Edit config as required:
+$ sudo vi /opt/meza/ansible/<env-name>/hosts
+$ sudo vi /opt/meza/ansible/<env-name>/group_vars/all.yml
+$ sudo meza deploy <env-name>
 
-Every command has directives. If you run any command without directives it will
-provide help for that command.
+Commands    Directives           Description
+---------------------------------------------------------------
+install     dev-networking       Setup networking on VM
+            monolith             Install server on this machine
+            docker               Install Docker (CentOS only)
+deploy      <environment name>   Deploy your server
+setup       env                  Setup an environment
+            dev                  Setup dev features (Git, FTP)
+create      wiki                 Create a wiki
+            wiki-promptless      Create a wiki without prompts
+backup      <environment name>   Create a backup of an env
+docker      run                  (experimental) Start container
+            exec                 Execute command on container
+
+Every command has directives. If you run any command without
+directives it will provide help for that command.
+

--- a/manual/meza-cmd/create.txt
+++ b/manual/meza-cmd/create.txt
@@ -4,4 +4,8 @@ Usage: meza create [directives]
 
 List of directives:
 
-wiki   create a wiki
+Directive          Description
+---------------------------------------------------------------
+wiki               Create a wiki
+wiki-promptless    Create a wiki without prompts. This is not
+                   intended to be called by users.

--- a/manual/meza-cmd/deploy.txt
+++ b/manual/meza-cmd/deploy.txt
@@ -1,0 +1,17 @@
+Mediawiki EZ Admin
+
+Usage: meza deploy <environment name> [options]
+
+Example: Backup production, load data onto test
+$ meza backup production
+$ meza deploy test --data-from=production --force
+
+List of options:
+
+Options                     Description
+---------------------------------------------------------------
+NOT YET IMPLEMENTED
+--data-from=<another env>   Get data from backup of another env
+
+NOT YET IMPLEMENTED
+--force                     Overwrite with data from backups

--- a/manual/meza-cmd/docker.txt
+++ b/manual/meza-cmd/docker.txt
@@ -4,4 +4,11 @@ Usage: meza docker [directives]
 
 List of directives:
 
-run   run a particular docker image and install meza
+Directive     Description
+---------------------------------------------------------------
+COMMANDS BELOW ARE EXPERIMENTAL ONLY
+run           Start a Docker container. Optionally specify a
+              Docker image to use.
+exec          Execute a command on your container. Required to
+              specify container ID. Usage:
+              $ meza docker exec <id> some command and args

--- a/manual/meza-cmd/install.txt
+++ b/manual/meza-cmd/install.txt
@@ -4,7 +4,8 @@ Usage: meza install [directives]
 
 List of directives:
 
-dev-networking       Setup a VirtualBox VM networking
-monolith             Install meza on a single machine
-app-with-remote-db   Install meza on a single machine, but with remote database
-remote-db-master     Install a remote database for use as a master
+Directive          Description
+---------------------------------------------------------------
+dev-networking     Setup a VirtualBox VM networking
+monolith           Install meza on a single machine
+docker             Install Docker (CentOS only)

--- a/manual/meza-cmd/setup.txt
+++ b/manual/meza-cmd/setup.txt
@@ -1,0 +1,11 @@
+Mediawiki EZ Admin
+
+Usage: meza setup [directives]
+
+List of directives:
+
+Directive   Description
+---------------------------------------------------------------
+env         Setup an environment, like "production" or "test"
+            Usage: meza setup env <environment name>
+dev         Setup Git user and FTP to make dev easier

--- a/scripts/meza.sh
+++ b/scripts/meza.sh
@@ -2,6 +2,14 @@
 #
 # meza command
 #
+###############################################################################
+#                                                                             #
+# WARNING: THIS SCRIPT WAS INTENDED AS A PROTOTYPE OF THE meza COMMAND PRIOR  #
+#          TO REWRITING IN PYTHON. THE DOCUMENTATION AND NOTES MAY NOT BE     #
+#          PERFECT.                                                           #
+#                                                                             #
+###############################################################################
+#
 # Call like:
 # sudo meza install dev-networking
 # sudo meza install
@@ -51,11 +59,8 @@
 
 source "/opt/meza/config/core/config.sh"
 
-# Make sure this file exists
-touch "$m_local_config_file"
-
 # meza requires a command parameter. No first param, no command. Display help
-if [ -z "$1" ]; then
+if [ -z "$1" ] || [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
 	cat "$m_meza/manual/meza-cmd/base.txt"
 	exit 0;
 fi
@@ -68,6 +73,9 @@ if [ -z "$2" ]; then
 fi
 
 source "$m_i18n/$m_language.sh"
+
+# Make sure this file exists
+touch "$m_local_config_file"
 
 
 prompt () {
@@ -160,30 +168,6 @@ check_environment () {
 case "$1" in
 	install)
 
-		# base requirements for all meza installs
-		mod_base="base base-extras"
-
-		# mediawiki app server
-		mod_app_initial="imagemagick apache php"
-
-		# services
-		mod_memcached="memcached"
-		mod_db="db-server"
-		mod_parsoid="parsoid"
-		mod_elastic="elasticsearch"
-
-		# more mediawiki app server stuff
-		mod_app_final="mediawiki extensions"
-
-		# security. @todo: FIXME can this be rolled into base module?
-		mod_security="security"
-
-		# dev-networking
-		# monolith
-		# mw-app
-		# db-master/slave
-		# search-node
-		# parsoid
 		case "$2" in
 			"dev-networking")
 				source "$m_scripts/dev-networking.sh"
@@ -438,6 +422,11 @@ case "$1" in
 
 	config)
 
+		#
+		# WARNING: THIS FUNCTION IS NOT USED ANYMORE AFAIK. IT WILL BE REMOVED
+		# WHEN THAT IS CONFIRMED. FIXME.
+		#
+
 		# $2 is key
 		# $3 is optional, and is value to set to key
 		if [ ! -f "$m_local_config_file" ]; then
@@ -500,6 +489,11 @@ case "$1" in
 
 	prompt)
 
+		#
+		# WARNING: THIS FUNCTION IS NOT USED ANYMORE AFAIK. IT WILL BE REMOVED
+		# WHEN THAT IS CONFIRMED. FIXME.
+		#
+
 		# $1 = prompt
 		prompt_var="$2"
 		prompt_description="$3 and press [ENTER]:"
@@ -531,6 +525,11 @@ case "$1" in
 
 	prompt_default_on_blank)
 
+		#
+		# WARNING: THIS FUNCTION IS NOT USED ANYMORE AFAIK. IT WILL BE REMOVED
+		# WHEN THAT IS CONFIRMED. FIXME.
+		#
+
 		# $1 = prompt
 		prompt_var="$2"
 		prompt_description="$3 and press [ENTER]:"
@@ -551,6 +550,11 @@ case "$1" in
 		;;
 
 	prompt_secure)
+
+		#
+		# WARNING: THIS FUNCTION IS NOT USED ANYMORE AFAIK. IT WILL BE REMOVED
+		# WHEN THAT IS CONFIRMED. FIXME.
+		#
 
 		# $1 = prompt
 		prompt_var="$2"
@@ -580,6 +584,12 @@ case "$1" in
 
 	maint)
 
+		#
+		# WARNING: THIS FUNCTION SHOULD STILL WORK ON MONOLITHS, BUT HAS NOT BE
+		#          RE-TESTED SINCE MOVING TO ANSIBLE. FOR NON-MONOLITHS IT WILL
+		#          NOT WORK AND NEEDS TO BE ANSIBLE-IZED. FIXME.
+		#
+
 		case "$2" in
 			"jobs")
 				anywiki=`ls -d /opt/meza/htdocs/wikis/*/ | tail -1`
@@ -597,11 +607,6 @@ case "$1" in
 				exit 1;
 				;;
 		esac
-		;;
-
-	import)
-		echo "This function not created yet"
-		exit 1;
 		;;
 
 	docker)


### PR DESCRIPTION
Improve help files for meza command, so `meza --help` is more useful. Also cleaned some things up in `meza.sh` (the meza command file) to remove unused items and flagged some items as likely to be removed or reworked.