### PR TITLE
Don't hard-code secret key, random generate on setting up new env

### DIFF
--- a/ansible/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/ansible/roles/mediawiki/templates/LocalSettings.php.j2
@@ -404,16 +404,8 @@ $wgHashedUploadDirectory = true;
 # Site language code, should be one of the list in ./languages/Names.php
 $wgLanguageCode = "en";
 
-/**
- * @todo: figure out what to do with these.
- * These should be moved out of this file and generated randomly for each
- * install. Either that, or they should be removed entirely since they
- * appear not to be used post MW v1.17.
- **/
-$wgSecretKey = "h950ac53h622q0shtr0aSDh743y534yae68i8745436hl29iu48974safgd435o6";
-# Site upgrade key. Must be set to a string (default provided) to turn on the
-# web installer while LocalSettings.php is in place
-$wgUpgradeKey = "8w456u657946rw45";
+# https://www.mediawiki.org/wiki/Manual:$wgSecretKey
+$wgSecretKey = "{{ wg_secret_key }}";
 
 ## For attaching licensing metadata to pages, and displaying an
 ## appropriate copyright notice / icon. GNU Free Documentation

--- a/ansible/template-env/blank/group_vars/all.yml
+++ b/ansible/template-env/blank/group_vars/all.yml
@@ -33,3 +33,6 @@ mysql_replication_user:
 #   true
 #   false
 enable_wiki_emails: INSERT_ENABLE_EMAIL
+
+# May be required for certain cryptographic functions
+wg_secret_key: INSERT_SECRET_KEY

--- a/scripts/meza.sh
+++ b/scripts/meza.sh
@@ -290,9 +290,13 @@ case "$1" in
 					email=$(echo "$email" | sed -e 's/[\/&]/\\&/g')
 					private_net_zone=$(echo "$private_net_zone" | sed -e 's/[\/&]/\\&/g')
 
+					# Generate a random secret key
+					wg_secret_key=$(cat /dev/urandom | tr -dc "a-zA-Z0-9" | fold -w 64 | head -n 1)
+
 					sed -r -i "s/INSERT_FQDN/$fqdn/g;"                         "$m_meza/ansible/env/$3/group_vars/all.yml"
 					sed -r -i "s/INSERT_PRIVATE_ZONE/$private_net_zone/g;"     "$m_meza/ansible/env/$3/group_vars/all.yml"
 					sed -r -i "s/INSERT_ENABLE_EMAIL/$email/g;"                "$m_meza/ansible/env/$3/group_vars/all.yml"
+					sed -r -i "s/INSERT_SECRET_KEY/$wg_secret_key/g;"          "$m_meza/ansible/env/$3/group_vars/all.yml"
 
 					# All DB users used by the application (root, app, slave)
 					# have the same password. Update as required.


### PR DESCRIPTION
`LocalSettings.php` had `$wgSecretKey` set to a single value, which was very insecure. Now it will be randomly generated when a new environment is created. Value should be set in `group_vars/all.yml`.