### PR TITLE
Ensure all servers have git installed

### DIFF
--- a/ansible/roles/base/tasks/main.yml
+++ b/ansible/roles/base/tasks/main.yml
@@ -17,6 +17,7 @@
     - openssh-server
     - openssh-clients
     - vim
+    - git
     - net-tools
     - firewalld
     - selinux-policy


### PR DESCRIPTION
Build failed on a multi-server setup where Parsoid was on its own server. Meza needed to use git to checkout Parsoid and failed. The server that had Parsoid on it had only had the following commands run on it directly prior to the control server starting to configure it:

```
sudo ifup enp0s3
curl -L minion.getmeza.org > doit
sudo bash doit
curl -L vbox.getmeza.org > doit2
sudo bash doit2
```

None of those steps install Git. They were followed by the control server pushing its SSH keys to this minion and then `meza setup env myenv` and `meza deploy myenv` which began installing meza across all the wikis.

When installing a monolith you setup the meza command with `curl -L getmeza.org > doit` and `sudo bash doit` and that installs git. Since that step is not required when setting up a minion (minions don't require the meza command since you shouldn't need to interact with them directly) the minions were not guaranteed to have Git.

