### PR TITLE
Improve optional variables handling

### DIFF
--- a/src/playbooks/backup.yml
+++ b/src/playbooks/backup.yml
@@ -29,20 +29,22 @@
 # FIXME: If a slave is available, should pull from there
 - hosts: db-master
   become: yes
-  vars_files:
-    - "/opt/meza/config/core/paths.yml"
-    - "/opt/meza/config/local-public/deploy-config.yml"
+  # vars_files:
+  #   - "/opt/meza/config/core/paths.yml"
+  #   - "/opt/meza/config/local-public/deploy-config.yml"
 
   roles:
+    - set-vars
     - dump-db-wikis
 
 
 - hosts: backup-servers
   become: yes
-  vars_files:
-    - "/opt/meza/config/core/paths.yml"
-    - "/opt/meza/config/local-public/deploy-config.yml"
+  # vars_files:
+  #   - "/opt/meza/config/core/paths.yml"
+  #   - "/opt/meza/config/local-public/deploy-config.yml"
   roles:
+    - set-vars
     - backup-db-wikis
     - backup-uploads
     # FIXME: add role to specify current configuration state, such that it's

--- a/src/playbooks/backup.yml
+++ b/src/playbooks/backup.yml
@@ -30,7 +30,8 @@
 - hosts: db-master
   become: yes
   vars_files:
-    - ["/opt/meza/config/core/paths.yml","/opt/meza/config/local-public/deploy-config.yml"]
+    - "/opt/meza/config/core/paths.yml"
+    - "/opt/meza/config/local-public/deploy-config.yml"
 
   roles:
     - dump-db-wikis
@@ -39,7 +40,8 @@
 - hosts: backup-servers
   become: yes
   vars_files:
-    - ["/opt/meza/config/core/paths.yml","/opt/meza/config/local-public/deploy-config.yml"]
+    - "/opt/meza/config/core/paths.yml"
+    - "/opt/meza/config/local-public/deploy-config.yml"
   roles:
     - backup-db-wikis
     - backup-uploads

--- a/src/playbooks/backup.yml
+++ b/src/playbooks/backup.yml
@@ -29,10 +29,6 @@
 # FIXME: If a slave is available, should pull from there
 - hosts: db-master
   become: yes
-  # vars_files:
-  #   - "/opt/meza/config/core/paths.yml"
-  #   - "/opt/meza/config/local-public/deploy-config.yml"
-
   roles:
     - set-vars
     - dump-db-wikis
@@ -40,9 +36,6 @@
 
 - hosts: backup-servers
   become: yes
-  # vars_files:
-  #   - "/opt/meza/config/core/paths.yml"
-  #   - "/opt/meza/config/local-public/deploy-config.yml"
   roles:
     - set-vars
     - backup-db-wikis

--- a/src/playbooks/create-wiki-promptless.yml
+++ b/src/playbooks/create-wiki-promptless.yml
@@ -2,9 +2,10 @@
 
 - hosts: app-servers
   become: yes
-  vars_files:
-    - "/opt/meza/config/core/paths.yml"
-    - "/opt/meza/config/local-public/deploy-config.yml"
+  # vars_files:
+  #   - "/opt/meza/config/core/paths.yml"
+  #   - "/opt/meza/config/local-public/deploy-config.yml"
 
   roles:
+    - set-vars
     - create-wiki-wrapper

--- a/src/playbooks/create-wiki-promptless.yml
+++ b/src/playbooks/create-wiki-promptless.yml
@@ -4,6 +4,7 @@
   become: yes
   vars_files:
     - "/opt/meza/config/core/paths.yml"
+    - "/opt/meza/config/local-public/deploy-config.yml"
 
   roles:
     - create-wiki-wrapper

--- a/src/playbooks/create-wiki-promptless.yml
+++ b/src/playbooks/create-wiki-promptless.yml
@@ -2,10 +2,6 @@
 
 - hosts: app-servers
   become: yes
-  # vars_files:
-  #   - "/opt/meza/config/core/paths.yml"
-  #   - "/opt/meza/config/local-public/deploy-config.yml"
-
   roles:
     - set-vars
     - create-wiki-wrapper

--- a/src/playbooks/create-wiki.yml
+++ b/src/playbooks/create-wiki.yml
@@ -2,9 +2,6 @@
 
 - hosts: app-servers
   become: yes
-  # vars_files:
-  #   - "/opt/meza/config/core/paths.yml"
-  #   - "/opt/meza/config/local-public/deploy-config.yml"
 
   # prompt for wiki_id and wiki_name
   vars_prompt:

--- a/src/playbooks/create-wiki.yml
+++ b/src/playbooks/create-wiki.yml
@@ -4,6 +4,7 @@
   become: yes
   vars_files:
     - "/opt/meza/config/core/paths.yml"
+    - "/opt/meza/config/local-public/deploy-config.yml"
 
   # prompt for wiki_id and wiki_name
   vars_prompt:

--- a/src/playbooks/create-wiki.yml
+++ b/src/playbooks/create-wiki.yml
@@ -2,9 +2,9 @@
 
 - hosts: app-servers
   become: yes
-  vars_files:
-    - "/opt/meza/config/core/paths.yml"
-    - "/opt/meza/config/local-public/deploy-config.yml"
+  # vars_files:
+  #   - "/opt/meza/config/core/paths.yml"
+  #   - "/opt/meza/config/local-public/deploy-config.yml"
 
   # prompt for wiki_id and wiki_name
   vars_prompt:
@@ -29,4 +29,5 @@
       private: no
 
   roles:
+    - set-vars
     - create-wiki-wrapper

--- a/src/playbooks/setup-env.yml
+++ b/src/playbooks/setup-env.yml
@@ -4,6 +4,5 @@
   become: yes
   vars_files:
     - "/opt/meza/config/core/paths.yml"
-    - "/opt/meza/config/local-public/deploy-config.yml"
   roles:
     - setup-env

--- a/src/playbooks/setup-env.yml
+++ b/src/playbooks/setup-env.yml
@@ -4,5 +4,6 @@
   become: yes
   vars_files:
     - "/opt/meza/config/core/paths.yml"
+    - "/opt/meza/config/local-public/deploy-config.yml"
   roles:
     - setup-env

--- a/src/playbooks/setup-env.yml
+++ b/src/playbooks/setup-env.yml
@@ -2,7 +2,8 @@
 
 - hosts: localhost
   become: yes
-  vars_files:
-    - "/opt/meza/config/core/paths.yml"
+  # vars_files:
+  #   - "/opt/meza/config/core/paths.yml"
   roles:
+    - set-vars
     - setup-env

--- a/src/playbooks/setup-env.yml
+++ b/src/playbooks/setup-env.yml
@@ -2,8 +2,6 @@
 
 - hosts: localhost
   become: yes
-  # vars_files:
-  #   - "/opt/meza/config/core/paths.yml"
   roles:
     - set-vars
     - setup-env

--- a/src/playbooks/site.yml
+++ b/src/playbooks/site.yml
@@ -6,38 +6,42 @@
 
 - hosts: all
   become: yes
-  vars_files:
-    - "/opt/meza/config/core/paths.yml"
+  # vars_files:
+  #   - "/opt/meza/config/core/paths.yml"
   roles:
+    - set-vars
     - base
     # FIXME: add "security" module here
 
 # FIXME: why is controller init on all app servers?
 - hosts: app-servers
   become: yes
-  vars_files:
-    - "/opt/meza/config/core/paths.yml"
+  # vars_files:
+  #   - "/opt/meza/config/core/paths.yml"
   roles:
+    - set-vars
     - init-controller-config
 
 - hosts: load-balancers
   become: yes
-  vars_files:
+  # vars_files:
     # NOTE: This, oddly, will supposedly load all files that exist, but putting
     # the files on separate lines will cause an error if deploy-config.yml
     # doesn't exist yet.
-    - "/opt/meza/config/core/paths.yml"
-    - "/opt/meza/config/local-public/deploy-config.yml"
+    # - "/opt/meza/config/core/paths.yml"
+    # - "/opt/meza/config/local-public/deploy-config.yml"
   tags: load-balancer
   roles:
+    - set-vars
     - haproxy
 
 - hosts: app-servers
   become: yes
-  vars_files:
-    - "/opt/meza/config/core/paths.yml"
-    - "/opt/meza/config/local-public/deploy-config.yml"
+  # vars_files:
+  #   - "/opt/meza/config/core/paths.yml"
+  #   - "/opt/meza/config/local-public/deploy-config.yml"
   roles:
+    - set-vars
     - role: firewalld
       # firewalld_service: http
       firewalld_port: 8080
@@ -56,10 +60,11 @@
 
 - hosts: memcached-servers
   become: yes
-  vars_files:
-    - "/opt/meza/config/core/paths.yml"
-    - "/opt/meza/config/local-public/deploy-config.yml"
+  # vars_files:
+  #   - "/opt/meza/config/core/paths.yml"
+  #   - "/opt/meza/config/local-public/deploy-config.yml"
   roles:
+    - set-vars
     - role: firewalld
       firewalld_port: 11211
       firewalld_protocol: tcp
@@ -70,10 +75,11 @@
 - hosts: db-master
   become: yes
   tags: database
-  vars_files:
-    - "/opt/meza/config/core/paths.yml"
-    - "/opt/meza/config/local-public/deploy-config.yml"
+  # vars_files:
+  #   - "/opt/meza/config/core/paths.yml"
+  #   - "/opt/meza/config/local-public/deploy-config.yml"
   roles:
+    - set-vars
     - role: firewalld
       firewalld_service: mysql
       firewalld_servers: "{{ groups['app-servers'] }}"
@@ -94,10 +100,11 @@
 - hosts: db-slaves
   become: yes
   tags: database
-  vars_files:
-    - "/opt/meza/config/core/paths.yml"
-    - "/opt/meza/config/local-public/deploy-config.yml"
+  # vars_files:
+  #   - "/opt/meza/config/core/paths.yml"
+  #   - "/opt/meza/config/local-public/deploy-config.yml"
   roles:
+    - set-vars
     - role: firewalld
       firewalld_service: mysql
       firewalld_servers: "{{ groups['app-servers'] }}"
@@ -112,11 +119,12 @@
 
 - hosts: parsoid-servers
   become: yes
-  vars_files:
-    - "/opt/meza/config/core/paths.yml"
-    - "/opt/meza/config/local-public/deploy-config.yml"
+  # vars_files:
+  #   - "/opt/meza/config/core/paths.yml"
+  #   - "/opt/meza/config/local-public/deploy-config.yml"
   tags: parsoid
   roles:
+    - set-vars
     # Allow app servers to get to parsoid server(s) on port 8000
     - role: firewalld
       firewalld_port: 8000
@@ -137,11 +145,12 @@
 
 - hosts: elastic-servers
   become: yes
-  vars_files:
-    - "/opt/meza/config/core/paths.yml"
-    - "/opt/meza/config/local-public/deploy-config.yml"
+  # vars_files:
+  #   - "/opt/meza/config/core/paths.yml"
+  #   - "/opt/meza/config/local-public/deploy-config.yml"
   tags: elasticsearch
   roles:
+    - set-vars
     - role: firewalld
       firewalld_port: 9200
       firewalld_protocol: tcp
@@ -167,10 +176,11 @@
 # Note: this is app-servers again, but must be after everything else is setup
 - hosts: app-servers
   become: yes
-  vars_files:
-    - "/opt/meza/config/core/paths.yml"
-    - "/opt/meza/config/local-public/deploy-config.yml"
+  # vars_files:
+  #   - "/opt/meza/config/core/paths.yml"
+  #   - "/opt/meza/config/local-public/deploy-config.yml"
   tags: mediawiki
   roles:
+    - set-vars
     - composer
     - mediawiki

--- a/src/playbooks/site.yml
+++ b/src/playbooks/site.yml
@@ -26,7 +26,8 @@
     # NOTE: This, oddly, will supposedly load all files that exist, but putting
     # the files on separate lines will cause an error if deploy-config.yml
     # doesn't exist yet.
-    - ["/opt/meza/config/core/paths.yml","/opt/meza/config/local-public/deploy-config.yml"]
+    - "/opt/meza/config/core/paths.yml"
+    - "/opt/meza/config/local-public/deploy-config.yml"
   tags: load-balancer
   roles:
     - haproxy
@@ -34,7 +35,8 @@
 - hosts: app-servers
   become: yes
   vars_files:
-    - ["/opt/meza/config/core/paths.yml","/opt/meza/config/local-public/deploy-config.yml"]
+    - "/opt/meza/config/core/paths.yml"
+    - "/opt/meza/config/local-public/deploy-config.yml"
   roles:
     - role: firewalld
       # firewalld_service: http
@@ -55,7 +57,8 @@
 - hosts: memcached-servers
   become: yes
   vars_files:
-    - ["/opt/meza/config/core/paths.yml","/opt/meza/config/local-public/deploy-config.yml"]
+    - "/opt/meza/config/core/paths.yml"
+    - "/opt/meza/config/local-public/deploy-config.yml"
   roles:
     - role: firewalld
       firewalld_port: 11211
@@ -68,7 +71,8 @@
   become: yes
   tags: database
   vars_files:
-    - ["/opt/meza/config/core/paths.yml","/opt/meza/config/local-public/deploy-config.yml"]
+    - "/opt/meza/config/core/paths.yml"
+    - "/opt/meza/config/local-public/deploy-config.yml"
   roles:
     - role: firewalld
       firewalld_service: mysql
@@ -91,7 +95,8 @@
   become: yes
   tags: database
   vars_files:
-    - ["/opt/meza/config/core/paths.yml","/opt/meza/config/local-public/deploy-config.yml"]
+    - "/opt/meza/config/core/paths.yml"
+    - "/opt/meza/config/local-public/deploy-config.yml"
   roles:
     - role: firewalld
       firewalld_service: mysql
@@ -108,7 +113,8 @@
 - hosts: parsoid-servers
   become: yes
   vars_files:
-    - ["/opt/meza/config/core/paths.yml","/opt/meza/config/local-public/deploy-config.yml"]
+    - "/opt/meza/config/core/paths.yml"
+    - "/opt/meza/config/local-public/deploy-config.yml"
   tags: parsoid
   roles:
     # Allow app servers to get to parsoid server(s) on port 8000
@@ -132,7 +138,8 @@
 - hosts: elastic-servers
   become: yes
   vars_files:
-    - ["/opt/meza/config/core/paths.yml","/opt/meza/config/local-public/deploy-config.yml"]
+    - "/opt/meza/config/core/paths.yml"
+    - "/opt/meza/config/local-public/deploy-config.yml"
   tags: elasticsearch
   roles:
     - role: firewalld
@@ -161,7 +168,8 @@
 - hosts: app-servers
   become: yes
   vars_files:
-    - ["/opt/meza/config/core/paths.yml","/opt/meza/config/local-public/deploy-config.yml"]
+    - "/opt/meza/config/core/paths.yml"
+    - "/opt/meza/config/local-public/deploy-config.yml"
   tags: mediawiki
   roles:
     - composer

--- a/src/playbooks/site.yml
+++ b/src/playbooks/site.yml
@@ -6,8 +6,6 @@
 
 - hosts: all
   become: yes
-  # vars_files:
-  #   - "/opt/meza/config/core/paths.yml"
   roles:
     - set-vars
     - base
@@ -16,20 +14,12 @@
 # FIXME: why is controller init on all app servers?
 - hosts: app-servers
   become: yes
-  # vars_files:
-  #   - "/opt/meza/config/core/paths.yml"
   roles:
     - set-vars
     - init-controller-config
 
 - hosts: load-balancers
   become: yes
-  # vars_files:
-    # NOTE: This, oddly, will supposedly load all files that exist, but putting
-    # the files on separate lines will cause an error if deploy-config.yml
-    # doesn't exist yet.
-    # - "/opt/meza/config/core/paths.yml"
-    # - "/opt/meza/config/local-public/deploy-config.yml"
   tags: load-balancer
   roles:
     - set-vars
@@ -37,9 +27,6 @@
 
 - hosts: app-servers
   become: yes
-  # vars_files:
-  #   - "/opt/meza/config/core/paths.yml"
-  #   - "/opt/meza/config/local-public/deploy-config.yml"
   roles:
     - set-vars
     - role: firewalld
@@ -60,9 +47,6 @@
 
 - hosts: memcached-servers
   become: yes
-  # vars_files:
-  #   - "/opt/meza/config/core/paths.yml"
-  #   - "/opt/meza/config/local-public/deploy-config.yml"
   roles:
     - set-vars
     - role: firewalld
@@ -75,9 +59,6 @@
 - hosts: db-master
   become: yes
   tags: database
-  # vars_files:
-  #   - "/opt/meza/config/core/paths.yml"
-  #   - "/opt/meza/config/local-public/deploy-config.yml"
   roles:
     - set-vars
     - role: firewalld
@@ -100,9 +81,6 @@
 - hosts: db-slaves
   become: yes
   tags: database
-  # vars_files:
-  #   - "/opt/meza/config/core/paths.yml"
-  #   - "/opt/meza/config/local-public/deploy-config.yml"
   roles:
     - set-vars
     - role: firewalld
@@ -119,9 +97,6 @@
 
 - hosts: parsoid-servers
   become: yes
-  # vars_files:
-  #   - "/opt/meza/config/core/paths.yml"
-  #   - "/opt/meza/config/local-public/deploy-config.yml"
   tags: parsoid
   roles:
     - set-vars
@@ -145,9 +120,6 @@
 
 - hosts: elastic-servers
   become: yes
-  # vars_files:
-  #   - "/opt/meza/config/core/paths.yml"
-  #   - "/opt/meza/config/local-public/deploy-config.yml"
   tags: elasticsearch
   roles:
     - set-vars
@@ -176,9 +148,6 @@
 # Note: this is app-servers again, but must be after everything else is setup
 - hosts: app-servers
   become: yes
-  # vars_files:
-  #   - "/opt/meza/config/core/paths.yml"
-  #   - "/opt/meza/config/local-public/deploy-config.yml"
   tags: mediawiki
   roles:
     - set-vars

--- a/src/roles/init-controller-config/tasks/main.yml
+++ b/src/roles/init-controller-config/tasks/main.yml
@@ -123,4 +123,4 @@
     - MezaLocalExtensions.yml
     - preLocalSettings_allWikis.php
     - postLocalSettings_allWikis.php
-    - deploy-config.yml
+    - vars.yml

--- a/src/roles/init-controller-config/templates/vars.yml
+++ b/src/roles/init-controller-config/templates/vars.yml
@@ -1,5 +1,5 @@
 ---
-# deploy-config.yml
+# vars.yml
 #
 # Config file for putting non-secure items needed for configuration during
 # deploy of the application

--- a/src/roles/set-vars/tasks/main.yml
+++ b/src/roles/set-vars/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Set meza-core path variables
+  include_vars:
+    file: /opt/meza/config/core/paths.yml
+
+- name: Set meza-local variables
+  include_vars:
+    file: "{{ m_local_public }}/deploy-config.yml"
+
+  # Ingore errors so this file is not required to be included
+  ignore_errors: yes

--- a/src/roles/set-vars/tasks/main.yml
+++ b/src/roles/set-vars/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
+
 - name: Set meza-core path variables
   include_vars:
     file: /opt/meza/config/core/paths.yml
 
 - name: Set meza-local variables
   include_vars:
-    file: "{{ m_local_public }}/deploy-config.yml"
-
+    file: "{{ m_local_public }}/vars.yml"
   # Ingore errors so this file is not required to be included
   ignore_errors: yes

--- a/tests/travis/run-tests.sh
+++ b/tests/travis/run-tests.sh
@@ -141,9 +141,6 @@ elif [ "$test_type" == "monolith_from_import" ]; then
 
 	echo "TEST TYPE = monolith_from_import"
 
-	# TEST ANSIBLE SYNTAX. FIXME: syntax check all playbooks
-	${docker_exec[@]} ANSIBLE_CONFIG=/opt/meza/config/core/ansible.cfg ansible-playbook /opt/meza/src/playbooks/site.yml --syntax-check
-
 	# Get test "secret" config
 	${docker_exec[@]} mkdir /opt/meza/config/local-secret
 	${docker_exec[@]} git clone https://github.com/enterprisemediawiki/meza-test-config-secret.git /opt/meza/config/local-secret/imported
@@ -157,6 +154,10 @@ elif [ "$test_type" == "monolith_from_import" ]; then
 
 	# Deploy "imported" environment with test config
 	${docker_exec[@]} meza deploy imported
+
+	# TEST ANSIBLE SYNTAX. FIXME: syntax check all playbooks
+	# Won't pass syntax checks prior to deploy because it won't find deploy-config.yaml
+	# ${docker_exec[@]} ANSIBLE_CONFIG=/opt/meza/config/core/ansible.cfg ansible-playbook /opt/meza/src/playbooks/site.yml --syntax-check
 
 	# Basic system check
 	server_check

--- a/tests/travis/run-tests.sh
+++ b/tests/travis/run-tests.sh
@@ -141,6 +141,9 @@ elif [ "$test_type" == "monolith_from_import" ]; then
 
 	echo "TEST TYPE = monolith_from_import"
 
+	# TEST ANSIBLE SYNTAX. FIXME: syntax check all playbooks
+	${docker_exec[@]} ANSIBLE_CONFIG=/opt/meza/config/core/ansible.cfg ansible-playbook /opt/meza/src/playbooks/site.yml --syntax-check
+
 	# Get test "secret" config
 	${docker_exec[@]} mkdir /opt/meza/config/local-secret
 	${docker_exec[@]} git clone https://github.com/enterprisemediawiki/meza-test-config-secret.git /opt/meza/config/local-secret/imported
@@ -154,10 +157,6 @@ elif [ "$test_type" == "monolith_from_import" ]; then
 
 	# Deploy "imported" environment with test config
 	${docker_exec[@]} meza deploy imported
-
-	# TEST ANSIBLE SYNTAX. FIXME: syntax check all playbooks
-	# Won't pass syntax checks prior to deploy because it won't find deploy-config.yaml
-	# ${docker_exec[@]} ANSIBLE_CONFIG=/opt/meza/config/core/ansible.cfg ansible-playbook /opt/meza/src/playbooks/site.yml --syntax-check
 
 	# Basic system check
 	server_check


### PR DESCRIPTION
Previously local-public config had a file `deploy-config.yml` which was an attempt to override `/opt/meza/config/core/paths.yml` and other config vars. However, it did not work properly. This PR sets it up to work, such that any config variable can be overriden. This allows basic configuration changes like setting the title on the landing page, or changing the path to the backups directory.

### Testing

- [x] `curl -L getmeza.org > doit`
- [x] `sudo bash doit`
- [x] `cd /opt/meza && sudo git checkout deploy-config` to checkout this change
- [x] `sudo meza deploy monolith`
- [x] Apply changes to `/opt/meza/config/local-public/vars.yml`. Specifically set vars for landing page.
- [x] Perform standard tests from [CONTRIBUTING.md](https://github.com/enterprisemediawiki/meza/blob/master/CONTRIBUTING.md) (though note that these guidelines need updating)

### Changes

* `deploy-config.yml --> vars.yml`
* Loading of `vars.yml` and `paths.yml` now performed by role `set-vars` instead of a `vars_files` call

### Issues

* Closes #502
