### PR TITLE
Support RedHat 7

### DIFF
--- a/manual/1.0-SettingUpVirtualBox.md
+++ b/manual/1.0-SettingUpVirtualBox.md
@@ -61,3 +61,7 @@ These steps do the following:
 1. Start your VM
 2. SSH into the VM
 3. Run `sudo meza deploy monolith` to install your wiki server.
+
+## Red Hat
+
+Want to setup a Red Hat VM instead of CentOS? See [instructions](SetupRedHat.md).

--- a/manual/SetupRedHat.md
+++ b/manual/SetupRedHat.md
@@ -1,0 +1,15 @@
+Setup a RedHat Dev VM
+=====================
+
+1. Download the DVD.iso RedHat 7 image on the [Red Hat downloads page](https://developers.redhat.com/products/rhel/download/). When you attempt to download for the first time you'll have to generate a Red Hat account. You're going to have to create a username and password anyway, so there doesn't appear to be a strong need to use a linked account (e.g. Google, Github).
+2. Place the ISO in your home folder and use `create-vm.sh` as described on the [VirtualBox setup instructions](1.0-SettingUpVirtualBox.md)
+3. Install the Red Hat Enterprise Linux operating system in the same way you install CentOS
+4. After the OS is installed, when you've booted into your OS command line, start with the same command as on CentOS: `sudo ifup enp0s3` (starts networking)
+5. Next, setup your RedHat subscription with `sudo subscription-manager register --username <username> --password <password> --auto-attach` using your username and password for your RedHat developer account
+6. Continue with normal CentOS steps:
+  1. `curl -L getmeza.org > doit`
+  2. `sudo bash doit`
+  3. (optional) `cd /opt/meza && sudo git checkout <branch>` if you're testing a new branch
+  4. `sudo meza setup dev-networking`
+  5. SSH into your VM
+  6. `sudo meza deploy monolith`

--- a/src/roles/apache-php/tasks/ius.yml
+++ b/src/roles/apache-php/tasks/ius.yml
@@ -7,7 +7,7 @@
 - name: Install IUS (RHEL) repo.
   yum:
     name: "https://rhel{{ ansible_distribution_major_version }}.iuscommunity.org/ius-release.rpm"
-  when: ansible_distribution == "Red Hat Enterprise Linux"
+  when: ansible_distribution == "RedHat"
 
 - name: Import IUS Community Project GPG key
   rpm_key:

--- a/src/roles/base/tasks/main.yml
+++ b/src/roles/base/tasks/main.yml
@@ -34,6 +34,9 @@
   ignore_errors: "{{ ansible_check_mode }}"
 
 
+- name: Ensure optional repos enabled
+  shell: subscription-manager repos --enable rhel-7-server-optional-rpms
+  when: ansible_distribution == "RedHat"
 
 
 - name: ensure libselinux-python installed prior to SELinux

--- a/src/roles/base/tasks/main.yml
+++ b/src/roles/base/tasks/main.yml
@@ -3,9 +3,40 @@
   yum: name=deltarpm state=installed
 - name: upgrade all packages
   yum: name=* state=latest
+
+
 # FIXME: for RedHat may need to enable "Optional RPMs"
 - name: ensure EPEL installed
-  yum: name=epel-release state=installed
+  yum:
+    name: epel-release
+    state: installed
+  when: ansible_distribution == "CentOS"
+
+- name: Check if EPEL repo is already configured.
+  stat: path={{ epel_repofile_path }}
+  register: epel_repofile_result
+  when: ansible_distribution == "RedHat"
+
+- name: Install EPEL repo.
+  yum:
+    name: "{{ epel_repo_url }}"
+    state: present
+  register: result
+  until: '"failed" not in result'
+  retries: 5
+  delay: 10
+  when: ansible_distribution == "RedHat" and not epel_repofile_result.stat.exists
+
+- name: Import EPEL GPG key.
+  rpm_key:
+    key: "{{ epel_repo_gpg_key_url }}"
+    state: present
+  when: ansible_distribution == "RedHat" and not epel_repofile_result.stat.exists
+  ignore_errors: "{{ ansible_check_mode }}"
+
+
+
+
 - name: ensure libselinux-python installed prior to SELinux
   yum: name=libselinux-python state=installed
 - name: Install base packages

--- a/src/roles/base/tasks/main.yml
+++ b/src/roles/base/tasks/main.yml
@@ -4,7 +4,6 @@
 - name: upgrade all packages
   yum: name=* state=latest
 
-
 # FIXME: for RedHat may need to enable "Optional RPMs"
 - name: ensure EPEL installed
   yum:
@@ -13,13 +12,13 @@
   when: ansible_distribution == "CentOS"
 
 - name: Check if EPEL repo is already configured.
-  stat: path={{ epel_repofile_path }}
+  stat:
+    path: "/etc/yum.repos.d/epel.repo"
   register: epel_repofile_result
-  when: ansible_distribution == "RedHat"
 
 - name: Install EPEL repo.
   yum:
-    name: "{{ epel_repo_url }}"
+    name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
     state: present
   register: result
   until: '"failed" not in result'
@@ -29,7 +28,7 @@
 
 - name: Import EPEL GPG key.
   rpm_key:
-    key: "{{ epel_repo_gpg_key_url }}"
+    key: "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
     state: present
   when: ansible_distribution == "RedHat" and not epel_repofile_result.stat.exists
   ignore_errors: "{{ ansible_check_mode }}"

--- a/src/scripts/dev-networking.sh
+++ b/src/scripts/dev-networking.sh
@@ -16,47 +16,21 @@ done
 #
 net_scripts="/etc/sysconfig/network-scripts"
 
+# CentOS 7 (and presumably later) use ifcfg-enp0s3 and ifcfg-enp0s8 files
+network_adapter1="ifcfg-enp0s3"
+network_adapter2="ifcfg-enp0s8"
 
-
-# CentOS/RHEL Version?
-if grep -Fxq "VERSION_ID=\"7\"" /etc/os-release
-then
-	echo "Enterprise Linux version 7."
-	enterprise_linux_version="7"
-
-	# CentOS 7 (and presumably later) use ifcfg-enp0s3 and ifcfg-enp0s8 files
-	network_adapter1="ifcfg-enp0s3"
-	network_adapter2="ifcfg-enp0s8"
-
-else
-	echo "Enterprise Linux version 6."
-	enterprise_linux_version="6"
-
-	# CentOS 6 (and presumably earlier) used ifcfg-eth0 and ifcfg-eth1 files
-	network_adapter1="ifcfg-eth0"
-	network_adapter2="ifcfg-eth1"
-fi
-
-
-# modify ifcfg-eth0 (NAT)
+# modify first net interface (NAT)
 sed -r -i 's/ONBOOT=no/ONBOOT=yes/g;' "$net_scripts/$network_adapter1"
 sed -r -i 's/NM_CONTROLLED=yes/NM_CONTROLLED=no/g;' "$net_scripts/$network_adapter1"
 
 
 # note: prefix with \ removes root's alias in .bashrc to "cp -i" which forces cp
 # to ask the user if they want to overwrite existing. We do want to overwrite.
-curl -L "https://raw.githubusercontent.com/enterprisemediawiki/meza/master/config/core/template/$network_adapter2" > "$net_scripts/$network_adapter2"
+curl -L "https://raw.github.com/enterprisemediawiki/meza/master/config/core/template/$network_adapter2" > "$net_scripts/$network_adapter2"
 
 # modify IP address as required:
 sed -r -i "s/IPADDR=192.168.56.56/IPADDR=$ipaddr/g;" "$net_scripts/$network_adapter2"
-
-
-# get eth1 HWADDR from ifconfig, insert into ifcfg-eth1
-# Note: not required for CentOS 7 (ifcfg-enp0s8 does not have HWADDR)
-if [ "$enterprise_linux_version" = "6" ]; then
-	eth1_hwaddr="$(ifconfig eth1 | grep '[a-zA-Z0-9]{2}:[a-zA-Z0-9]{2}:[a-zA-Z0-9]{2}:[a-zA-Z0-9]{2}:[a-zA-Z0-9]{2}:[a-zA-Z0-9]{2}' -o -P)"
-	sed -r -i "s/HWADDR=.*$/HWADDR=$eth1_hwaddr/g;" "$net_scripts/ifcfg-eth1"
-fi
 
 
 # restart networking

--- a/src/scripts/getmeza.sh
+++ b/src/scripts/getmeza.sh
@@ -9,7 +9,21 @@ if [ "$(whoami)" != "root" ]; then
 	exit 1
 fi
 
-yum install -y epel-release
+# Install epel if not installed
+if [ ! -f "/etc/yum.repos.d/epel.repo" ]; then
+
+	# if CentOS
+	if [ $(cat /etc/redhat-release | grep -q "CentOS") ]; then
+		yum install -y epel-release
+	else # if RedHat
+		epel_repo_url="https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+		epel_repo_gpg_key_url="/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7"
+		rpm -Uvh $epel_repo_url
+
+	fi
+
+fi
+
 yum install -y git ansible
 
 # if /opt/meza doesn't exist, clone into and use master branch (which is the

--- a/src/scripts/getmeza.sh
+++ b/src/scripts/getmeza.sh
@@ -12,14 +12,14 @@ fi
 # Install epel if not installed
 if [ ! -f "/etc/yum.repos.d/epel.repo" ]; then
 
-	# if CentOS
-	if [ $(cat /etc/redhat-release | grep -q "CentOS") ]; then
+	distro=$(cat /etc/redhat-release | grep -q "CentOS" && echo "CentOS" || echo "RedHat")
+
+ 	if [ "$distro" == "CentOS" ]; then
 		yum install -y epel-release
 	else # if RedHat
 		epel_repo_url="https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
-		epel_repo_gpg_key_url="/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7"
+		# epel_repo_gpg_key_url="/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7"
 		rpm -Uvh $epel_repo_url
-
 	fi
 
 fi


### PR DESCRIPTION
A description of the pull request

### Testing

- [ ] Follow the new docs for Red Hat setup if testing on Red Hat
- [ ] `curl -L https://raw.github.com/enterprisemediawiki/meza/redhat/src/scripts/getmeza.sh > doit` to get this `getmeza.sh` script (`getmeza.org` gives `master` version and this has changes)
- [ ] `sudo bash doit`
- [ ] `cd /opt/meza && sudo git checkout redhat` to get this branch
- [ ] `sudo meza setup dev-networking`
- [ ] `sudo meza deploy monolith`
- [ ] Perform standard tests from [CONTRIBUTING.md](https://github.com/enterprisemediawiki/meza/blob/master/CONTRIBUTING.md)

### Changes

* Add [manual/SetupRedHat.md](manual/SetupRedHat.md) for getting a Red Hat dev license and setting up a VM
* Fix IUS repo download for Red Hat. Conditional had bad value when checking for Red Hat
* Make role:base properly ensure EPEL exists for Red Hat. For CentOS you simply need to do `yum install epel-release`. For Red Hat you need to get EPEL from a URL
  * Also make `dev-networking.sh` properly install EPEL
* Remove CentOS 6 lines from `dev-networking.sh` which conflicted with RHEL 7 and were pointless anyway

