### PR TITLE
Move mariadb data directory

### DIFF
--- a/src/roles/database/defaults/main.yml
+++ b/src/roles/database/defaults/main.yml
@@ -47,8 +47,6 @@ mysql_sql_mode: ''
 # The following variables have a default value depending on operating system.
 # mysql_pid_file: /var/run/mysqld/mysqld.pid
 # mysql_socket: /var/lib/mysql/mysql.sock
-# Deviation from geerlinguy role
-mysql_socket: /opt/meza/data/mariadb/mysql.sock
 
 # Slow query log settings.
 mysql_slow_query_log_enabled: no

--- a/src/roles/database/defaults/main.yml
+++ b/src/roles/database/defaults/main.yml
@@ -38,11 +38,17 @@ mysql_enablerepo: ""
 mysql_port: "3306"
 mysql_bind_address: '0.0.0.0'
 mysql_skip_name_resolve: no
-mysql_datadir: /var/lib/mysql
+
+# Deviation from geerlinguy role
+# mysql_datadir: /var/lib/mysql
+mysql_datadir: /opt/meza/data/mariadb
+
 mysql_sql_mode: ''
 # The following variables have a default value depending on operating system.
 # mysql_pid_file: /var/run/mysqld/mysqld.pid
 # mysql_socket: /var/lib/mysql/mysql.sock
+# Deviation from geerlinguy role
+mysql_socket: /opt/meza/data/mariadb/mysql.sock
 
 # Slow query log settings.
 mysql_slow_query_log_enabled: no


### PR DESCRIPTION
This change must have been overwritten at some point, because we have been keeping data in `/opt/meza/data` for a very long time. This was a simple change because the Ansible role for MySQL/MariaDB handles the change. This PR sets the default to `/opt/meza/data/mariadb`, but it is possible to override this in a meza instance's settings.