### PR TITLE
Added Semantic Drilldown to Core Extensions

### DIFF
--- a/src/roles/mediawiki/files/MezaCoreExtensions.yml
+++ b/src/roles/mediawiki/files/MezaCoreExtensions.yml
@@ -184,6 +184,10 @@ list:
     repo: https://gerrit.wikimedia.org/r/mediawiki/extensions/SemanticCompoundQueries.git
     version: REL1_27
     legacy_load: true
+  - name: SemanticDrilldown
+    repo: https://gerrit.wikimedia.org/r/mediawiki/extensions/SemanticDrilldown.git
+    version: REL1_27
+    legacy_load: true
   - name: Arrays
     repo: https://gerrit.wikimedia.org/r/mediawiki/extensions/Arrays.git
     version: REL1_27


### PR DESCRIPTION
Added Semantic Drilldown extension to list of core extensions.

Tested deploy on fresh install of CentOS 7 and worked w/o issue.