### PR TITLE
Fix permissions for services accessing MediaWiki

### DIFF
--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -657,7 +657,16 @@ $mezaValidParsoidServers[] = '127.0.0.1';
 {% endif %}
 $mezaValidParsoidServers[] = '{{ host }}';
 {% endfor %}
-if ( isset( $_SERVER['REMOTE_ADDR'] ) && in_array( $_SERVER['REMOTE_ADDR'], $mezaValidParsoidServers ) ) {
+
+/**
+ * HTTP_X_FORWARDED_FOR is set by HAProxy when users request pages via
+ * the load balancer. No users should directly access webservers. Only
+ * other services (e.g. Parsoid) should directly access webservers. In
+ * order to allow services to access MediaWiki with full permissions,
+ * if HTTP_X_FORWARDED_FOR does NOT exist then assume it's not a regular
+ * user and grant permissions
+ **/
+if ( ! isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
 	$wgGroupPermissions['*']['read'] = true;
 	$wgGroupPermissions['*']['edit'] = true;
 }


### PR DESCRIPTION
Check for presence of HTTP_X_FORWARDED_FOR to determine if request is from
a real user or if it is a request from a service. If it's a service, then
set permissions to be able to view/edit all. Real users will have
HTTP_X_FORWARDED_FOR, service request (that don't go through the load
balancer) do not.
