### PR TITLE
Enable install with Vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ htdocs/wikis/*
 
 simplesamlphp/
 
+.vagrant/*

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,46 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+
+  # config.vm.define "monolith" do |web|
+  #   web.vm.box = "precise64"
+  #   web.vm.hostname = 'web'
+  #   web.vm.box_url = "ubuntu/precise64"
+
+  config.vm.box = "centos/7"
+
+  config.vm.network :private_network, ip: "192.168.56.56"
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = 2048
+    vb.cpus = 1
+  end
+
+  # Disable default synced folder at /vagrant, instead put at /opt/meza
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+  config.vm.synced_folder ".", "/opt/meza"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  config.vm.provision "shell", inline: <<-SHELL
+    bash /opt/meza/src/scripts/getmeza.sh
+    meza setup env monolith --fqdn=192.168.56.56 --db_pass=1234 --enable_email=true
+    meza deploy monolith
+  SHELL
+
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,9 +37,12 @@ Vagrant.configure("2") do |config|
   #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
   # end
 
-  config.vm.provision "shell", inline: <<-SHELL
+  config.vm.provision "setup", type: "shell", inline: <<-SHELL
     bash /opt/meza/src/scripts/getmeza.sh
     meza setup env monolith --fqdn=192.168.56.56 --db_pass=1234 --enable_email=true
+  SHELL
+
+  config.vm.provision "deploy", type: "shell", inline: <<-SHELL
     meza deploy monolith
   SHELL
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,7 +23,7 @@ Vagrant.configure("2") do |config|
 
   # Disable default synced folder at /vagrant, instead put at /opt/meza
   config.vm.synced_folder ".", "/vagrant", disabled: true
-  config.vm.synced_folder ".", "/opt/meza"
+  config.vm.synced_folder ".", "/opt/meza", type: "rsync", rsync__exclude: ".git/"
 
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on


### PR DESCRIPTION
Use Vagrant to initiate meza in VirtualBox:

1. Download and install [Git](https://git-scm.com/), [VirtualBox](https://www.virtualbox.org/), and [Vagrant](https://www.vagrantup.com/)
2. `git clone https://github.com/enterprisemediawiki/meza`
3. `cd meza`
4. `vagrant up` (Takes about 20-30 minutes)
5. Use meza at https://192.168.56.56
6. SSH into the machine by doing `vagrant ssh`

Documentation will come in a later PR after spending time using Vagrant with meza.