### PR TITLE
Allow MW and extensions on host to be rsynced to guest

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,7 +23,7 @@ Vagrant.configure("2") do |config|
 
   # Disable default synced folder at /vagrant, instead put at /opt/meza
   config.vm.synced_folder ".", "/vagrant", disabled: true
-  config.vm.synced_folder ".", "/opt/meza", type: "rsync", rsync__exclude: ".git/"
+  config.vm.synced_folder ".", "/opt/meza", type: "rsync"
 
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,7 +23,9 @@ Vagrant.configure("2") do |config|
 
   # Disable default synced folder at /vagrant, instead put at /opt/meza
   config.vm.synced_folder ".", "/vagrant", disabled: true
-  config.vm.synced_folder ".", "/opt/meza", type: "rsync"
+  config.vm.synced_folder ".", "/opt/meza", type: "rsync",
+    rsync__args: ["--verbose", "--archive", "--delete", "-z"]
+
 
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on


### PR DESCRIPTION
`vagrant up` now rsyncs the whole Vagrantfile directory into `/opt/meza` including `.git` directories and symlinks. This allows having MW and extensions in `htdocs/mediawiki` pre-cloned on the host, which will be transferred to the guest. This shaves several minutes off install.