### PR TITLE
Fix talkright permissions

### DIFF
--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -557,6 +557,8 @@ else if ( $mezaAuthType === 'anon-read' ) {
     $wgGroupPermissions['*']['edit'] = false;
     $wgGroupPermissions['user']['edit'] = true;
 
+	// do allow anonymous to edit talk pages
+	$wgGroupPermissions['*']['talk'] = true;
 }
 
 else if ( $mezaAuthType === 'user-edit' ) {
@@ -577,9 +579,10 @@ else if ( $mezaAuthType === 'user-read' ) {
     $wgGroupPermissions['*']['read'] = false;
     $wgGroupPermissions['*']['edit'] = false;
 
-    // users read NOT write
+    // users read NOT write, but can talk
     $wgGroupPermissions['user']['read'] = true;
     $wgGroupPermissions['user']['edit'] = false;
+    $wgGroupPermissions['user']['talk'] = true;
 
     $wgGroupPermissions['Contributor'] = $wgGroupPermissions['user'];
     $wgGroupPermissions['Contributor']['edit'] = true;
@@ -597,6 +600,7 @@ else if ( $mezaAuthType === 'viewer-read' ) {
     // create the Viewer group with read permissions
     $wgGroupPermissions['Viewer'] = $wgGroupPermissions['user'];
     $wgGroupPermissions['Viewer']['read'] = true;
+    $wgGroupPermissions['Viewer']['talk'] = true;
 
     // also explicitly give sysop read since you otherwise end up with
     // a chicken/egg situation prior to giving people Viewer


### PR DESCRIPTION
Extension:TalkRight permissions were not being set. Allow users who can view but not edit to be able to talk. This is replacing #452.