### PR TITLE
Add meza-ansible to groups wheel and apache

### DIFF
--- a/src/roles/apache-php/tasks/main.yml
+++ b/src/roles/apache-php/tasks/main.yml
@@ -12,6 +12,13 @@
     group: apache
     mode: 0775
 
+- name: Ensure user meza-ansible is in group "apache"
+  user:
+    name: meza-ansible
+    # add onto groups
+    groups: apache
+    append: yes
+
 # Check if there's a CA cert file in place, so the appropriate directives
 # can be added to httpd.conf if needed
 - name: Check if CA cert exists

--- a/src/roles/base/tasks/main.yml
+++ b/src/roles/base/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Ensure user meza-ansible in group "wheel"
+  user:
+    name: meza-ansible
+    # primary group
+    group: wheel
+
 - name: ensure deltarpm is installed and latest
   yum: name=deltarpm state=installed
 - name: upgrade all packages


### PR DESCRIPTION
In order for user `meza-ansible` to perform some actions it must be part of the groups "wheel" and "apache". This allows the user to perform actions without `sudo`. This particularly came into play when working on backups and imports where the meza-ansible user may be invoked outside of the normal Ansible methods.

Closes #510 