### PR TITLE
Add libselinux-python to getmeza.sh for initial conditions

### DIFF
--- a/src/scripts/getmeza.sh
+++ b/src/scripts/getmeza.sh
@@ -24,7 +24,7 @@ if [ ! -f "/etc/yum.repos.d/epel.repo" ]; then
 
 fi
 
-yum install -y git ansible
+yum install -y git ansible libselinux-python
 
 # if /opt/meza doesn't exist, clone into and use master branch (which is the
 # default, but should we make this configurable?)


### PR DESCRIPTION
Minimal install of CentOS and RHEL doesn't include SELinux. Currently [libselinux-python is explicitly installed before SELinux](https://github.com/enterprisemediawiki/meza/blob/a49d61a453acdeb3a917befd4931ec25eaa806de/src/roles/base/tasks/main.yml#L42) in role "base". This satisfies Ansible's requirements for SELinux. However, if SELinux is pre-installed on the system without libselinux-python then the following error occurs:

> Aborting, target uses selinux but python bindings (libselinux-python) aren't installed.

This PR fixes this by adding `yum install libselinux-python` to `getmeza.sh`.

Closes #509