### PR TITLE
Add deploy option to `vagrant up`

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -42,10 +42,22 @@ Vagrant.configure("2") do |config|
   config.vm.provision "setup", type: "shell", inline: <<-SHELL
     bash /opt/meza/src/scripts/getmeza.sh
   SHELL
-  # meza setup env monolith --fqdn=192.168.56.56 --db_pass=1234 --enable_email=true
 
-  # config.vm.provision "deploy", type: "shell", inline: <<-SHELL
-  #   meza deploy monolith
-  # SHELL
+  # Default is to run `meza deploy` command. Add environment variable to override
+  if not ENV["deploy"] || ENV["deploy"] == "basic"
+
+    config.vm.provision "deploy", type: "shell", inline: <<-SHELL
+      meza setup env monolith --fqdn=192.168.56.56 --db_pass=1234 --enable_email=true
+      meza deploy monolith
+    SHELL
+
+  # Could have option to get test configs enterprisemediawiki/meza-test-config
+  # and enterprisemediawiki/meza-test-config-secret, and backups from
+  # jamesmontalvo3/meza-test-backups, to bootstrap a test config. Also could
+  # have more involved installations with many well-developed wikis showcasing
+  # what is possible.
+  # elsif ENV["deploy"] == "test"
+
+  end
 
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -41,11 +41,11 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision "setup", type: "shell", inline: <<-SHELL
     bash /opt/meza/src/scripts/getmeza.sh
-    meza setup env monolith --fqdn=192.168.56.56 --db_pass=1234 --enable_email=true
   SHELL
+  # meza setup env monolith --fqdn=192.168.56.56 --db_pass=1234 --enable_email=true
 
-  config.vm.provision "deploy", type: "shell", inline: <<-SHELL
-    meza deploy monolith
-  SHELL
+  # config.vm.provision "deploy", type: "shell", inline: <<-SHELL
+  #   meza deploy monolith
+  # SHELL
 
 end


### PR DESCRIPTION
Adds a deploy option to `vagrant up` command via environment variable. Now you have to options:

1. `vagrant up` will deploy a basic monolithic installation
2. `deploy=none vagrant up` will just install the `meza` command and dependencies. This allows the user to then `vagrant ssh` to login and perform `sudo meza deploy monolith` or whatever other custom commands required. Note that the IP address `192.168.56.56` must be chosen.