### PR TITLE
Create init-containers.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ env:
     init: /usr/lib/systemd/systemd
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
     test_type: monolith_from_import
+  - docker_repo: jamesmontalvo3/meza-docker-test-max:latest
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    test_type: two_containers
+
   # - distro: centos6
   #   init: /sbin/init
   #   run_opts: ""

--- a/tests/travis/init-container.sh
+++ b/tests/travis/init-container.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+#
+#
+
+# Allow undefined vars just for this top part
+set +u
+
+# Set defaults before declaring now undefined variables
+if [ -z "$docker_repo" ]; then
+	docker_repo="jamesmontalvo3/meza-docker-test-max:latest"
+	echo "Using default docker_repo = $docker_repo"
+fi
+if [ -z "$init" ]; then
+	init="/usr/lib/systemd/systemd"
+	echo "Using default init = $init"
+fi
+if [ -z "$run_opts" ]; then
+	run_opts="--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+	echo "Using default run_opts = $run_opts"
+fi
+
+# If $host_mount_dir is defined, mount that dir as /opt/meza on the container.
+# If not, mount nothing. $meza_version must then be supplied, to git-clone that
+# version further down in this script
+if [ -z "$host_mount_dir" ]; then
+	docker_mount=""
+else
+	docker_mount="--volume=${host_mount_dir}:/opt/meza"
+fi
+
+# -e: kill script if anything fails
+# -u: don't allow undefined variables
+# -x: debug mode; print executed commands
+set -eux
+
+# Print git version that will be checked out. Since the -u option is set above,
+# this will cause an error if $meza_version is missing.
+if [ "$docker_mount" = "" ]; then
+	echo "Not mounting /opt/meza from host. Will git-clone meza version $meza_version"
+fi
+
+# Pull the docker image if not already present
+if [[ "$(docker images -q $docker_repo 2> /dev/null)" == "" ]]; then
+	echo "pulling image $docker_repo"
+	docker pull ${docker_repo}
+fi
+
+
+# SETUP CONTAINER
+# Run container in detached state, capture container ID
+container_id=$(mktemp)
+docker run --detach "$meza_mount" \
+	--add-host="localhost:127.0.0.1" ${run_opts} \
+	"${docker_repo}" "${init}" > "${container_id}"
+container_id=$(cat ${container_id})
+
+# Wrap all the `docker exec ...` in an array for clarity
+docker_exec=( docker exec --tty "$container_id" env TERM=xterm )
+
+# Make sure firewalld installed and docker0 interface is in zone public
+# Discovered thanks to https://github.com/docker/docker/issues/16137
+# Note this was only observed on Docker on Travis CI, not on Docker on a CentOS
+# or Ubuntu 14.04 host. Only tested on new version of Docker (docker-ce version
+# 17.something), whereas Travis is on 1.12.something.
+${docker_exec[@]} yum -y install firewalld
+${docker_exec[@]} systemctl start firewalld
+${docker_exec[@]} firewall-cmd --permanent --zone=public --change-interface=docker0
+
+# Docker image "jamesmontalvo3/meza-docker-test-max:latest" has mediawiki and
+# several extensions pre-cloned, but not in the correct location. Move them
+# into place. For some reason gives exit code 129 on Travis sometimes. Force
+# non-failing exit code.
+${docker_exec[@]} mv /opt/mediawiki /opt/meza/htdocs/mediawiki || true
+
+# If meza repo not mounted from host, clone it
+if [ "$docker_mount" = "" ]; then
+	${docker_exec[@]} git clone https://github.com/enterprisemediawiki/meza /opt/meza
+	${docker_exec[@]} git --git-dir=/opt/meza/.git checkout "$meza_version"
+fi
+
+# Install meza command
+${docker_exec[@]} bash /opt/meza/src/scripts/getmeza.sh

--- a/tests/travis/init-container.sh
+++ b/tests/travis/init-container.sh
@@ -49,7 +49,7 @@ fi
 # SETUP CONTAINER
 # Run container in detached state, capture container ID
 container_id=$(mktemp)
-docker run --detach "$docker_mount" \
+docker run --detach $docker_mount \
 	--add-host="localhost:127.0.0.1" ${run_opts} \
 	"${docker_repo}" "${init}" > "${container_id}"
 container_id=$(cat ${container_id})

--- a/tests/travis/init-container.sh
+++ b/tests/travis/init-container.sh
@@ -49,7 +49,7 @@ fi
 # SETUP CONTAINER
 # Run container in detached state, capture container ID
 container_id=$(mktemp)
-docker run --detach "$meza_mount" \
+docker run --detach "$docker_mount" \
 	--add-host="localhost:127.0.0.1" ${run_opts} \
 	"${docker_repo}" "${init}" > "${container_id}"
 container_id=$(cat ${container_id})
@@ -80,3 +80,6 @@ fi
 
 # Install meza command
 ${docker_exec[@]} bash /opt/meza/src/scripts/getmeza.sh
+
+# Get IP of docker image
+docker_ip=$(docker inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}" "$container_id")

--- a/tests/travis/run-tests.sh
+++ b/tests/travis/run-tests.sh
@@ -8,7 +8,7 @@ docker -v
 
 # Working directory in Travis is the GitHub repo, which is meza. Mount it.
 host_mount_dir="${PWD}"
-source /opt/meza/tests/travis/init-container.sh
+source ./tests/travis/init-container.sh
 
 # Get IP of docker image
 docker_ip=$(docker inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}" "$container_id")

--- a/tests/travis/run-tests.sh
+++ b/tests/travis/run-tests.sh
@@ -2,68 +2,13 @@
 #
 #
 
-# Set defaults before declaring now undefined variables
-if [ -z "$docker_repo" ]; then
-	docker_repo="jamesmontalvo3/meza-docker-test-max:latest"
-	echo "Using default docker_repo = $docker_repo"
-fi
-if [ -z "$init" ]; then
-	init="/usr/lib/systemd/systemd"
-	echo "Using default init = $init"
-fi
-if [ -z "$run_opts" ]; then
-	run_opts="--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-	echo "Using default run_opts = $run_opts"
-fi
-
-# -e: kill script if anything fails
-# -u: don't allow undefined variables
-# -x: debug mode; print executed commands
-set -eux
-
-# Pull the docker image if not already present
-if [[ "$(docker images -q $docker_repo 2> /dev/null)" == "" ]]; then
-	echo "pulling image $docker_repo"
-	docker pull ${docker_repo}
-fi
-
 # Report docker version just in case we run into issues in the future, and we
 # want to be able to track how things have changed
 docker -v
 
-# SETUP CONTAINER
-# Run container in detached state, capture container ID
-container_id=$(mktemp)
-docker run --detach --volume="${PWD}":/opt/meza \
-	--add-host="localhost:127.0.0.1" ${run_opts} \
-	"${docker_repo}" "${init}" > "${container_id}"
-container_id=$(cat ${container_id})
-
-# Wrap all the `docker exec ...` in an array for clarity
-docker_exec_lite=( docker exec "$container_id" )
-docker_exec=( docker exec --tty "$container_id" env TERM=xterm )
-
-# Capture args for cURLing for status codes
-curl_args=( curl --write-out %{http_code} --silent --output /dev/null )
-
-
-# Make sure firewalld installed and docker0 interface is in zone public
-# Discovered thanks to https://github.com/docker/docker/issues/16137
-# Note this was only observed on Docker on Travis CI, not on Docker on a CentOS
-# or Ubuntu 14.04 host. Only tested on new version of Docker (docker-ce version
-# 17.something), whereas Travis is on 1.12.something.
-${docker_exec[@]} yum -y install firewalld
-${docker_exec[@]} systemctl start firewalld
-${docker_exec[@]} firewall-cmd --permanent --zone=public --change-interface=docker0
-
-# Docker image "jamesmontalvo3/meza-docker-test-max:latest" has mediawiki and
-# several extensions pre-cloned, but not in the correct location. Move them
-# into place. For some reason gives exit code 129 on Travis sometimes. Force
-# non-failing exit code.
-${docker_exec[@]} mv /opt/mediawiki /opt/meza/htdocs/mediawiki || true
-
-# Install meza command
-${docker_exec[@]} bash /opt/meza/src/scripts/getmeza.sh
+# Working directory in Travis is the GitHub repo, which is meza. Mount it.
+host_mount_dir="${PWD}"
+source /opt/meza/tests/travis/init-container.sh
 
 # Get IP of docker image
 docker_ip=$(docker inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}" "$container_id")

--- a/tests/travis/run-tests.sh
+++ b/tests/travis/run-tests.sh
@@ -7,8 +7,7 @@
 docker -v
 
 # Working directory in Travis is the GitHub repo, which is meza. Mount it.
-host_mount_dir="${PWD}"
-source ./tests/travis/init-container.sh
+source ./tests/travis/init-container.sh "${PWD}" "mount"
 
 if [ "$test_type" == "monolith_from_scratch" ]; then
 
@@ -35,9 +34,7 @@ elif [ "$test_type" == "two_containers" ]; then
 
 	# Create a second container that needs to git-clone meza and checkout the
 	# same commit as Travis already has
-	host_mount_dir=""
-	meza_version="$TRAVIS_COMMIT"
-	source ./tests/travis/init-container.sh
+	source ./tests/travis/init-container.sh "${PWD}" "copy"
 
 	# Get vars and copy the docker exec command
 	container_id_2="$container_id"

--- a/tests/travis/run-tests.sh
+++ b/tests/travis/run-tests.sh
@@ -10,9 +10,6 @@ docker -v
 host_mount_dir="${PWD}"
 source ./tests/travis/init-container.sh
 
-# Get IP of docker image
-docker_ip=$(docker inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}" "$container_id")
-
 if [ "$test_type" == "monolith_from_scratch" ]; then
 
 	${docker_exec[@]} bash /opt/meza/tests/travis/monolith-from-scratch.sh "$docker_ip"
@@ -23,6 +20,39 @@ elif [ "$test_type" == "monolith_from_import" ]; then
 	${docker_exec[@]} ANSIBLE_CONFIG=/opt/meza/config/core/ansible.cfg ansible-playbook /opt/meza/src/playbooks/site.yml --syntax-check
 
 	${docker_exec[@]} bash /opt/meza/tests/travis/monolith-from-import.sh "$docker_ip"
+
+elif [ "$test_type" == "two_containers" ]; then
+
+	# Get vars and copy the docker exec command from first container
+	container_id_1="$container_id"
+	docker_ip_1="$docker_ip"
+	docker_exec_1=( "${docker_exec[@]}" )
+
+	echo
+	echo "First container id: $container_id_1"
+	echo "First container IP address: $docker_ip_1"
+	echo
+
+	# Create a second container that needs to git-clone meza and checkout the
+	# same commit as Travis already has
+	host_mount_dir=""
+	meza_version="$TRAVIS_COMMIT"
+	source ./tests/travis/init-container.sh
+
+	# Get vars and copy the docker exec command
+	container_id_2="$container_id"
+	docker_ip_2="$docker_ip"
+	docker_exec_2=( "${docker_exec[@]}" )
+
+	echo
+	echo "Second container id: $container_id_2"
+	echo "Second container IP address: $docker_ip_2"
+	echo
+
+	# Note: both of these git commands should be replaced by `meza --version`
+	#       but that is having issues as of this time (Issue #527)
+	${docker_exec_1[@]} git --git-dir=/opt/meza/.git describe --tags
+	${docker_exec_2[@]} git --git-dir=/opt/meza/.git describe --tags
 
 else
 	echo "Bad test type: $test_type"


### PR DESCRIPTION
Take components of `run-tests.sh` that were used to build Docker containers and generalize into a new script `init-container.sh`. This can now be used to build containers on any machine or build multiple containers on Travis.

Also creates a new Travis job that tests creating multiple containers.