### PR TITLE
Fix really long delay in syncing configs due to also syncing .git directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,15 @@
 .DS_Store
 config/config.local.sh
 
-config/local-secret
-config/local-public
-config/local_app
+# Ignore all files or directories starting with local, as the
+# place that users will modify their local meza configuration
+config/local*
+
+# Ignore all files or directories in the core directory that
+# start with app. These files/dirs are configuration written
+# by the meza application based upon inputs from core and
+# local user settings
+config/core/app*
 
 # data directory used to hold MariaDB and Elasticsearch data
 # which should not be added to this repo. However, there are

--- a/config/core/app-ansible/README.md
+++ b/config/core/app-ansible/README.md
@@ -1,0 +1,4 @@
+app-ansible config directory
+============================
+
+Config files written by Ansible which need a place to live, and cannot be written to places like `/etc/parsoid` or `/opt/meza/htdocs/mediawiki`. The first file this was created for was Extensions.php, which is written by Ansible based upon MezaCoreExtensions.yml and MezaLocalExtensions.yml, but cannot be written to the same app config directory as PHP files rsynced from /opt/meza/config/local-public, because the rsync action would eliminate them.

--- a/config/core/app-ansible/README.md
+++ b/config/core/app-ansible/README.md
@@ -2,3 +2,4 @@ app-ansible config directory
 ============================
 
 Config files written by Ansible which need a place to live, and cannot be written to places like `/etc/parsoid` or `/opt/meza/htdocs/mediawiki`. The first file this was created for was Extensions.php, which is written by Ansible based upon MezaCoreExtensions.yml and MezaLocalExtensions.yml, but cannot be written to the same app config directory as PHP files rsynced from /opt/meza/config/local-public, because the rsync action would eliminate them.
+

--- a/config/core/paths.yml
+++ b/config/core/paths.yml
@@ -10,6 +10,10 @@ m_local_secret: /opt/meza/config/local-secret
 m_local_public: /opt/meza/config/local-public
 m_local_app: /opt/meza/config/local_app
 
+# Config files written by Ansible which need a place to live. See README.md in
+# this directory for more info.
+m_config_app_ansible: /opt/meza/config/core/app-ansible
+
 # scripts dir
 m_scripts: /opt/meza/src/scripts
 

--- a/src/roles/base/tasks/main.yml
+++ b/src/roles/base/tasks/main.yml
@@ -62,6 +62,7 @@
     - selinux-policy
     - rsyslog
     - jq
+    - tree
 - name: put SELinux in permissive mode
   selinux:
     policy: targeted

--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -87,7 +87,7 @@
 - name: Ensure Extensions.php in place
   template:
     src: Extensions.php.j2
-    dest: "{{ m_local_app }}/Extensions.php"
+    dest: "{{ m_config_app_ansible }}/Extensions.php"
 
 # Adds extensions with composer param from MezaCoreExtensions.yml and
 # MezaLocalExtensions.yml

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -623,7 +623,7 @@ else if ( $mezaAuthType === 'viewer-read' ) {
  *  below.
  */
 
-require_once "{{ m_local_app }}/Extensions.php";
+require_once "{{ m_config_app_ansible }}/Extensions.php";
 
 
 /**

--- a/src/roles/sync-configs/tasks/main.yml
+++ b/src/roles/sync-configs/tasks/main.yml
@@ -32,6 +32,9 @@
     force: yes
   register: app_server_config
 
+- name: "Print directory info for {{ m_local_app }}"
+  shell: "tree -aCugp {{ m_local_app }}"
+
 # The commands above seemed to be putting the files in m_local_app without
 # properly setting` file modes. This does a recursive setting of those modes.
 - name: Ensure app servers local config directory and contents configured
@@ -46,4 +49,7 @@
   #   mode: 0755
   #   recurse: yes
   when: app_server_config.changed
+
+- name: "Print directory info for {{ m_local_app }}"
+  shell: "tree -aCugp {{ m_local_app }}"
 

--- a/src/roles/sync-configs/tasks/main.yml
+++ b/src/roles/sync-configs/tasks/main.yml
@@ -30,16 +30,20 @@
     group: root
     mode: 755
     force: yes
+  register: app_server_config
 
 # The commands above seemed to be putting the files in m_local_app without
 # properly setting` file modes. This does a recursive setting of those modes.
 - name: Ensure app servers local config directory and contents configured
-  file:
-    path: "{{ m_local_app }}"
-    state: directory
-    owner: root
-    group: root
-    mode: 0755
-    recurse: yes
-
+  shell: |
+    chown -R root:root {{ m_local_app }}
+    chmod -R 0755 {{ m_local_app }}
+  # file:
+  #   path: "{{ m_local_app }}"
+  #   state: directory
+  #   owner: root
+  #   group: root
+  #   mode: 0755
+  #   recurse: yes
+  when: app_server_config.changed
 

--- a/src/roles/sync-configs/tasks/main.yml
+++ b/src/roles/sync-configs/tasks/main.yml
@@ -9,52 +9,26 @@
     mode: 0755
     recurse: yes
 
-
-# # Ensure nothing in app servers m_local, to make sure it gets a clean copy from
-# # controller
-# - name: Empty m_local on app servers (not idempotent)
-#   file:
-#     state: absent
-#     path: "{{ m_local }}/"
-
 # At this point the controller must have a local config. Now force it upon the
 # app servers.
 # This is run on all app servers (assuming conditions apply)
 - name: Ensure app servers have config from controller
-  copy:
-    # trailing slash means CONTENTS of m_local on controller will be copied
-    # into already existing m_local directory on app servers
+  synchronize:
     src: "{{ m_local_public }}/"
     dest: "{{ m_local_app }}"
-    owner: root
-    group: root
-    mode: 755
-    force: yes
-  register: app_server_config
-
-- name: "Print directory info for {{ m_local_app }}"
-  shell: "tree -aCugp {{ m_local_app }}"
-  register: treeoutput
-
-- debug: { msg: "{{treeoutput.stdout}}" }
+    recursive: yes
+    delete: yes
+    rsync_opts:
+      - "--no-motd"
+      - "--exclude=.git"
 
 # The commands above seemed to be putting the files in m_local_app without
 # properly setting` file modes. This does a recursive setting of those modes.
 - name: Ensure app servers local config directory and contents configured
-  shell: |
-    chown -R root:root {{ m_local_app }}
-    chmod -R 0755 {{ m_local_app }}
-  # file:
-  #   path: "{{ m_local_app }}"
-  #   state: directory
-  #   owner: root
-  #   group: root
-  #   mode: 0755
-  #   recurse: yes
-  when: app_server_config.changed
-
-- name: "Print directory info for {{ m_local_app }}"
-  shell: "tree -aCugp {{ m_local_app }}"
-  register: treeoutput
-
-- debug: { msg: "{{treeoutput.stdout}}" }
+  file:
+    path: "{{ m_local_app }}"
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+    recurse: yes

--- a/src/roles/sync-configs/tasks/main.yml
+++ b/src/roles/sync-configs/tasks/main.yml
@@ -34,6 +34,9 @@
 
 - name: "Print directory info for {{ m_local_app }}"
   shell: "tree -aCugp {{ m_local_app }}"
+  register: treeoutput
+
+- debug: { msg: "{{treeoutput.stdout}}" }
 
 # The commands above seemed to be putting the files in m_local_app without
 # properly setting` file modes. This does a recursive setting of those modes.
@@ -52,4 +55,6 @@
 
 - name: "Print directory info for {{ m_local_app }}"
   shell: "tree -aCugp {{ m_local_app }}"
+  register: treeoutput
 
+- debug: { msg: "{{treeoutput.stdout}}" }

--- a/tests/travis/run-tests.sh
+++ b/tests/travis/run-tests.sh
@@ -48,8 +48,8 @@ elif [ "$test_type" == "two_containers" ]; then
 
 	# Note: both of these git commands should be replaced by `meza --version`
 	#       but that is having issues as of this time (Issue #527)
-	${docker_exec_1[@]} git --git-dir=/opt/meza/.git describe --tags
-	${docker_exec_2[@]} git --git-dir=/opt/meza/.git describe --tags
+	${docker_exec_1[@]} git --git-dir=/opt/meza/.git rev-parse HEAD
+	${docker_exec_2[@]} git --git-dir=/opt/meza/.git rev-parse HEAD
 
 else
 	echo "Bad test type: $test_type"


### PR DESCRIPTION
Use rsync (with option to exclude `.git` directories) to transfer config from controller to app servers. Without this, the transfer of `.git` directory contents was taking 3.5 minutes if the `local-public` directory was a git repository. Changing to rsync (Ansible `synchronize`) with the `delete: yes` option also ensures that any files that are removed from the config do not continue to reside on app servers. However, this change made it so `Extensions.php`, which is an Ansible-generated file not originating from `local-public`, was being overwritten by the rsync-delete. Instead it is now placed in `config/core/app-ansible`.

Also changed `run-test.sh` for the 2-Docker-container test to change `git describe --tags` to `git rev-parse HEAD`. `describe --tags` fails if no tags present, and for some reason one particular commit just doesn't appear to be picking up tags in Travis. Other commits do see the tags, even on the same branch, and even the Pull Request Travis job directly associated with the commit-job that's failing.