### PR TITLE
Fix branch checkout for travis PRs

### DIFF
--- a/tests/travis/git-setup.sh
+++ b/tests/travis/git-setup.sh
@@ -27,7 +27,7 @@ cd /opt/meza
 git fetch origin
 if [ "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then
 	git checkout "$TRAVIS_BRANCH"
-	git merge "TRAVIS_PULL_REQUEST_BRANCH" || true
+	git merge "$TRAVIS_PULL_REQUEST_BRANCH" || true
 	git status
 	echo
 	echo "rev-parse HEAD:"


### PR DESCRIPTION
Missing `$` on variable when checking out branch. This created a chicken-vs-egg situation for following pull requests, not allowing them to checkout the appropriate branch.