### PR TITLE
Fix travis merging of pull request tests

### DIFF
--- a/tests/travis/git-setup.sh
+++ b/tests/travis/git-setup.sh
@@ -27,7 +27,7 @@ cd /opt/meza
 git fetch origin
 if [ "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then
 	git checkout "$TRAVIS_BRANCH"
-	git merge "$TRAVIS_PULL_REQUEST_BRANCH" || true
+	git merge "origin/$TRAVIS_PULL_REQUEST_BRANCH" || true
 	git status
 	echo
 	echo "rev-parse HEAD:"


### PR DESCRIPTION
Need to do `git merge origin/branchname`, not just `git merge branchname`, when performing required merge for Travis CI pull request tests.