### PR TITLE
Allow pulling database/uploads from alternate sources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   - test_type: monolith-from-import
   - test_type: import-from-remote
   - test_type: backup-to-remote
+  - test_type: import-from-alt-remote
 
 # before_install:
   # To upgrade Docker, uncomment the following lines. Do this only if there are

--- a/src/playbooks/site.yml
+++ b/src/playbooks/site.yml
@@ -10,6 +10,46 @@
     shell: passwd --delete meza-ansible
     ignore_errors: yes
 
+  - name: Ensure controller has user alt-meza-ansible
+    user:
+      name: alt-meza-ansible
+      # primary group
+      group: wheel
+
+  - name: Ensure user alt-meza-ansible .ssh dir configured
+    file:
+      path: "/home/alt-meza-ansible/.ssh"
+      owner: alt-meza-ansible
+      group: wheel
+      mode: 0700
+      state: directory
+
+  - name: Copy meza-ansible keys to alt-meza-ansible
+    copy:
+      src: "/home/meza-ansible/.ssh/{{ item }}"
+      dest: "/home/alt-meza-ansible/.ssh/{{ item }}"
+      owner: alt-meza-ansible
+      group: wheel
+      mode: "{{ item.mode }}"
+    with_items:
+    - name: id_rsa
+      mode: "0600"
+    - name: id_rsa.pub
+      mode: "0644"
+
+  - name: Copy meza-ansible known_hosts to alt-meza-ansible
+    copy:
+      src: "/home/meza-ansible/.ssh/{{ item }}"
+      dest: "/home/alt-meza-ansible/.ssh/{{ item }}"
+      owner: alt-meza-ansible
+      group: wheel
+      mode: "{{ item.mode }}"
+    ignore_errors: True
+    with_items:
+    - name: known_hosts
+      mode: "0600"
+
+
 # Ensure proper base setup on all servers in inventory, with the exception of
 # servers in "exclude-all" group. At present, the intent of this group is to
 # allow servers which serve as sources for database and user-uploaded files,

--- a/src/playbooks/site.yml
+++ b/src/playbooks/site.yml
@@ -26,8 +26,8 @@
 
   - name: Copy meza-ansible keys to alt-meza-ansible
     copy:
-      src: "/home/meza-ansible/.ssh/{{ item }}"
-      dest: "/home/alt-meza-ansible/.ssh/{{ item }}"
+      src: "/home/meza-ansible/.ssh/{{ item.name }}"
+      dest: "/home/alt-meza-ansible/.ssh/{{ item.name }}"
       owner: alt-meza-ansible
       group: wheel
       mode: "{{ item.mode }}"
@@ -39,8 +39,8 @@
 
   - name: Copy meza-ansible known_hosts to alt-meza-ansible
     copy:
-      src: "/home/meza-ansible/.ssh/{{ item }}"
-      dest: "/home/alt-meza-ansible/.ssh/{{ item }}"
+      src: "/home/meza-ansible/.ssh/{{ item.name }}"
+      dest: "/home/alt-meza-ansible/.ssh/{{ item.name }}"
       owner: alt-meza-ansible
       group: wheel
       mode: "{{ item.mode }}"

--- a/src/playbooks/site.yml
+++ b/src/playbooks/site.yml
@@ -10,7 +10,11 @@
     shell: passwd --delete meza-ansible
     ignore_errors: yes
 
-- hosts: all
+# Ensure proper base setup on all servers in inventory, with the exception of
+# servers in "exclude-all" group. At present, the intent of this group is to
+# allow servers which serve as sources for database and user-uploaded files,
+# but are not managed by this meza install.
+- hosts: all:!exclude-all
   become: yes
   roles:
     - set-vars

--- a/src/roles/apache-php/tasks/main.yml
+++ b/src/roles/apache-php/tasks/main.yml
@@ -12,12 +12,15 @@
     group: apache
     mode: 0775
 
-- name: Ensure user meza-ansible is in group "apache"
+- name: Ensure user meza-ansible and alt-meza-ansible in group "apache"
   user:
-    name: meza-ansible
+    name: "{{ item }}"
     # add onto groups
     groups: apache
     append: yes
+  with_items:
+  - meza-ansible
+  - alt-meza-ansible
 
 # Check if there's a CA cert file in place, so the appropriate directives
 # can be added to httpd.conf if needed

--- a/src/roles/base/tasks/main.yml
+++ b/src/roles/base/tasks/main.yml
@@ -42,7 +42,7 @@
 # Add line to visudo file if it does not exist
 - name: Ensure alt-meza-ansible is passwordless sudoer
   lineinfile:
-    path: /etc/sudoers
+    dest: /etc/sudoers
     state: present
     line: 'alt-meza-ansible ALL=(ALL) NOPASSWD: ALL'
     validate: 'visudo -cf %s'

--- a/src/roles/base/tasks/main.yml
+++ b/src/roles/base/tasks/main.yml
@@ -16,19 +16,8 @@
     mode: 0700
     state: directory
 
-- shell: ls -la /home
-  register: home_dir
-  ignore_errors: true
-- shell: ls -la /home/alt-meza-ansible
-  register: user_dir
-  ignore_errors: true
-- shell: ls -la /home/alt-meza-ansible/.ssh
-  register: ssh_dir
-  ignore_errors: true
-
-- debug: { var: home_dir }
-- debug: { var: user_dir }
-- debug: { var: ssh_dir }
+- name: Copy meza-ansible authorized_keys to alt-meza-ansible
+  shell: cp /home/meza-ansible/.ssh/authorized_keys /home/alt-meza-ansible/.ssh/authorized_keys
 
 - name: Ensure user meza-ansible and alt-meza-ansible authorized_keys configured
   file:

--- a/src/roles/base/tasks/main.yml
+++ b/src/roles/base/tasks/main.yml
@@ -16,6 +16,20 @@
     mode: 0700
     state: directory
 
+- shell: ls -la /home
+  register: home_dir
+  ignore_errors: true
+- shell: ls -la /home/alt-meza-ansible
+  register: user_dir
+  ignore_errors: true
+- shell: ls -la /home/alt-meza-ansible/.ssh
+  register: ssh_dir
+  ignore_errors: true
+
+- debug: { var: home_dir }
+- debug: { var: user_dir }
+- debug: { var: ssh_dir }
+
 - name: Ensure user meza-ansible and alt-meza-ansible authorized_keys configured
   file:
     path: "/home/{{ item }}/.ssh/authorized_keys"

--- a/src/roles/base/tasks/main.yml
+++ b/src/roles/base/tasks/main.yml
@@ -8,7 +8,15 @@
   - meza-ansible
   - alt-meza-ansible
 
-- name: Ensure user meza-ansible authorized_keys configured
+- name: Ensure user alt-meza-ansible .ssh dir configured
+  file:
+    path: "/home/alt-meza-ansible/.ssh"
+    owner: alt-meza-ansible
+    group: wheel
+    mode: 0700
+    state: directory
+
+- name: Ensure user meza-ansible and alt-meza-ansible authorized_keys configured
   file:
     path: "/home/{{ item }}/.ssh/authorized_keys"
     owner: "{{ item }}"

--- a/src/roles/base/tasks/main.yml
+++ b/src/roles/base/tasks/main.yml
@@ -1,16 +1,40 @@
 ---
-- name: Ensure user meza-ansible in group "wheel"
+- name: Ensure user's meza-ansible and alt-meza-ansible in group "wheel"
   user:
-    name: meza-ansible
+    name: "{{ item }}"
     # primary group
     group: wheel
+  with_items:
+  - meza-ansible
+  - alt-meza-ansible
 
 - name: Ensure user meza-ansible authorized_keys configured
   file:
-    path: /home/meza-ansible/.ssh/authorized_keys
-    owner: meza-ansible
+    path: "/home/{{ item }}/.ssh/authorized_keys"
+    owner: "{{ item }}"
     group: wheel
     mode: 0644
+  with_items:
+  - meza-ansible
+  - alt-meza-ansible
+
+- name: Set authorized key for alt-meza-ansible
+  authorized_key:
+    user: alt-meza-ansible
+    state: present
+    key: "{{ lookup('file', '/home/meza-ansible/.ssh/id_rsa.pub') }}"
+
+- name: Ensure no password on alt-meza-ansible user
+  shell: passwd --delete alt-meza-ansible
+  ignore_errors: yes
+
+# Add line to visudo file if it does not exist
+- name: Ensure alt-meza-ansible is passwordless sudoer
+  lineinfile:
+    path: /etc/sudoers
+    state: present
+    line: 'alt-meza-ansible ALL=(ALL) NOPASSWD: ALL'
+    validate: 'visudo -cf %s'
 
 - name: ensure deltarpm is installed and latest
   yum: name=deltarpm state=installed

--- a/src/roles/grant-keys/tasks/main.yml
+++ b/src/roles/grant-keys/tasks/main.yml
@@ -7,6 +7,7 @@
     group: wheel
     mode: "{{ item.mode }}"
   delegate_to: "{{ grant_keys_to_server }}"
+  remote_user: "{{ alt_remote_user }}"
   with_items:
   - file: id_rsa
     mode: "0600"
@@ -25,4 +26,5 @@
     group: wheel
     mode: "0644"
   delegate_to: "{{ grant_keys_to_server }}"
+  remote_user: "{{ alt_remote_user }}"
   ignore_errors: True

--- a/src/roles/grant-keys/tasks/main.yml
+++ b/src/roles/grant-keys/tasks/main.yml
@@ -2,8 +2,8 @@
 - name: "Grant keys to delegated server {{ grant_keys_to_server }}"
   copy:
     src: "/home/meza-ansible/.ssh/{{ item.file }}"
-    dest: "/home/alt-meza-ansible/.ssh/{{ item.file }}"
-    owner: alt-meza-ansible
+    dest: "/home/{{ alt_remote_user }}/.ssh/{{ item.file }}"
+    owner: "{{ alt_remote_user }}"
     group: wheel
     mode: "{{ item.mode }}"
   delegate_to: "{{ grant_keys_to_server }}"
@@ -21,8 +21,8 @@
 - name: "Copy known_hosts to delegated server {{ grant_keys_to_server }}"
   copy:
     src: "/home/meza-ansible/.ssh/known_hosts"
-    dest: "/home/alt-meza-ansible/.ssh/known_hosts"
-    owner: alt-meza-ansible
+    dest: "/home/{{ alt_remote_user }}/.ssh/known_hosts"
+    owner: "{{ alt_remote_user }}"
     group: wheel
     mode: "0644"
   delegate_to: "{{ grant_keys_to_server }}"

--- a/src/roles/grant-keys/tasks/main.yml
+++ b/src/roles/grant-keys/tasks/main.yml
@@ -2,8 +2,8 @@
 - name: "Grant keys to delegated server {{ grant_keys_to_server }}"
   copy:
     src: "/home/meza-ansible/.ssh/{{ item.file }}"
-    dest: "/home/meza-ansible/.ssh/{{ item.file }}"
-    owner: meza-ansible
+    dest: "/home/alt-meza-ansible/.ssh/{{ item.file }}"
+    owner: alt-meza-ansible
     group: wheel
     mode: "{{ item.mode }}"
   delegate_to: "{{ grant_keys_to_server }}"
@@ -20,8 +20,8 @@
 - name: "Copy known_hosts to delegated server {{ grant_keys_to_server }}"
   copy:
     src: "/home/meza-ansible/.ssh/known_hosts"
-    dest: "/home/meza-ansible/.ssh/known_hosts"
-    owner: meza-ansible
+    dest: "/home/alt-meza-ansible/.ssh/known_hosts"
+    owner: alt-meza-ansible
     group: wheel
     mode: "0644"
   delegate_to: "{{ grant_keys_to_server }}"

--- a/src/roles/revoke-keys/tasks/main.yml
+++ b/src/roles/revoke-keys/tasks/main.yml
@@ -4,6 +4,7 @@
     path: "/home/alt-meza-ansible/.ssh/{{ item }}"
     state: absent
   delegate_to: "{{ revoke_keys_from_server }}"
+  remote_user: "{{ alt_remote_user }}"
   with_items:
   - id_rsa
   - id_rsa.pub

--- a/src/roles/revoke-keys/tasks/main.yml
+++ b/src/roles/revoke-keys/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Revoke keys from delegated server {{ revoke_keys_from_server }}"
   file:
-    path: "/home/alt-meza-ansible/.ssh/{{ item }}"
+    path: "/home/{{ alt_remote_user }}/.ssh/{{ item }}"
     state: absent
   delegate_to: "{{ revoke_keys_from_server }}"
   remote_user: "{{ alt_remote_user }}"

--- a/src/roles/revoke-keys/tasks/main.yml
+++ b/src/roles/revoke-keys/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Revoke keys from delegated server {{ revoke_keys_from_server }}"
   file:
-    path: "/home/meza-ansible/.ssh/{{ item }}"
+    path: "/home/alt-meza-ansible/.ssh/{{ item }}"
     state: absent
   delegate_to: "{{ revoke_keys_from_server }}"
   with_items:

--- a/src/roles/verify-wiki/tasks/init-wiki.yml
+++ b/src/roles/verify-wiki/tasks/init-wiki.yml
@@ -1,46 +1,21 @@
 ---
 
-- name: Update database
-  include_role:
-    name: update.php
 
-# Import pages required for SemanticMeetingMinutes and rebuild indices
+# Import pages required for SemanticMeetingMinutes and rebuild recent changes
 - name: import pages for SemanticMeetingMinutes
   shell: >
     WIKI="{{ wiki_id }}" php "{{ m_mediawiki }}/maintenance/importDump.php" --report --debug < {{ m_mediawiki }}/extensions/SemanticMeetingMinutes/ImportFiles/import.xml
   run_once: true
-
 - name: rebuildrecentchanges.php
   shell: >
     WIKI="{{ wiki_id }}" php "{{ m_mediawiki }}/maintenance/rebuildrecentchanges.php"
   run_once: true
 
-# Create an admin user for this demo wiki
+
+# Create an admin user for Demo Wiki only if the wiki was just created
 - name: Create "Admin" user on Demo Wiki
   shell: >
     WIKI="{{ wiki_id }}" php "{{ m_mediawiki }}/maintenance/createAndPromote.php" --force --custom-groups="sysop bureaucrat" Admin adminpass
   run_once: true
   when: wiki_id == "demo"
 
-- name: Run SMW's rebuildData.php
-  shell: >
-    WIKI="{{ wiki_id }}" php "{{ m_mediawiki }}/extensions/SemanticMediaWiki/maintenance/rebuildData.php"
-    -d 5 -v --ignore-exceptions --exception-log="{{ m_meza }}/logs/rebuilddata-exceptions-{{ wiki_id }}-.log"
-  run_once: true
-
-# Is this "disable search update" required at this point? I'm not sure why we'd do this
-# echo "\$wgDisableSearchUpdate = true;" >> "$m_htdocs/wikis/$wiki_id/config/postLocalSettings.php"
-- name: Run runJobs.php
-  shell: >
-    WIKI="{{ wiki_id }}" php "{{ m_mediawiki }}/maintenance/runJobs.php" --quick
-  run_once: true
-# sed -r -i 's/\$wgDisableSearchUpdate = true;//g;' "$m_htdocs/wikis/$wiki_id/config/postLocalSettings.php"
-
-# Generate ES index, since it is skipped in the initial create-wiki.sh
-# Ref: https://git.wikimedia.org/blob/mediawiki%2Fextensions%2FCirrusSearch.git/REL1_25/README
-- name: Running elastic-build-index.sh for demo wiki
-  shell: |
-    wiki_id="{{ wiki_id }}"
-    source "/opt/meza/config/core/config.sh"
-    source "{{ m_scripts }}/elastic-build-index.sh"
-  run_once: true

--- a/src/roles/verify-wiki/tasks/main.yml
+++ b/src/roles/verify-wiki/tasks/main.yml
@@ -59,7 +59,6 @@
   set_fact:
     sql_backup_server: "{{ groups['db-src'][0] }}"
     do_sql_dump: True
-    sql_dir_path: /home/meza-ansible
     sql_file_match: "wiki_{{ wiki_id }}.sql"
     sql_backup_server_set: True
   when: "'db-src' in groups and groups['db-src']|length|int > 0"
@@ -102,6 +101,11 @@
   when:
     sql_backup_server is defined
     and 'alt_remote_user' not in hostvars[sql_backup_server]
+
+- name: If doing a SQL dump, need to set path to SQL file based on remote user
+  set_fact:
+    sql_dir_path: "/home/{{ db_backup_server_remote_user }}"
+  when: do_sql_dump
 
 
 

--- a/src/roles/verify-wiki/tasks/main.yml
+++ b/src/roles/verify-wiki/tasks/main.yml
@@ -14,6 +14,7 @@
 #      - eventually need method to force-rsync from backup
 
 
+
 # Check if databases starting with "wiki_" exist
 #   if database exists: wiki_database.rc == 0
 #   if no database:  wiki_database.rc == 1
@@ -36,91 +37,6 @@
 
 
 
-# Logic for sourcing database:
-#
-# If db-src[0] exists:
-#     make dump
-#     pull dump onto db-master[0]
-# If backup-src[0] exists and backups_src_sql_path valid on server:
-#
-#
-#
-#
-#
-# If not backup exists (force-overwrite impossible):
-#     If wiki exists: DO BASICALLY NOTHING
-#     If not wiki exists: SOURCE WIKI FROM tables.sql
-#
-# If backup exists:
-#     If force-overwrite:
-#         If wiki exists: DROP DATABASE, THEN SOURCE FROM BACKUP
-#         If not wiki exists: SOURCE FROM BACKUP
-#
-#     If not force-overwrite:
-#         If wiki exists: DO BASICALLY NOTHING
-#         If not wiki exists: SOURCE WIKI FROM tables.sql
-#
-
-
-
-
-
-# WARNING: If you're using db-src and/or backups-src servers and DO NOT want
-#          this meza installation to attempt to alter those servers, also add
-#          them to the [exclude-all] group in your inventory file.
-#
-# Wiki database and uploads can be pulled from the `backup-servers` group or
-# can optionally come from either of the following if they are defined:
-#
-#   1. groups['db-src'][0]: Will pull directly from a mysql database on this
-#      server. Must also include db_src_mysql_user and db_src_mysql_pass vars.
-#
-#   2. groups['backups-src'][0]: Will pull database (if #1 above not defined)
-#      and uploads from this source. Requires the following to be defined:
-#
-#      a. backups_src_sql_path: Path to directory holding SQL file for a wiki.
-#         The wiki ID, if it is part of the path, should be indicated by `<id>`
-#         so the deploy script can properly set the ID at runtime. This path
-#         should ONLY SET THE DIRECTORY of the SQL file, not the filename
-#         itself, and should not end in a slash. If the filename does not match
-#         the pattern *.sql or includes the wiki ID in the filename, the can be
-#         set using backups_src_sql_file_match. See example 2 below.
-#
-#         ex1: backups_src_sql_path: /home/mw/backups/<id>
-#
-#              This will find the alphabetically-latest SQL file in the $1
-#              directory. Override the filename matching default of *.sql by
-#              setting the backups_src_sql_file_match var. See next example.
-#
-#         ex2: backups_src_sql_path: /home/mw/backups
-#              backups_src_sql_file_match: wiki_<id>*.sql
-#
-#              This will find the alphabetically latest file matching
-#              wiki_demo*.sql (if your wiki ID was "demo") in the
-#              /home/mw/backups directory
-#
-#      b. backups_src_uploads_path: Path to the directory holding uploads (AKA
-#         "images") for a given wiki ID. Make a placeholder for the wiki ID
-#         with a `<id>`, such that the deploy script can fill in the wiki ID at
-#         runtime. Do not end in a slash.
-#
-#         ex: backups_src_uploads_path: /opt/meza/htdocs/wikis/<id>/images
-#
-
-
-
-# Logic for sourcing database:
-#
-# If db-src[0] exists:
-#     make dump
-#     pull dump onto db-master[0]
-# If backup-src[0] exists and backups_src_sql_path valid on server:
-#
-
-
-
-
-
 #
 # Set facts to clarify if overwriting data is INITIALLY INTENDED (regardless of
 #  whether later checks make it possible)
@@ -135,8 +51,9 @@
     intend_overwrite_from_backup: False
   when: force_overwrite_from_backup is not defined or force_overwrite_from_backup == false
 
-
-
+- name: "Mark sql_backup_server_set as NOT SET yet"
+  set_fact:
+    sql_backup_server_set: False
 
 - name: "Set SQL source-from-backup facts IF SOURCING FROM db-src"
   set_fact:
@@ -144,15 +61,17 @@
     do_sql_dump: True
     sql_dir_path: /home/meza-ansible
     sql_file_match: "wiki_{{ wiki_id }}.sql"
+    sql_backup_server_set: True
   when: "'db-src' in groups and groups['db-src']|length|int > 0"
 
-- name: "Set SQL source-from-backup facts IF SOURCING FROM backups-src"
+- name: "Set SQL source-from-backup facts IF SOURCING FROM backup-src"
   set_fact:
     sql_backup_server: "{{ groups['backup-src'][0] }}"
     do_sql_dump: False
     sql_dir_path: "{{ backups_src_sql_path | regex_replace('<id>', wiki_id) }}"
-    sql_file_match: "{{ backups_src_sql_file_match | default('wiki*.sql') | regex_replace('<id>', wiki_id) }}"
-  when: "'backup-src' in groups and groups['backup-src']|length|int > 0"
+    sql_file_match: "{{ backups_src_sql_file_match | default('*.sql') | regex_replace('<id>', wiki_id) }}"
+    sql_backup_server_set: True
+  when: "not sql_backup_server_set and 'backup-src' in groups and groups['backup-src']|length|int > 0"
 
 - name: "Set SQL source-from-backup facts IF SOURCING FROM backup-servers"
   set_fact:
@@ -160,7 +79,8 @@
     do_sql_dump: False
     sql_dir_path: "{{ m_backups }}/{{ env }}/{{ wiki_id }}"
     sql_file_match: "*.sql"
-  when: "'backup-servers' in groups and groups['backup-servers']|length|int > 0"
+    sql_backup_server_set: True
+  when: "not sql_backup_server_set and 'backup-servers' in groups and groups['backup-servers']|length|int > 0"
 
 
 
@@ -194,6 +114,9 @@
     state: dump
     name: "wiki_{{ wiki_id }}"
     target: "{{ sql_dir_path }}/{{ sql_file_match }}"
+    # FIXME: Security issue?
+    login_user: "{{ db_src_mysql_user }}"
+    login_password: "{{ db_src_mysql_pass }}"
   delegate_to: "{{ sql_backup_server }}"
   run_once: true
   when: do_sql_dump
@@ -236,7 +159,6 @@
 
 
 
-
   #
   # Since backup-servers[0], master-db[0] and controller (localhost) are three
   # different servers, and the current Ansible play is being run against app-
@@ -275,7 +197,7 @@
     state: absent
     path: "{{ wiki_sql_file.stdout }}"
   delegate_to: "{{ sql_backup_server }}"
-  when: do_sql_dump
+  when: do_sql_dump and sql_file_exists
 
 - name: If wiki_sql_file NOT defined, send generic file to master db
   copy:
@@ -286,7 +208,7 @@
   delegate_to: "{{ groups['db-master'][0] }}"
   when: not sql_file_exists
 
-- name: Drop database if --force (or -f) set
+- name: Drop database if --overwrite (or -o) set
   mysql_db:
     name: "wiki_{{ wiki_id }}"
     state: absent
@@ -377,19 +299,27 @@
 
 
 
+#
+# Determine uploads server and required variables
+#
+- name: "Mark uploads_backup_server_set as NOT SET yet"
+  set_fact:
+    uploads_backup_server_set: False
 
-
-- name: "Set uploads-source-from-backup facts IF SOURCING FROM backups-src"
+- name: "Set uploads-source-from-backup facts IF SOURCING FROM backup-src"
   set_fact:
     uploads_backup_server: "{{ groups['backup-src'][0] }}"
     uploads_backup_dir_path: "{{ backups_src_uploads_path | regex_replace('<id>', wiki_id) }}"
+    uploads_backup_server_set: True
   when: "'backup-src' in groups and groups['backup-src']|length|int > 0"
 
 - name: "Set uploads-source-from-backup facts IF SOURCING FROM backup-servers"
   set_fact:
     uploads_backup_server: "{{ groups['backup-servers'][0] }}"
     uploads_backup_dir_path: "{{ m_backups }}/{{ env }}/{{ wiki_id }}/uploads"
-  when: "'backup-servers' in groups and groups['backup-servers']|length|int > 0"
+    uploads_backup_server_set: True
+  when: "not uploads_backup_server_set and 'backup-servers' in groups and groups['backup-servers']|length|int > 0"
+
 
 
 #
@@ -418,7 +348,9 @@
   when: not intend_overwrite_from_backup or not images_backup_dir.stat.exists
 
 
-
+#
+# Do the rsync transfer of files
+#
 - name: If no uploads dir, but backup dir exists, give backups.0 the keys
   include_role:
     name: grant-keys
@@ -455,8 +387,6 @@
     and uploads_backup_server != inventory_hostname
     # don't revoke keys if the backup server is the current server
 
-
-
 # Either way (existing backup or no) make sure uploads dir is configured
 - name: Ensure wiki's uploads dir is still configured properly
   file:
@@ -470,7 +400,11 @@
 
 
 
-
+#
+#
+# Do database and search index updates as required
+#
+#
 
 # Whether a new wiki was created or something was imported, run db update
 - name: Update database

--- a/src/roles/verify-wiki/tasks/main.yml
+++ b/src/roles/verify-wiki/tasks/main.yml
@@ -380,7 +380,7 @@
     ssh_args: "-l alt-meza-ansible"
   # server A
   delegate_to: "{{ uploads_backup_server }}"
-  become_user: alt-meza-ansible
+  remote_user: alt-meza-ansible
   when:
     images_backup_dir.stat.exists
     and (not wiki_has_uploads or do_overwrite_uploads_from_backup)

--- a/src/roles/verify-wiki/tasks/main.yml
+++ b/src/roles/verify-wiki/tasks/main.yml
@@ -370,6 +370,14 @@
     # copy to server B
     dest: "{{ m_uploads_dir }}/{{ wiki_id }}"
     recursive: yes
+
+    # Perhaps required due to not being able to properly specify an Ansible
+    # user in synchronize
+    # ref: https://github.com/ansible/ansible/issues/16215
+    #
+    # Potentially should use ssh_extra_args or ssh_common_args
+    # Ref: https://github.com/ansible/ansible/pull/15306
+    ssh_args: "-l alt-meza-ansible"
   # server A
   delegate_to: "{{ uploads_backup_server }}"
   become_user: alt-meza-ansible

--- a/src/roles/verify-wiki/tasks/main.yml
+++ b/src/roles/verify-wiki/tasks/main.yml
@@ -19,40 +19,222 @@
 #   if no database:  wiki_database.rc == 1
 - name: check if wiki database exists
   shell: 'mysqlshow "wiki_{{ wiki_id }}" | grep -v Wildcard | grep -o wiki_{{ wiki_id }}'
-  register: wiki_exists
+  register: wiki_exists_check
   delegate_to: "{{ groups['db-master'][0] }}"
   ignore_errors: yes
   run_once: true
 
-- debug: { msg: "Database wiki_{{ wiki_id }} DOES exist" }
-  when: wiki_exists is defined and wiki_exists.rc == 0
+- name: "Set fact if database wiki_{{ wiki_id }} DOES exist"
+  set_fact:
+    wiki_exists: True
+  when: wiki_exists_check is defined and wiki_exists_check.rc == 0
 
-- debug: { msg: "Database wiki_{{ wiki_id }} DOES NOT exist" }
-  when: wiki_exists is defined and wiki_exists.rc == 1
+- name: "Set fact if database wiki_{{ wiki_id }} DOES NOT exist"
+  set_fact:
+    wiki_exists: False
+  when: wiki_exists_check is defined and wiki_exists_check.rc != 0
+
+
+
+# Logic for sourcing database:
+#
+# If db-src[0] exists:
+#     make dump
+#     pull dump onto db-master[0]
+# If backup-src[0] exists and backups_src_sql_path valid on server:
+#
+#
+#
+#
+#
+# If not backup exists (force-overwrite impossible):
+#     If wiki exists: DO BASICALLY NOTHING
+#     If not wiki exists: SOURCE WIKI FROM tables.sql
+#
+# If backup exists:
+#     If force-overwrite:
+#         If wiki exists: DROP DATABASE, THEN SOURCE FROM BACKUP
+#         If not wiki exists: SOURCE FROM BACKUP
+#
+#     If not force-overwrite:
+#         If wiki exists: DO BASICALLY NOTHING
+#         If not wiki exists: SOURCE WIKI FROM tables.sql
+#
+
+
+
+
+
+# WARNING: If you're using db-src and/or backups-src servers and DO NOT want
+#          this meza installation to attempt to alter those servers, also add
+#          them to the [exclude-all] group in your inventory file.
+#
+# Wiki database and uploads can be pulled from the `backup-servers` group or
+# can optionally come from either of the following if they are defined:
+#
+#   1. groups['db-src'][0]: Will pull directly from a mysql database on this
+#      server. Must also include db_src_mysql_user and db_src_mysql_pass vars.
+#
+#   2. groups['backups-src'][0]: Will pull database (if #1 above not defined)
+#      and uploads from this source. Requires the following to be defined:
+#
+#      a. backups_src_sql_path: Path to directory holding SQL file for a wiki.
+#         The wiki ID, if it is part of the path, should be indicated by `<id>`
+#         so the deploy script can properly set the ID at runtime. This path
+#         should ONLY SET THE DIRECTORY of the SQL file, not the filename
+#         itself, and should not end in a slash. If the filename does not match
+#         the pattern *.sql or includes the wiki ID in the filename, the can be
+#         set using backups_src_sql_file_match. See example 2 below.
+#
+#         ex1: backups_src_sql_path: /home/mw/backups/<id>
+#
+#              This will find the alphabetically-latest SQL file in the $1
+#              directory. Override the filename matching default of *.sql by
+#              setting the backups_src_sql_file_match var. See next example.
+#
+#         ex2: backups_src_sql_path: /home/mw/backups
+#              backups_src_sql_file_match: wiki_<id>*.sql
+#
+#              This will find the alphabetically latest file matching
+#              wiki_demo*.sql (if your wiki ID was "demo") in the
+#              /home/mw/backups directory
+#
+#      b. backups_src_uploads_path: Path to the directory holding uploads (AKA
+#         "images") for a given wiki ID. Make a placeholder for the wiki ID
+#         with a `<id>`, such that the deploy script can fill in the wiki ID at
+#         runtime. Do not end in a slash.
+#
+#         ex: backups_src_uploads_path: /opt/meza/htdocs/wikis/<id>/images
+#
+
+
+
+# Logic for sourcing database:
+#
+# If db-src[0] exists:
+#     make dump
+#     pull dump onto db-master[0]
+# If backup-src[0] exists and backups_src_sql_path valid on server:
+#
+
+
+
+
 
 #
-# If wiki database does not exist
+# Set facts to clarify if overwriting data is INITIALLY INTENDED (regardless of
+#  whether later checks make it possible)
 #
+- name: "Set fact if INTEND overwrite data"
+  set_fact:
+    intend_overwrite_from_backup: True
+  when: force_overwrite_from_backup is defined and force_overwrite_from_backup == true
 
+- name: "Set fact if NOT INTEND overwrite data"
+  set_fact:
+    intend_overwrite_from_backup: False
+  when: force_overwrite_from_backup is not defined or force_overwrite_from_backup == false
+
+
+
+
+- name: "Set SQL source-from-backup facts IF SOURCING FROM db-src"
+  set_fact:
+    sql_backup_server: "{{ groups['db-src'][0] }}"
+    do_sql_dump: True
+    sql_dir_path: /home/meza-ansible
+    sql_file_match: "wiki_{{ wiki_id }}.sql"
+  when: "'db-src' in groups and groups['db-src']|length|int > 0"
+
+- name: "Set SQL source-from-backup facts IF SOURCING FROM backups-src"
+  set_fact:
+    sql_backup_server: "{{ groups['backup-src'][0] }}"
+    do_sql_dump: False
+    sql_dir_path: "{{ backups_src_sql_path | regex_replace('<id>', wiki_id) }}"
+    sql_file_match: "{{ backups_src_sql_file_match | default('wiki*.sql') | regex_replace('<id>', wiki_id) }}"
+  when: "'backup-src' in groups and groups['backup-src']|length|int > 0"
+
+- name: "Set SQL source-from-backup facts IF SOURCING FROM backup-servers"
+  set_fact:
+    sql_backup_server: "{{ groups['backup-servers'][0] }}"
+    do_sql_dump: False
+    sql_dir_path: "{{ m_backups }}/{{ env }}/{{ wiki_id }}"
+    sql_file_match: "*.sql"
+  when: "'backup-servers' in groups and groups['backup-servers']|length|int > 0"
+
+
+
+#
+# Check for backups directory
+#
 - name: Check if backups dir exists
   stat:
-    path: "{{ m_backups }}/{{ env }}/{{ wiki_id }}"
-  register: backups_dir
-  when: wiki_exists is defined and wiki_exists.rc == 1
-  delegate_to: "{{ groups['backup-servers'][0] }}"
+    path: "{{ sql_dir_path }}"
+  register: backups_dir_stat
+  delegate_to: "{{ sql_backup_server }}"
+  run_once: true
+
+- name: "Set fact if backups server DOES have {{ sql_dir_path }}"
+  set_fact:
+    backup_dir_exists: True
+  when: backups_dir_stat.stat.exists == true
+
+- name: "Set fact if backups server DOES NOT have {{ sql_dir_path }}"
+  set_fact:
+    backup_dir_exists: False
+  when: backups_dir_stat.stat.exists == false
+
+
+
+#
+# Dump SQL if required
+#
+- name: Dump SQL file from db-src
+  mysql_db:
+    state: dump
+    name: "wiki_{{ wiki_id }}"
+    target: "{{ sql_dir_path }}/{{ sql_file_match }}"
+  delegate_to: "{{ sql_backup_server }}"
+  run_once: true
+  when: do_sql_dump
+
 
 
 # This will find the latest sql file by name, or wiki.sql over any timestamped one
 # assuming timestamp-named files like 20170220000002_wiki.sql
 - name: Find SQL file if it exists
-  shell: 'find {{ m_backups }}/{{ env }}/{{ wiki_id }} -maxdepth 1 -type f -iname "*.sql" | sort -r | head -n +1'
+  shell: 'find {{ sql_dir_path }} -maxdepth 1 -type f -iname "{{ sql_file_match }}" | sort -r | head -n +1'
   register: wiki_sql_file
-  delegate_to: "{{ groups['backup-servers'][0] }}"
+  delegate_to: "{{ sql_backup_server }}"
   run_once: true
-  when:
-    wiki_exists is defined
-    and wiki_exists.rc == 1
-    and backups_dir.stat.exists == true
+  when: backup_dir_exists and (not wiki_exists or intend_overwrite_from_backup)
+
+- name: "Set fact if SQL file DOES exist"
+  set_fact:
+    sql_file_exists: True
+  when: wiki_sql_file is defined and wiki_sql_file.rc == 0
+
+- name: "Set fact if SQL file DOES NOT exist"
+  set_fact:
+    sql_file_exists: False
+  when: wiki_sql_file is not defined or wiki_sql_file.rc != 0
+
+
+
+#
+# Set facts to clarify if overwriting data should actually occur
+#
+- name: "Set fact if SHOULD overwrite data (only possible if backup exists)"
+  set_fact:
+    do_overwrite_db_from_backup: True
+  when: intend_overwrite_from_backup and sql_file_exists
+
+- name: "Set fact if SHOULD NOT overwrite data"
+  set_fact:
+    do_overwrite_db_from_backup: False
+  when: not intend_overwrite_from_backup or not sql_file_exists
+
+
 
 
   #
@@ -61,16 +243,14 @@
   # servers, there's no way to send from backup-servers[0] to master-db[0]
   # directly. Instead, pass to controller, then form controller to master-db
   #
-- name: if wiki_sql_file defined, FIRST remove preexisting SQL file from controller
+- name: if wiki_sql_file exists, FIRST remove preexisting SQL file from controller
   file:
     path: /tmp/controller-wiki.sql
     state: absent
   run_once: true
   delegate_to: localhost
-  when:
-    wiki_sql_file is defined
-    and wiki_sql_file.rc == 0
-- name: if wiki_sql_file defined, NEXT send SQL file to controller
+  when: sql_file_exists
+- name: if wiki_sql_file exists, NEXT send SQL file to controller
   fetch:
     src: "{{ wiki_sql_file.stdout }}"
     dest: /tmp/controller-wiki.sql
@@ -80,22 +260,22 @@
   # http://docs.ansible.com/ansible/fetch_module.html
   become: no
   run_once: true
-  delegate_to: "{{ groups['backup-servers'][0] }}"
-  when:
-    wiki_sql_file is defined
-    and wiki_sql_file.rc == 0
-- name: if wiki_sql_file defined, NEXT send file from controller to master-db
+  delegate_to: "{{ sql_backup_server }}"
+  when: sql_file_exists
+- name: if wiki_sql_file exists, NEXT send file from controller to master-db
   copy:
     src: /tmp/controller-wiki.sql
     dest: /tmp/wiki.sql
     force: yes
   run_once: true
   delegate_to: "{{ groups['db-master'][0] }}"
-  when:
-    wiki_sql_file is defined
-    and wiki_sql_file.rc == 0
-
-
+  when: sql_file_exists
+- name: If SQL was dumped from db-src, remove file now that it's on db-master
+  file:
+    state: absent
+    path: "{{ wiki_sql_file.stdout }}"
+  delegate_to: "{{ sql_backup_server }}"
+  when: do_sql_dump
 
 - name: If wiki_sql_file NOT defined, send generic file to master db
   copy:
@@ -104,9 +284,13 @@
     force: yes
   run_once: true
   delegate_to: "{{ groups['db-master'][0] }}"
-  when:
-    wiki_sql_file is not defined
-    or wiki_sql_file.rc != 0
+  when: not sql_file_exists
+
+- name: Drop database if --force (or -f) set
+  mysql_db:
+    name: "wiki_{{ wiki_id }}"
+    state: absent
+  when: do_overwrite_db_from_backup
 
 - name: Import SQL file
   mysql_db:
@@ -115,7 +299,7 @@
     target: /tmp/wiki.sql
   run_once: true
   delegate_to: "{{ groups['db-master'][0] }}"
-  when: wiki_exists is defined and wiki_exists.rc == 1
+  when: not wiki_exists or do_overwrite_db_from_backup
 
 - name: Remove SQL file from master DB
   file:
@@ -123,7 +307,15 @@
     state: absent
   run_once: true
   delegate_to: "{{ groups['db-master'][0] }}"
-  when: wiki_exists is defined and wiki_exists.rc == 1
+  when: not wiki_exists or do_overwrite_db_from_backup
+
+
+
+#
+#
+# Ensure access to logo and favicon
+#
+#
 
 
 #
@@ -151,54 +343,106 @@
 
 
 #
-# Make sure wiki's uploads directory is properly setup
 #
+# Handling file uploads
+#
+#
+
+
+# FIXME: This nees to be rectified for multiple app servers vs shared storage
+#        (e.g. on a SAN or other mount) vs GlusterFS.
 - name: Check if wiki's uploads dir exists ON APP SERVER
   stat:
     path: "{{ m_uploads_dir }}/{{ wiki_id }}"
   register: uploads_dir
-
-- name: Check if wiki's uploads backup dir exists on backups.0
-  stat:
-    path: "{{ m_backups }}/{{ env }}/{{ wiki_id }}/uploads"
-  register: images_backup_dir
-  delegate_to: "{{ groups['backup-servers'][0] }}"
-
-# Either way (existing backup or no) make sure uploads dir is configured
-- name: If no uploads dir, but backup dir exists, first make uploads dir
+# Either way (existing backup or no, existing uploads or no) make sure uploads
+# dir is configured
+- name: Ensure uploads dir configured
   file:
     path: "{{ m_uploads_dir }}/{{ wiki_id }}"
     state: directory
     mode: 0755
     owner: apache
     group: apache
-  when:
-    not uploads_dir.stat.exists
-    and images_backup_dir.stat.exists
+
+- name: "Set fact if wiki {{ wiki_id }} DOES HAVE uploads"
+  set_fact:
+    wiki_has_uploads: True
+  when: uploads_dir.stat.exists
+
+- name: "Set fact if wiki {{ wiki_id }} DOES NOT HAVE uploads"
+  set_fact:
+    wiki_has_uploads: False
+  when: not uploads_dir.stat.exists
+
+
+
+
+
+- name: "Set uploads-source-from-backup facts IF SOURCING FROM backups-src"
+  set_fact:
+    uploads_backup_server: "{{ groups['backup-src'][0] }}"
+    uploads_backup_dir_path: "{{ backups_src_uploads_path | regex_replace('<id>', wiki_id) }}"
+  when: "'backup-src' in groups and groups['backup-src']|length|int > 0"
+
+- name: "Set uploads-source-from-backup facts IF SOURCING FROM backup-servers"
+  set_fact:
+    uploads_backup_server: "{{ groups['backup-servers'][0] }}"
+    uploads_backup_dir_path: "{{ m_backups }}/{{ env }}/{{ wiki_id }}/uploads"
+  when: "'backup-servers' in groups and groups['backup-servers']|length|int > 0"
+
+
+#
+# Check if uploads backups exist on defined server
+#
+- name: Check if wiki's uploads backup dir exists on backups.0
+  stat:
+    path: "{{ uploads_backup_dir_path }}"
+  register: images_backup_dir
+  delegate_to: "{{ uploads_backup_server }}"
+  run_once: true
+
+
+
+#
+# Set facts to clarify if overwriting data should actually occur
+#
+- name: "Set fact if SHOULD overwrite uploads data (only possible if backup exists)"
+  set_fact:
+    do_overwrite_uploads_from_backup: True
+  when: intend_overwrite_from_backup and images_backup_dir.stat.exists
+
+- name: "Set fact if SHOULD NOT overwrite uploads data"
+  set_fact:
+    do_overwrite_uploads_from_backup: False
+  when: not intend_overwrite_from_backup or not images_backup_dir.stat.exists
+
+
 
 - name: If no uploads dir, but backup dir exists, give backups.0 the keys
   include_role:
     name: grant-keys
   vars:
-    grant_keys_to_server: "{{ groups['backup-servers'][0] }}"
+    grant_keys_to_server: "{{ uploads_backup_server }}"
   when:
-    not uploads_dir.stat.exists
-    and images_backup_dir.stat.exists
-    and groups['backup-servers'][0] != inventory_hostname
+    images_backup_dir.stat.exists
+    and (not wiki_has_uploads or do_overwrite_uploads_from_backup)
+    and uploads_backup_server != inventory_hostname
+    # don't grant keys if the backup server is the current server
 
 # copy from server A (backups.0) to server B (the app server in context)
 - name: If no uploads dir, but backup dir exists, copy from there
   synchronize:
     # copy from server A
-    src: "{{ m_backups }}/{{ env }}/{{ wiki_id }}/uploads/"
+    src: "{{ uploads_backup_dir_path }}/"
     # copy to server B
     dest: "{{ m_uploads_dir }}/{{ wiki_id }}"
     recursive: yes
   # server A
-  delegate_to: "{{ groups['backup-servers'][0] }}"
+  delegate_to: "{{ uploads_backup_server }}"
   when:
-    not uploads_dir.stat.exists
-    and images_backup_dir.stat.exists
+    images_backup_dir.stat.exists
+    and (not wiki_has_uploads or do_overwrite_uploads_from_backup)
 
 - name: If no uploads dir, but backup dir exists, revoke keys
   include_role:
@@ -206,13 +450,15 @@
   vars:
     revoke_keys_from_server: "{{ groups['backup-servers'][0] }}"
   when:
-    not uploads_dir.stat.exists
-    and images_backup_dir.stat.exists
+    images_backup_dir.stat.exists
+    and (not uploads_dir.stat.exists or do_overwrite_uploads_from_backup)
+    and uploads_backup_server != inventory_hostname
+    # don't revoke keys if the backup server is the current server
 
 
 
 # Either way (existing backup or no) make sure uploads dir is configured
-- name: Ensure wiki's uploads dir is configured
+- name: Ensure wiki's uploads dir is still configured properly
   file:
     path: "{{ m_uploads_dir }}/{{ wiki_id }}"
     state: directory
@@ -221,6 +467,46 @@
     group: apache
     # recursive?
 
-- name: Include init-wiki.yml only when a new wiki was created
+
+
+
+
+
+# Whether a new wiki was created or something was imported, run db update
+- name: Update database
+  include_role:
+    name: update.php
+  when: not wiki_exists or do_overwrite_db_from_backup
+
+
+- name: Include init-wiki.yml only when a new wiki created (but not imported)
   include: init-wiki.yml
-  when: wiki_exists is defined and wiki_exists.rc == 1
+  when: not wiki_exists and not sql_file_exists
+
+
+- name: Run SMW's rebuildData.php
+  shell: >
+    WIKI="{{ wiki_id }}" php "{{ m_mediawiki }}/extensions/SemanticMediaWiki/maintenance/rebuildData.php"
+    -d 5 -v --ignore-exceptions --exception-log="{{ m_meza }}/logs/rebuilddata-exceptions-{{ wiki_id }}-.log"
+  run_once: true
+  when: not wiki_exists or do_overwrite_db_from_backup
+
+
+# Is this "disable search update" required at this point? I'm not sure why we'd do this
+# echo "\$wgDisableSearchUpdate = true;" >> "$m_htdocs/wikis/$wiki_id/config/postLocalSettings.php"
+- name: Run runJobs.php
+  shell: >
+    WIKI="{{ wiki_id }}" php "{{ m_mediawiki }}/maintenance/runJobs.php" --quick
+  run_once: true
+  when: not wiki_exists or do_overwrite_db_from_backup
+# sed -r -i 's/\$wgDisableSearchUpdate = true;//g;' "$m_htdocs/wikis/$wiki_id/config/postLocalSettings.php"
+
+# Generate ES index, since it is skipped in the initial create-wiki.sh
+# Ref: https://git.wikimedia.org/blob/mediawiki%2Fextensions%2FCirrusSearch.git/REL1_25/README
+- name: Running elastic-build-index.sh for demo wiki
+  shell: |
+    wiki_id="{{ wiki_id }}"
+    source "/opt/meza/config/core/config.sh"
+    source "{{ m_scripts }}/elastic-build-index.sh"
+  run_once: true
+  when: not wiki_exists or do_overwrite_db_from_backup

--- a/src/roles/verify-wiki/tasks/main.yml
+++ b/src/roles/verify-wiki/tasks/main.yml
@@ -85,6 +85,27 @@
 
 
 #
+# Set remote user to access database backup
+#
+- name: Set fact for database backup server remote user IF ALTERNATE SPECIFIED
+  set_fact:
+    db_backup_server_remote_user: "{{ hostvars[sql_backup_server]['alt_remote_user'] }}"
+  when:
+    sql_backup_server is defined
+    and 'alt_remote_user' in hostvars[sql_backup_server]
+
+# Note: since not rsync-ing from one remote to another, can use meza-ansible
+# here instead of alt-meza-ansible
+- name: Set fact for database backup server remote user TO DEFAULT meza-ansible
+  set_fact:
+    db_backup_server_remote_user: "meza-ansible"
+  when:
+    sql_backup_server is defined
+    and 'alt_remote_user' not in hostvars[sql_backup_server]
+
+
+
+#
 # Check for backups directory
 #
 - name: Check if backups dir exists
@@ -92,6 +113,7 @@
     path: "{{ sql_dir_path }}"
   register: backups_dir_stat
   delegate_to: "{{ sql_backup_server }}"
+  remote_user: "{{ db_backup_server_remote_user }}"
   run_once: true
 
 - name: "Set fact if backups server DOES have {{ sql_dir_path }}"
@@ -118,6 +140,7 @@
     login_user: "{{ db_src_mysql_user }}"
     login_password: "{{ db_src_mysql_pass }}"
   delegate_to: "{{ sql_backup_server }}"
+  remote_user: "{{ db_backup_server_remote_user }}"
   run_once: true
   when: do_sql_dump
 
@@ -130,6 +153,7 @@
   register: wiki_sql_file
   delegate_to: "{{ sql_backup_server }}"
   run_once: true
+  remote_user: "{{ db_backup_server_remote_user }}"
   when: backup_dir_exists and (not wiki_exists or intend_overwrite_from_backup)
 
 - name: "Set fact if SQL file DOES exist"
@@ -172,6 +196,7 @@
   run_once: true
   delegate_to: localhost
   when: sql_file_exists
+
 - name: if wiki_sql_file exists, NEXT send SQL file to controller
   fetch:
     src: "{{ wiki_sql_file.stdout }}"
@@ -183,7 +208,9 @@
   become: no
   run_once: true
   delegate_to: "{{ sql_backup_server }}"
+  remote_user: "{{ db_backup_server_remote_user }}"
   when: sql_file_exists
+
 - name: if wiki_sql_file exists, NEXT send file from controller to master-db
   copy:
     src: /tmp/controller-wiki.sql
@@ -192,11 +219,13 @@
   run_once: true
   delegate_to: "{{ groups['db-master'][0] }}"
   when: sql_file_exists
+
 - name: If SQL was dumped from db-src, remove file now that it's on db-master
   file:
     state: absent
     path: "{{ wiki_sql_file.stdout }}"
   delegate_to: "{{ sql_backup_server }}"
+  remote_user: "{{ db_backup_server_remote_user }}"
   when: do_sql_dump and sql_file_exists
 
 - name: If wiki_sql_file NOT defined, send generic file to master db
@@ -212,6 +241,8 @@
   mysql_db:
     name: "wiki_{{ wiki_id }}"
     state: absent
+  run_once: true
+  delegate_to: "{{ groups['db-master'][0] }}"
   when: do_overwrite_db_from_backup
 
 - name: Import SQL file

--- a/src/roles/verify-wiki/tasks/main.yml
+++ b/src/roles/verify-wiki/tasks/main.yml
@@ -372,6 +372,7 @@
     recursive: yes
   # server A
   delegate_to: "{{ uploads_backup_server }}"
+  become_user: alt-meza-ansible
   when:
     images_backup_dir.stat.exists
     and (not wiki_has_uploads or do_overwrite_uploads_from_backup)

--- a/src/roles/verify-wiki/tasks/main.yml
+++ b/src/roles/verify-wiki/tasks/main.yml
@@ -321,6 +321,23 @@
   when: "not uploads_backup_server_set and 'backup-servers' in groups and groups['backup-servers']|length|int > 0"
 
 
+#
+# Set remote user to access uploads backup
+#
+- name: Set fact for uploads backup server remote user IF ALTERNATE SPECIFIED
+  set_fact:
+    uploads_backup_server_remote_user: "{{ hostvars[uploads_backup_server]['alt_remote_user'] }}"
+  when:
+    uploads_backup_server is defined
+    and 'alt_remote_user' in hostvars[uploads_backup_server]
+
+- name: Set fact for uploads backup server remote user TO DEFAULT alt-meza-ansible
+  set_fact:
+    uploads_backup_server_remote_user: "alt-meza-ansible"
+  when:
+    uploads_backup_server is defined
+    and 'alt_remote_user' not in hostvars[uploads_backup_server]
+
 
 #
 # Check if uploads backups exist on defined server
@@ -330,6 +347,7 @@
     path: "{{ uploads_backup_dir_path }}"
   register: images_backup_dir
   delegate_to: "{{ uploads_backup_server }}"
+  remote_user: "{{ uploads_backup_server_remote_user }}"
   run_once: true
 
 
@@ -356,6 +374,7 @@
     name: grant-keys
   vars:
     grant_keys_to_server: "{{ uploads_backup_server }}"
+    alt_remote_user: "{{ uploads_backup_server_remote_user }}"
   when:
     images_backup_dir.stat.exists
     and (not wiki_has_uploads or do_overwrite_uploads_from_backup)
@@ -380,7 +399,7 @@
     ssh_args: "-l meza-ansible"
   # server A
   delegate_to: "{{ uploads_backup_server }}"
-  remote_user: alt-meza-ansible
+  remote_user: "{{ uploads_backup_server_remote_user }}"
   when:
     images_backup_dir.stat.exists
     and (not wiki_has_uploads or do_overwrite_uploads_from_backup)
@@ -388,6 +407,7 @@
 - name: If no uploads dir, but backup dir exists, revoke keys
   include_role:
     name: revoke-keys
+    alt_remote_user: "{{ uploads_backup_server_remote_user }}"
   vars:
     revoke_keys_from_server: "{{ groups['backup-servers'][0] }}"
   when:

--- a/src/roles/verify-wiki/tasks/main.yml
+++ b/src/roles/verify-wiki/tasks/main.yml
@@ -141,8 +141,8 @@
     name: "wiki_{{ wiki_id }}"
     target: "{{ sql_dir_path }}/{{ sql_file_match }}"
     # FIXME: Security issue?
-    login_user: "{{ db_src_mysql_user }}"
-    login_password: "{{ db_src_mysql_pass }}"
+    login_user: "{{ hostvars[sql_backup_server]['db_src_mysql_user'] }}"
+    login_password: "{{ hostvars[sql_backup_server]['db_src_mysql_pass'] }}"
   delegate_to: "{{ sql_backup_server }}"
   remote_user: "{{ db_backup_server_remote_user }}"
   run_once: true
@@ -344,7 +344,7 @@
 - name: "Set uploads-source-from-backup facts IF SOURCING FROM backup-src"
   set_fact:
     uploads_backup_server: "{{ groups['backup-src'][0] }}"
-    uploads_backup_dir_path: "{{ backups_src_uploads_path | regex_replace('<id>', wiki_id) }}"
+    uploads_backup_dir_path: "{{ hostvars[ groups['backup-src'][0] ]['backups_src_uploads_path'] | regex_replace('<id>', wiki_id) }}"
     uploads_backup_server_set: True
   when: "'backup-src' in groups and groups['backup-src']|length|int > 0"
 

--- a/src/roles/verify-wiki/tasks/main.yml
+++ b/src/roles/verify-wiki/tasks/main.yml
@@ -377,7 +377,7 @@
     #
     # Potentially should use ssh_extra_args or ssh_common_args
     # Ref: https://github.com/ansible/ansible/pull/15306
-    ssh_args: "-l alt-meza-ansible"
+    ssh_args: "-l meza-ansible"
   # server A
   delegate_to: "{{ uploads_backup_server }}"
   remote_user: alt-meza-ansible

--- a/src/scripts/meza.py
+++ b/src/scripts/meza.py
@@ -76,6 +76,18 @@ def meza_command_deploy (argv):
 		else:
 			sys.exit(rc)
 
+	more_extra_vars = False
+
+	# strip environment off of it
+	argv = argv[1:]
+
+	# if argv[1:] includes -o or --overwrite
+	if len( set(argv).intersection({"-o", "--overwrite"}) ) > 0:
+		# remove -o and --overwrite from args;
+		argv = [value for value in argv[:] if value not in ["-o", "--overwrite"]]
+
+		more_extra_vars = { 'force_overwrite_from_backup': True }
+
 	# This breaks continuous integration. FIXME to get it back.
 	# THIS WAS WRITTEN WHEN `meza` WAS A BASH SCRIPT
 	# echo "You are about to deploy to the $ansible_env environment"
@@ -86,9 +98,9 @@ def meza_command_deploy (argv):
 		# stuff below was in here
 	# fi
 
-	shell_cmd = playbook_cmd( 'site', env )
-	if len(argv) > 1:
-		shell_cmd = shell_cmd + argv[1:]
+	shell_cmd = playbook_cmd( 'site', env, more_extra_vars )
+	if len(argv) > 0:
+		shell_cmd = shell_cmd + argv
 
 	return_code = meza_shell_exec( shell_cmd )
 

--- a/tests/deploys/setup-alt-source-backup.yml
+++ b/tests/deploys/setup-alt-source-backup.yml
@@ -50,3 +50,34 @@
         target: "{{ wiki_sql_file.stdout }}"
         login_user: root
         login_password: 1234
+
+    - name: Create alternate SSH user
+      user:
+        name: test-user
+
+    - name: Ensure test-user .ssh dir configured
+      file:
+        path: "/home/test-user/.ssh"
+        owner: test-user
+        group: test-user
+        mode: 0700
+        state: directory
+
+    - name: Ensure authorized_keys configured
+      file:
+        path: "/home/test-user/.ssh/authorized_keys"
+        owner: test-user
+        group: test-user
+        mode: 0644
+        state: touch
+
+    - name: Set authorized key test-user
+      authorized_key:
+        user: test-user
+        state: present
+        key: "{{ lookup('file', '/home/meza-ansible/.ssh/id_rsa.pub') }}"
+
+    - name: Ensure no password on test-user
+      shell: passwd --delete test-user
+      ignore_errors: yes
+

--- a/tests/deploys/setup-alt-source-backup.yml
+++ b/tests/deploys/setup-alt-source-backup.yml
@@ -1,0 +1,52 @@
+---
+
+# NOTE: this playbook is for test purposes only. It sets up a database and gets
+# file uploads for a wiki, which could be split over the db-src or the
+# backups-src server(s), but in the hosts declaration below it only specifies
+# backups-src. For the test case these servers will be the same.
+- hosts: backup-src
+  become: yes
+  vars:
+    alt_source_backups_dir: /opt/alt/backups
+
+  tasks:
+    - name: Ensure packages installed
+      yum:
+        name: "{{item}}"
+        state: installed
+      with_items:
+        - mariadb
+        - mariadb-server
+        - mariadb-libs
+        - MySQL-python
+        - perl-DBD-MySQL
+
+    - name: Ensure backups repo in place
+      git:
+        repo: https://github.com/jamesmontalvo3/meza-test-backups.git
+        dest: "{{ alt_source_backups_dir }}"
+        version: master
+
+    - name: Start mariadb
+      service:
+        name: mariadb
+        state: started
+        enabled: yes
+
+    - name: Set MariaDB root password
+      shell: mysqladmin -u root password 1234
+
+
+    # This will find the latest sql file by name, or wiki.sql over any timestamped one
+    # assuming timestamp-named files like 20170220000002_wiki.sql
+    - name: Find SQL file
+      shell: 'find {{ alt_source_backups_dir }}/top -maxdepth 1 -type f -iname "*.sql" | sort -r | head -n +1'
+      register: wiki_sql_file
+
+    - name: Create "top" DB
+      mysql_db:
+        name: wiki_top
+        state: import
+        target: "{{ wiki_sql_file.stdout }}"
+        login_user: root
+        login_password: 1234

--- a/tests/deploys/setup-alt-source-backup.yml
+++ b/tests/deploys/setup-alt-source-backup.yml
@@ -54,6 +54,18 @@
     - name: Create alternate SSH user
       user:
         name: test-user
+        group: wheel
+
+    # Add line to visudo file if it does not exist
+    # FIXME: This is really bad that a backup-retrieval-user needs sudo, but
+    #        unfortunately synchronize doesn't allow one end to be sudo and
+    #        the other to not.
+    - name: Ensure test-user is passwordless sudoer
+      lineinfile:
+        dest: /etc/sudoers
+        state: present
+        line: 'test-user ALL=(ALL) NOPASSWD: ALL'
+        validate: 'visudo -cf %s'
 
     - name: Ensure test-user .ssh dir configured
       file:

--- a/tests/deploys/setup-alt-source-backup.yml
+++ b/tests/deploys/setup-alt-source-backup.yml
@@ -71,7 +71,7 @@
       file:
         path: "/home/test-user/.ssh"
         owner: test-user
-        group: test-user
+        group: wheel
         mode: 0700
         state: directory
 
@@ -79,7 +79,7 @@
       file:
         path: "/home/test-user/.ssh/authorized_keys"
         owner: test-user
-        group: test-user
+        group: wheel
         mode: 0644
         state: touch
 

--- a/tests/docker/import-from-alt-remote.setup.sh
+++ b/tests/docker/import-from-alt-remote.setup.sh
@@ -76,7 +76,7 @@ ${docker_exec_1[@]} bash -c "echo -e 'db_src_mysql_pass: 1234\n' >> /opt/meza/co
 
 # Add database source (e.g. pull direct from database) to inventory, make some
 # modifications to database and uploaded files, then deploy with overwrite
-${docker_exec_1[@]} bash -c "echo -e '[db-src]\n$docker_ip_2\n\n' >> /opt/meza/config/local-secret/$env_name/hosts"
+${docker_exec_1[@]} bash -c "echo -e '[db-src]\n$docker_ip_2 alt_remote_user=test-user\n\n' >> /opt/meza/config/local-secret/$env_name/hosts"
 ${docker_exec_1[@]} cat "/opt/meza/config/local-secret/$env_name/hosts"
 # garbage data into database and file uploads, just to check that the changes
 # get copied to CONTAINER 1

--- a/tests/docker/import-from-alt-remote.setup.sh
+++ b/tests/docker/import-from-alt-remote.setup.sh
@@ -44,7 +44,7 @@ ${docker_exec_1[@]} sed -r -i "s/INSERT_FQDN/$docker_ip_1/g;" \
 # CONTAINER 1
 # Add to inventory file the "db-src" and "backups-src" groups (which will both
 # be CONTAINER 2)
-${docker_exec_1[@]} bash -c "echo -e '[backup-src]\n$docker_ip_2\n' >> /opt/meza/config/local-secret/$env_name/hosts"
+${docker_exec_1[@]} bash -c "echo -e '[backup-src]\n$docker_ip_2 alt_remote_user=test-user\n' >> /opt/meza/config/local-secret/$env_name/hosts"
 ${docker_exec_1[@]} bash -c "echo -e '[exclude-all]\n$docker_ip_2\n' >> /opt/meza/config/local-secret/$env_name/hosts"
 
 

--- a/tests/docker/import-from-alt-remote.setup.sh
+++ b/tests/docker/import-from-alt-remote.setup.sh
@@ -1,0 +1,134 @@
+#!/bin/sh
+#
+# Script creates two containers:
+#   1) A meza monolith, from a pre-built meza docker image
+#   2) A backup server, from a base docker image, with non-standard setup
+#
+
+# -e: kill script if anything fails
+# -u: don't allow undefined variables
+# -x: debug mode; print executed commands
+set -eux
+
+
+# CONTAINER 1 is controller and monolith
+container_name="ctrl"
+source "$m_meza_host/tests/docker/init-controller.sh"
+container_id_1="$container_id"
+docker_ip_1="$docker_ip"
+docker_exec_1=( "${docker_exec[@]}" )
+
+
+# CONTAINER 2 is a backup server
+container_name="bkup"
+source "$m_meza_host/tests/docker/init-minion.sh"
+docker_ip_2="$docker_ip"
+docker_exec_2=( "${docker_exec[@]}" )
+
+
+# CONTAINER 1
+# (1) Get local secret config from repo
+# (2) Change backup server IP address to docker#2 in hosts file
+# (3) Change all other servers to docker#1 IP address in hosts file
+# (4) Change FQDN to docker#1 IP address in group_vars/all.yml
+${docker_exec_1[@]} git clone \
+	https://github.com/enterprisemediawiki/meza-test-config-secret.git \
+	"/opt/meza/config/local-secret/$env_name"
+${docker_exec_1[@]} sed -r -i "s/localhost #backup/$docker_ip_2/g;" \
+	"/opt/meza/config/local-secret/$env_name/hosts"
+${docker_exec_1[@]} sed -r -i "s/localhost/$docker_ip_1/g;" \
+	"/opt/meza/config/local-secret/$env_name/hosts"
+${docker_exec_1[@]} sed -r -i "s/INSERT_FQDN/$docker_ip_1/g;" \
+	"/opt/meza/config/local-secret/$env_name/group_vars/all.yml"
+
+# CONTAINER 1
+# Add to inventory file the "db-src" and "backups-src" groups (which will both
+# be CONTAINER 2)
+${docker_exec_1[@]} bash -c "echo -e '[backup-src]\n$docker_ip_2\n' >> /opt/meza/config/local-secret/$env_name/hosts"
+${docker_exec_1[@]} bash -c "echo -e '[exclude-all]\n$docker_ip_2\n' >> /opt/meza/config/local-secret/$env_name/hosts"
+
+
+${docker_exec_1[@]} bash -c "echo -e 'backups_src_uploads_path: /opt/alt/backups/<id>/uploads\n' >> /opt/meza/config/local-secret/$env_name/group_vars/all.yml"
+${docker_exec_1[@]} bash -c "echo -e 'backups_src_sql_path: /opt/alt/backups/<id>\n' >> /opt/meza/config/local-secret/$env_name/group_vars/all.yml"
+
+
+${docker_exec_1[@]} cat "/opt/meza/config/local-secret/$env_name/hosts"
+
+
+# CONTAINER 1: Put backup files/database on CONTAINER 2
+# ${docker_exec_2[@]} git clone \
+# 	https://github.com/jamesmontalvo3/meza-test-backups.git \
+# 	"/opt/meza/data/backups/$env_name"
+${docker_exec_1[@]} sudo -u meza-ansible ansible-playbook \
+	/opt/meza/tests/deploys/setup-alt-source-backup.yml \
+	-i "/opt/meza/config/local-secret/$env_name/hosts" \
+	--extra-vars "{\"env\":\"$env_name\"}"
+
+
+# Run script on controller to `meza deploy`, `meza create wiki` and
+# `meza backup`
+${docker_exec_1[@]} bash /opt/meza/tests/deploys/import-from-remote.controller.sh "$env_name"
+
+
+${docker_exec_1[@]} bash -c "echo -e 'db_src_mysql_user: root\n' >> /opt/meza/config/local-secret/$env_name/group_vars/all.yml"
+${docker_exec_1[@]} bash -c "echo -e 'db_src_mysql_pass: 1234\n' >> /opt/meza/config/local-secret/$env_name/group_vars/all.yml"
+
+
+# Add database source (e.g. pull direct from database) to inventory, make some
+# modifications to database and uploaded files, then deploy with overwrite
+${docker_exec_1[@]} bash -c "echo -e '[db-src]\n$docker_ip_2\n\n' >> /opt/meza/config/local-secret/$env_name/hosts"
+${docker_exec_1[@]} cat "/opt/meza/config/local-secret/$env_name/hosts"
+# garbage data into database and file uploads, just to check that the changes
+# get copied to CONTAINER 1
+${docker_exec_2[@]} mysql -u root -p1234 wiki_top -e"INSERT INTO watchlist (wl_user, wl_namespace, wl_title) VALUES (10000,0,'FAKE PAGE');"
+${docker_exec_2[@]} bash -c "echo 'fake data' > /opt/alt/backups/top/uploads/fake.png"
+
+#
+# Re-deploy without --overwrite
+#
+${docker_exec_1[@]} meza deploy "$env_name" --tags "mediawiki" --skip-tags "latest"
+
+
+#
+# Do checks to make sure items NOT pulled from backups
+#
+${docker_exec_1[@]} mysql -e"SELECT * FROM wiki_top.watchlist WHERE wl_user = 10000;"
+rows=$(docker exec $container_id_1 mysql -AN -e"SELECT COUNT(*) FROM wiki_top.watchlist WHERE wl_user = 10000;")
+echo "${rows}"
+if [ ${rows} -eq 0 ]; then
+	echo "Row inserted into db-src server's database NOT FOUND in meza database AND SHOULD NOT BE"
+else
+	echo "Row inserted into db-src server's database IS PRESENT in meza database AND SHOULD NOT BE"
+	exit 1
+fi
+${docker_exec_1[@]} ls /opt/meza/data/uploads
+${docker_exec_1[@]} ls /opt/meza/data/uploads/top
+${docker_exec_1[@]} cat /opt/meza/data/uploads/top/fake.png \
+	&& (echo "fake.png present and should not be"; exit 1) \
+	|| (echo "fake.png not present and should not be"; exit 0)
+
+
+#
+# Re-deploy with --overwrite
+#
+${docker_exec_1[@]} meza deploy "$env_name" --overwrite --tags "mediawiki" --skip-tags "latest"
+
+
+#
+# Do checks to make sure that new items pulled over with --overwrite
+#
+${docker_exec_1[@]} mysql -e"SELECT * FROM wiki_top.watchlist WHERE wl_user = 10000;"
+
+rows=$(docker exec $container_id_1 mysql -AN -e"SELECT COUNT(*) FROM wiki_top.watchlist WHERE wl_user = 10000;")
+echo "${rows}"
+
+if [ ${rows} -gt 0 ]; then
+	echo "Row inserted into db-src server's database IS PRESENT in meza database AND SHOULD BE"
+else
+	echo "Row inserted into db-src server's database NOT FOUND in meza database AND SHOULD BE"
+	exit 1
+fi
+
+${docker_exec_1[@]} ls /opt/meza/data/uploads
+${docker_exec_1[@]} ls /opt/meza/data/uploads/top
+${docker_exec_1[@]} cat /opt/meza/data/uploads/top/fake.png

--- a/tests/docker/run-tests.sh
+++ b/tests/docker/run-tests.sh
@@ -71,6 +71,11 @@ elif [ "$test_type" == "backup-to-remote" ]; then
 	env_name=travis
 	source "$m_meza_host/tests/docker/backup-to-remote.setup.sh"
 
+elif [ "$test_type" == "import-from-alt-remote" ]; then
+
+	env_name=travis
+	source "$m_meza_host/tests/docker/import-from-alt-remote.setup.sh"
+
 else
 	echo "Bad test type: $test_type"
 	exit 1


### PR DESCRIPTION
## Major change: Support overwriting data in deploy

Modified `src/roles/verify-wiki/tasks/main.yml` and `src/scripts/meza.py` to support `--overwrite` (or `-o`) option when running `meza deploy`, which makes the deploy overwrite existing data (database and uploads) for all wikis, if the source data exists. Use it like:

```
sudo meza deploy staging --overwrite
```

## Major change: Support additional backup sources

Modified `src/roles/verify-wiki/tasks/main.yml` to support two additional groups in hosts inventory: `db-src` and `backup-src`. These two groups are intended as sources of backup data only. They will not be used for the installation to pull backups from.

### db-src

Use the following to specify a server as a db-src in your `local-secret/<your env>/hosts` file. This will tell `meza deploy` to make a `mysqldump` of the appropriate database on that server.

```
[db-src]
192.168.56.100
```

Since the database on the server will require a user and password, the following must be added to a config file such as `local-secret/<your env>/group_vars/all.yml`.

```
db_src_mysql_user: <your mysql user>
db_src_mysql_pass: <your mysql password>
```

### backup-src

Use the following to specify a server as a backup-src in your `local-secret/<your env>/hosts` file. This will tell `meza deploy` to pull uploaded files from this server, and if db-src is not specified then it will look for a `.sql` file for the database.

```
[backup-src]
192.168.56.101
```

If using `backup-src` as a source for file-uploads only, you should specify the path to uploads as follows. As a placeholder for the a particular wiki ID, put `<id>`. This variable should be added to `local-secret/<your env>/group_vars/all.yml` or somewhere else in your config.

```
backups_src_uploads_path: /opt/alt/backups/<id>/uploads
```

If additionally using `backup-src` as a source for SQL files, add the following should be added to your config.

```
# Directory in which SQL files for your database can be found. Use <id> as a
# placeholder for wiki ID
backups_src_sql_path: /home/mw/backups/<id>

# Pattern to match SQL file. This can use wildcards to find the latest file if
# files have timestamps in their filenames.
backups_src_sql_file_match: wiki_<id>*.sql
```

With all of these variables, you can alternatively put them into the hosts file like:

```
[backup-src]
192.168.56.101 backups_src_uploads_path=/opt/alt/backups/<id>/uploads
```

## More changes

### alt-meza-ansible user and custom users

Creates alt-meza-ansible user to be used in cases where one remote host must SSH into another remote host (e.g. to rsync files). In this case, the initiating host will be granted the private key of meza-ansible, and then will have the key removed afterwards. If meza-ansible was used instead of alt-meza-ansible, there would be a risk that meza-ansible's keys could be deleted (if the remote host was not actually a remote, but the controller posing as a remote).

Additionally, if using alt-meza-ansible is not desireable, it is possible to specify a custom user. This user must have meza-ansible's public key in `authorized_keys` and must be a passwordless sudoer. Specify the username in the hosts (aka inventory) file as follows:

```
[backup-src]
192.168.56.60 alt_remote_user=test-user
```

Using a custom user could be necessary if sourcing data from another meza installation, where meza-ansible and alt-meza-ansible may conflict.

### Tests

Add test job that pulls from an alternate backup with a preexisting SQL file, then add a backup location with database to dump from. Modify this database, and add a file to the uploads section. Re-deploy but without --force option. Verify no change to meza. Re-deploy with --force option and verify change.

### Add exclude-all group to inventory

Add exclude-all group to inventory, which allows playbooks to exclude specified servers from the `hosts: all` directive. This is useful particularly when pulling data from an alternate source that you don't want your meza installation to control.

```
[exclude-all]
192.168.56.100
192.168.56.101
```

### Refactoring

Move update.php, rebuildData.php, runJobs.php, and elastic-build-index out of `init-wiki.yml` (which is only run when a new wiki is created) and into `role/verify-wiki/tasks/main.yml`. These are now run when either a new wiki was created or the wiki was overwritten from a backup.