### PR TITLE
Upgrade SemanticMeetingMinutes; don't use Composer; add PageImporter

### DIFF
--- a/config/core/MezaCoreExtensions.yml
+++ b/config/core/MezaCoreExtensions.yml
@@ -336,7 +336,7 @@ list:
     legacy_load: True
   - name: SemanticMeetingMinutes
     repo: https://github.com/enterprisemediawiki/SemanticMeetingMinutes.git
-    version: use-page-importer
+    version: master
     legacy_load: True
   - name: HeaderFooter
     repo: https://github.com/enterprisemediawiki/HeaderFooter.git

--- a/config/core/MezaCoreExtensions.yml
+++ b/config/core/MezaCoreExtensions.yml
@@ -40,22 +40,9 @@ list:
   - name: SubPageList
     composer: "mediawiki/sub-page-list"
     version: "~1.1"
-  - name: Semantic Meeting Minutes
-    composer: "mediawiki/semantic-meeting-minutes"
-    version: "~0.3"
   - name: Semantic Maps
     composer: "mediawiki/semantic-maps"
     version: "~3.2"
-
-
-  # Extension:HeaderFooter (currently pulled in by composer as dependency)
-  # https://github.com/enterprisemediawiki/HeaderFooter.git
-
-  # Extension:NumerAlpha (currently pulled in by composer as dependency)
-  # https://github.com/jamesmontalvo3/NumerAlpha.git
-
-
-
 
 
 
@@ -232,8 +219,7 @@ list:
       $egApprovedRevsAutomaticApprovals = false;
   - name: MasonryMainPage
     repo: https://github.com/enterprisemediawiki/MasonryMainPage.git
-    version: extreg
-    legacy_load: true
+    version: master
   - name: WatchAnalytics
     repo: https://github.com/enterprisemediawiki/WatchAnalytics.git
     version: master
@@ -343,3 +329,20 @@ list:
     repo: https://gerrit.wikimedia.org/r/p/mediawiki/extensions/DataTransfer.git
     version: tags/0.6.2
     legacy_load: true
+
+  - name: PageImporter
+    repo: https://github.com/enterprisemediawiki/PageImporter.git
+    version: master
+    legacy_load: True
+  - name: SemanticMeetingMinutes
+    repo: https://github.com/enterprisemediawiki/SemanticMeetingMinutes.git
+    version: use-page-importer
+    legacy_load: True
+  - name: HeaderFooter
+    repo: https://github.com/enterprisemediawiki/HeaderFooter.git
+    version: master
+    legacy_load: True
+  - name: NumerAlpha
+    repo: https://gerrit.wikimedia.org/r/mediawiki/extensions/NumerAlpha.git
+    version: master
+    legacy_load: True

--- a/src/roles/verify-wiki/tasks/init-wiki.yml
+++ b/src/roles/verify-wiki/tasks/init-wiki.yml
@@ -2,15 +2,19 @@
 
 
 # Import pages required for SemanticMeetingMinutes and rebuild recent changes
-- name: import pages for SemanticMeetingMinutes
+# - name: import pages for SemanticMeetingMinutes
+#   shell: >
+#     WIKI="{{ wiki_id }}" php "{{ m_mediawiki }}/maintenance/importDump.php" --report --debug < {{ m_mediawiki }}/extensions/SemanticMeetingMinutes/ImportFiles/import.xml
+#   run_once: true
+- name: Import all pages registered with PageImporter (e.g. SemanticMeetingMinutes)
   shell: >
-    WIKI="{{ wiki_id }}" php "{{ m_mediawiki }}/maintenance/importDump.php" --report --debug < {{ m_mediawiki }}/extensions/SemanticMeetingMinutes/ImportFiles/import.xml
-  run_once: true
+    WIKI="{{ wiki_id }}" php "{{ m_mediawiki }}/extensions/PageImporter/importPages.php"
+  run_once: True
+
 - name: rebuildrecentchanges.php
   shell: >
     WIKI="{{ wiki_id }}" php "{{ m_mediawiki }}/maintenance/rebuildrecentchanges.php"
   run_once: true
-
 
 # Create an admin user for Demo Wiki only if the wiki was just created
 - name: Create "Admin" user on Demo Wiki

--- a/tests/docker/init-controller.sh
+++ b/tests/docker/init-controller.sh
@@ -35,3 +35,12 @@ ${docker_exec[@]} bash /opt/meza/tests/travis/git-setup.sh "$TRAVIS_EVENT_TYPE" 
 # Remove existing config info
 ${docker_exec[@]} rm -rf /opt/meza/config/local-secret/monolith || true
 ${docker_exec[@]} rm -rf /opt/meza/config/local-public || true
+
+# Docker image has these pre-installed with Composer, which conflicts with
+# attempts to install them with Git. Remove SMM from composer.local.json then
+# run composer update.
+# FIXME: Update the Docker image to have these preinstalled with Git (not
+# Composer), then remove these lines.
+${docker_exec[@]} sed -i '/semantic-meeting-minutes/d' /opt/meza/htdocs/mediawiki/composer.local.json || true
+${docker_exec[@]} bash -c 'cd /opt/meza/htdocs/mediawiki && /usr/local/bin/composer update'
+${docker_exec[@]} ls -la /opt/meza/htdocs/mediawiki/extensions


### PR DESCRIPTION
This PR changes SemanticMeetingMinutes (SMM) to *not* use Composer for installation. Composer generally complicates install, and since SMM has minimal dependencies it is easier to keep them in `MezaCoreExtensions.yml` instead.

Other changes:
* Add [Extension:PageImporter](https://github.com/enterprisemediawiki/PageImporter), a new dependency for SMM which handles importing required pages (forms, templates, properties, etc)
* Explicitly require [HeaderFooter](https://www.mediawiki.org/wiki/Extension:Header_Footer) and [NumerAlpha](https://www.mediawiki.org/wiki/Extension:NumerAlpha) in `MezaCoreExtensions.yml` rather than having them as implicit dependencies via Composer. This also upgrades the NumerAlpha version.
* Use PageImporter's `importPages.php` to import pages rather than MW's `importDump.php`. This allows for syncing pages at any time.
* In `tests/docker/init-controller.sh` use Composer to remove SMM, since tests using `init-controller.sh` use a Docker image that already has SMM installed via Composer. This caused conflicts that I'd rather not make backwards-compatible. Instead just put this bandaid on the test until the Docker image is updated.