### PR TITLE
Use /opt/meza/data/tmp instead of /tmp, particularly for large files

### DIFF
--- a/config/core/paths.yml
+++ b/config/core/paths.yml
@@ -22,6 +22,7 @@ m_test: /opt/meza/test
 
 # data dir
 m_meza_data: /opt/meza/data
+m_tmp: /opt/meza/data/tmp
 
 # uploads dir. In order to support both app-server-based uploads and
 # GlusterFS-based uploads (or other alternatives) it may be necessary to be

--- a/src/roles/backup-db-wikis/tasks/main.yml
+++ b/src/roles/backup-db-wikis/tasks/main.yml
@@ -29,7 +29,7 @@
 - name: Copy SQL files to backups
   synchronize:
     # copy from server A
-    src: "/tmp/{{ env }}_{{ item }}.sql"
+    src: "{{ m_tmp }}/{{ env }}_{{ item }}.sql"
     # copy to server B
     dest: "{{ m_backups }}/{{ env }}/{{ item }}/{{ backup_timestamp }}_wiki.sql"
   # server A
@@ -37,9 +37,9 @@
   with_items: "{{ wiki_dirs.files | map(attribute='path') | map('basename') | list }}"
 
 # Remove temp SQL files, only needs to be done on first backup server
-- name: Remove SQL files from DB master /tmp
+- name: Remove SQL files from DB master {{ m_tmp }}
   file:
-    path: "/tmp/{{ env }}_{{ item }}.sql"
+    path: "{{ m_tmp }}/{{ env }}_{{ item }}.sql"
     state: absent
   delegate_to: "{{ groups['db-master'][0] }}"
   with_items: "{{ wiki_dirs.files | map(attribute='path') | map('basename') | list }}"

--- a/src/roles/base/tasks/main.yml
+++ b/src/roles/base/tasks/main.yml
@@ -150,3 +150,11 @@
 #   template:
 #     src: config.php.j2
 #     dest: /opt/meza/config/config.php
+
+- name: "Ensure {{ m_tmp }} exists"
+  file:
+    path: "{{ m_tmp }}"
+    owner: meza-ansible
+    group: wheel
+    mode: 0755
+    state: directory

--- a/src/roles/database/tasks/replication.yml
+++ b/src/roles/database/tasks/replication.yml
@@ -89,7 +89,7 @@
     and not role_is_valid_slave|skipped
 
 - name: export dump file on master
-  shell: "mysqldump --databases {{ mysql_content_databases.stdout }} | gzip > /tmp/mysqldump-onmaster.sql.gz"
+  shell: "mysqldump --databases {{ mysql_content_databases.stdout }} | gzip > {{ m_tmp }}/mysqldump-onmaster.sql.gz"
   delegate_to: "{{ mysql_replication_master }}"
   when: >
     not slave_needs_configuration|skipped
@@ -105,17 +105,17 @@
 #
 - name: fetch dump file
   fetch:
-    src=/tmp/mysqldump-onmaster.sql.gz
-    dest=/tmp/mysqldump-oncontrol.sql.gz
-    flat=yes
+    src: "{{ m_tmp }}/mysqldump-onmaster.sql.gz"
+    dest: "{{ m_tmp }}/mysqldump-oncontrol.sql.gz"
+    flat: yes
   delegate_to: "{{ mysql_replication_master }}"
   when: >
     not slave_needs_configuration|skipped
     and not role_is_valid_slave|skipped
 - name: put dump file
   copy:
-    src=/tmp/mysqldump-oncontrol.sql.gz
-    dest=/tmp/mysqldump-onslave.sql.gz
+    src: "{{ m_tmp }}/mysqldump-oncontrol.sql.gz"
+    dest: "{{ m_tmp }}/mysqldump-onslave.sql.gz"
   when: >
     not slave_needs_configuration|skipped
     and not role_is_valid_slave|skipped
@@ -128,7 +128,7 @@
   mysql_db:
     state: import
     name: all
-    target: /tmp/mysqldump-onslave.sql.gz
+    target: "{{ m_tmp }}/mysqldump-onslave.sql.gz"
   when: >
     not slave_needs_configuration|skipped
     and not role_is_valid_slave|skipped

--- a/src/roles/dump-db-wikis/tasks/main.yml
+++ b/src/roles/dump-db-wikis/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - name: Remove any existing database dumps
   file:
-    path: "/tmp/{{ env }}_{{ item }}.sql"
+    path: "{{ m_tmp }}/{{ env }}_{{ item }}.sql"
     state: absent
   # see role "mediawiki" for explanation of filters below
   with_items: "{{ wiki_dirs.files | map(attribute='path') | map('basename') | list }}"
@@ -21,5 +21,5 @@
   mysql_db:
     state: dump
     name: "wiki_{{ item }}"
-    target: "/tmp/{{ env }}_{{ item }}.sql"
+    target: "{{ m_tmp }}/{{ env }}_{{ item }}.sql"
   with_items: "{{ wiki_dirs.files | map(attribute='path') | map('basename') | list }}"

--- a/src/roles/update.php/tasks/main.yml
+++ b/src/roles/update.php/tasks/main.yml
@@ -2,13 +2,13 @@
 
 - debug: { msg: "Running role:update.php for {{ wiki_id }}" }
 
-# FIXME: This shouldn't go to /tmp. Also it should be pushed to a backup server
+# FIXME: This shouldn't go to {{ m_tmp }}. Also it should be pushed to a backup server
 #        and maybe we should use incremental backups (patches) to limit size.
 - name: Backup wiki database prior to running update.php
   mysql_db:
     state: dump
     name: "wiki_{{ wiki_id }}"
-    target: "/tmp/backup_{{ wiki_id }}_{{ ansible_date_time.iso8601 }}.sql"
+    target: "{{ m_tmp }}/backup_{{ wiki_id }}_{{ ansible_date_time.iso8601 }}.sql"
   delegate_to: "{{ groups['db-master'][0] }}"
 
   # [1] This role should be included in such a way that it is run just once,

--- a/src/roles/verify-wiki/tasks/main.yml
+++ b/src/roles/verify-wiki/tasks/main.yml
@@ -195,7 +195,7 @@
   #
 - name: if wiki_sql_file exists, FIRST remove preexisting SQL file from controller
   file:
-    path: /tmp/controller-wiki.sql
+    path: "{{ m_tmp }}/controller-wiki.sql"
     state: absent
   run_once: true
   delegate_to: localhost
@@ -204,7 +204,7 @@
 - name: if wiki_sql_file exists, NEXT send SQL file to controller
   fetch:
     src: "{{ wiki_sql_file.stdout }}"
-    dest: /tmp/controller-wiki.sql
+    dest: "{{ m_tmp }}/controller-wiki.sql"
     fail_on_missing: yes
     flat: yes
   # note: don't run fetch with become on large files. ref bottom of this page:
@@ -217,8 +217,8 @@
 
 - name: if wiki_sql_file exists, NEXT send file from controller to master-db
   copy:
-    src: /tmp/controller-wiki.sql
-    dest: /tmp/wiki.sql
+    src: "{{ m_tmp }}/controller-wiki.sql"
+    dest: "{{ m_tmp }}/wiki.sql"
     force: yes
   run_once: true
   delegate_to: "{{ groups['db-master'][0] }}"
@@ -235,7 +235,7 @@
 - name: If wiki_sql_file NOT defined, send generic file to master db
   copy:
     src: templates/mediawiki-tables.sql
-    dest: /tmp/wiki.sql
+    dest: "{{ m_tmp }}/wiki.sql"
     force: yes
   run_once: true
   delegate_to: "{{ groups['db-master'][0] }}"
@@ -253,14 +253,14 @@
   mysql_db:
     name: "wiki_{{ wiki_id }}"
     state: import
-    target: /tmp/wiki.sql
+    target: "{{ m_tmp }}/wiki.sql"
   run_once: true
   delegate_to: "{{ groups['db-master'][0] }}"
   when: not wiki_exists or do_overwrite_db_from_backup
 
 - name: Remove SQL file from master DB
   file:
-    path: /tmp/wiki.sql
+    path: "{{ m_tmp }}/wiki.sql"
     state: absent
   run_once: true
   delegate_to: "{{ groups['db-master'][0] }}"

--- a/src/roles/verify-wiki/tasks/main.yml
+++ b/src/roles/verify-wiki/tasks/main.yml
@@ -425,6 +425,13 @@
     dest: "{{ m_uploads_dir }}/{{ wiki_id }}"
     recursive: yes
 
+    # If the source server has an /uploads directory with symlinks, follow
+    # the symlinks and re-assemble them on the destination server not as
+    # symlinks. This allows an old server that is running out of space to
+    # spread its data onto other partitions using symlinks, but a new server
+    # with more space to put everything back where it belongs.
+    copy_links: yes
+
     # Perhaps required due to not being able to properly specify an Ansible
     # user in synchronize
     # ref: https://github.com/ansible/ansible/issues/16215

--- a/src/roles/verify-wiki/tasks/main.yml
+++ b/src/roles/verify-wiki/tasks/main.yml
@@ -444,7 +444,7 @@
     name: revoke-keys
     alt_remote_user: "{{ uploads_backup_server_remote_user }}"
   vars:
-    revoke_keys_from_server: "{{ groups['backup-servers'][0] }}"
+    revoke_keys_from_server: "{{ uploads_backup_server }}"
   when:
     images_backup_dir.stat.exists
     and (not uploads_dir.stat.exists or do_overwrite_uploads_from_backup)


### PR DESCRIPTION
The intent of meza is to be easy to configure. By stating that the bulk of your free space needs to be in `/opt` it makes it easier to decide on partition sizes. However, backup scripts and other scripts moving files (particularly uploads (aka images)) and database dumps were clogging up the `/tmp` directory. Instead use `/opt/meza/data/tmp`.