### PR TITLE
provide options to enable debug mode

### DIFF
--- a/src/roles/mediawiki/defaults/main.yml
+++ b/src/roles/mediawiki/defaults/main.yml
@@ -27,3 +27,9 @@ blender_admins: []
 local_config_repo: {}
 
 enable_wiki_emails: true
+
+# Whether to enable debug at all times
+m_force_debug: false
+
+# Whether to enable debug when using the command line
+m_command_line_debug: true

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -93,8 +93,8 @@ foreach ( glob("$m_meza/config/local_app/wikis/$wikiId/preLocalSettings.d/*.php"
  *       users of a single wiki.
  *    5) Set `$mezaForceDebug = true;` to turn on debug for all users and wikis
  **/
-$mezaCommandLineDebug = true; // don't we always want debug on command line?
-$mezaForceDebug = false;
+$mezaCommandLineDebug = {{ m_command_line_debug }}; // don't we always want debug on command line?
+$mezaForceDebug = {{ m_force_debug }};
 
 
 if ( $mezaForceDebug ) {


### PR DESCRIPTION
Provide options to allow configuration to specify debug mode. Add to `/opt/meza/config/local-public/vars.yml`:

```yaml
# Whether to enable debug at all times
m_force_debug: true

# Whether to enable debug when using the command line
m_command_line_debug: true
```