### PR TITLE
Use ImagesLoaded extension, now separate from MasonryMainPage

### DIFF
--- a/config/core/MezaCoreExtensions.yml
+++ b/config/core/MezaCoreExtensions.yml
@@ -217,6 +217,9 @@ list:
     legacy_load: true
     config: |
       $egApprovedRevsAutomaticApprovals = false;
+  - name: ImagesLoaded
+    repo: https://github.com/enterprisemediawiki/ImagesLoaded.git
+    version: master
   - name: MasonryMainPage
     repo: https://github.com/enterprisemediawiki/MasonryMainPage.git
     version: master


### PR DESCRIPTION
The imagesloaded script was broken out of MasonryMainPage since it was being used also by MediaWiki:Common.js on some wikis. It therefore needs to be loaded even when MasonryMainPage is not.