### PR TITLE
Turn off geoip guessing

### DIFF
--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -516,7 +516,10 @@ $wgFileExtensions = array(
 	'xlsx'
 );
 
-
+// Tell Universal Language Selector not to try to guess language based upon IP
+// address. This (a) isn't likely needed in enterprise use cases and (b) fails
+// anyway due to outdated URLs or firewall rules.
+$wgULSGeoService = false;
 
 
 


### PR DESCRIPTION
Tell Universal Language Selector not to try to guess language based upon IP address. This (a) isn't likely needed in enterprise use cases and (b) fails anyway due to outdated URLs or firewall rules.

Without this you get these errors in JS console:

![image](https://cloud.githubusercontent.com/assets/716482/25258857/049ee448-2608-11e7-9399-15731fdffaf6.png)
