### PR TITLE
Fix SMW/Elastic rebuild order; names/functions misaligned

### DIFF
--- a/src/playbooks/rebuild-smw-and-index.yml
+++ b/src/playbooks/rebuild-smw-and-index.yml
@@ -6,14 +6,15 @@
     - set-vars
 
   tasks:
-  - name: Rebuild SemanticMediaWiki data for each wiki
-    shell: "bash /opt/meza/src/scripts/smw-rebuild-all.sh"
-    run_once: true
-    tags:
-    - smw-data
 
   - name: (Re-)build search index for each wiki
     shell: "bash /opt/meza/src/scripts/elastic-rebuild-all.sh"
     run_once: true
     tags:
     - search-index
+
+  - name: Rebuild SemanticMediaWiki data for each wiki
+    shell: "bash /opt/meza/src/scripts/smw-rebuild-all.sh"
+    run_once: true
+    tags:
+    - smw-data

--- a/src/roles/create-wiki-wrapper/tasks/main.yml
+++ b/src/roles/create-wiki-wrapper/tasks/main.yml
@@ -26,13 +26,13 @@
 # FIXME: WILL ONLY WORK WHEN CONTROLLER AND APP-SERVER ARE THE SAME MACHINE
 # Not totally sure SMW-rebuild is necessary, but maybe for imported pages?
 - name: (Re-)build search index for each wiki
-  shell: "bash /opt/meza/src/scripts/smw-rebuild-all.sh"
-  run_once: true
-  tags:
-  - smw-data
-- name: Rebuild SemanticMediaWiki data for each wiki
   shell: "bash /opt/meza/src/scripts/elastic-rebuild-all.sh"
   run_once: true
   tags:
   - search-index
 
+- name: Rebuild SemanticMediaWiki data for each wiki
+  shell: "bash /opt/meza/src/scripts/smw-rebuild-all.sh"
+  run_once: true
+  tags:
+  - smw-data

--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -228,17 +228,19 @@
 # Wikis are totally built at this point, but SMW and search need rebuilding
 # FIXME: WILL ONLY WORK WHEN CONTROLLER AND APP-SERVER ARE THE SAME MACHINE
 - name: (Re-)build search index for each wiki
-  shell: "bash /opt/meza/src/scripts/smw-rebuild-all.sh"
-  when: docker_skip_tasks is not defined or not docker_skip_tasks
-  run_once: true
-  tags:
-  - smw-data
-- name: Rebuild SemanticMediaWiki data for each wiki
   shell: "bash /opt/meza/src/scripts/elastic-rebuild-all.sh"
   when: docker_skip_tasks is not defined or not docker_skip_tasks
   run_once: true
   tags:
   - search-index
+
+- name: Rebuild SemanticMediaWiki data for each wiki
+  shell: "bash /opt/meza/src/scripts/smw-rebuild-all.sh"
+  when: docker_skip_tasks is not defined or not docker_skip_tasks
+  run_once: true
+  tags:
+  - smw-data
+
 
 
 # Run update.php (MediaWiki's database update script) against all wikis. This


### PR DESCRIPTION
On previous PR #581 SMW's `rebuildData.php` swapped order to be after Elasticsearch index rebuilding. However, the names of the tasks and the functions of the tasks were not aligned, so the order was not actually swapped as desired. This PR cleans that up.

SMW data rebuild should be second because (a) it takes a really long time, (b) it is not always required per discussion on SMW mailing list, and (c) even if it is required it is less detrimental to a new server to not have search index than to not have SMW data be perfect.