### PR TITLE
Use Wiretap master, don't legacy-load

### DIFF
--- a/config/core/MezaCoreExtensions.yml
+++ b/config/core/MezaCoreExtensions.yml
@@ -208,8 +208,7 @@ list:
     version: master
   - name: Wiretap
     repo: https://github.com/enterprisemediawiki/Wiretap.git
-    version: extreg
-    legacy_load: true
+    version: master
   - name: ApprovedRevs
     repo: https://github.com/jamesmontalvo3/MediaWiki-ApprovedRevs.git
     version: master


### PR DESCRIPTION
Stop using `extreg` branch which was missing fix for `wfchecklimits` function