### PR TITLE
Fix conditional checks failures that arose when Ansible 2.2.1-->2.3

### DIFF
--- a/src/roles/database/tasks/replication.yml
+++ b/src/roles/database/tasks/replication.yml
@@ -55,7 +55,7 @@
     (
       (slave.Is_Slave is defined and not slave.Is_Slave)
       or (slave.Is_Slave is not defined and slave|failed)
-      or (slave.Slave_IO_Running == 'No' and slave.Slave_SQL_Running == 'No')
+      or (slave.Slave_IO_Running is defined and slave.Slave_SQL_Running == 'No')
       or (mysql_force_slave_configuration)
     )
 - debug: { var: slave_needs_configuration }

--- a/src/roles/database/tasks/replication.yml
+++ b/src/roles/database/tasks/replication.yml
@@ -56,7 +56,7 @@
       (slave.Is_Slave is defined and not slave.Is_Slave)
       or (slave.Is_Slave is not defined and slave|failed)
       or (slave.Slave_IO_Running is defined and slave.Slave_SQL_Running == 'No')
-      or (mysql_force_slave_configuration)
+      or (mysql_force_slave_configuration is defined and mysql_force_slave_configuration)
     )
 - debug: { var: slave_needs_configuration }
 

--- a/src/roles/verify-wiki/tasks/main.yml
+++ b/src/roles/verify-wiki/tasks/main.yml
@@ -164,12 +164,12 @@
 - name: "{{ wiki_id }} - Set fact if SQL file DOES exist"
   set_fact:
     sql_file_exists: True
-  when: wiki_sql_file is defined and wiki_sql_file.rc == 0
+  when: wiki_sql_file is defined and wiki_sql_file.rc is defined and wiki_sql_file.rc == 0
 
 - name: "{{ wiki_id }} - Set fact if SQL file DOES NOT exist"
   set_fact:
     sql_file_exists: False
-  when: wiki_sql_file is not defined or wiki_sql_file.rc != 0
+  when: wiki_sql_file is not defined or wiki_sql_file.rc is not defined or wiki_sql_file.rc != 0
 
 
 


### PR DESCRIPTION
Ansible, as provided by `yum` via EPEL, jumped from v2.2.1 to v2.3 in the last day. On one day the build passed, and the next day it failed:

* [Passing build from 26-APR-2017](https://travis-ci.org/enterprisemediawiki/meza/builds/226090878)
  * [Log line showing Ansible 2.2.1](https://travis-ci.org/enterprisemediawiki/meza/jobs/226090879#L324)
* [Failing build from 27-APR-2017](https://travis-ci.org/enterprisemediawiki/meza/builds/226481748)
  * [Log line showing Ansible 2.3](https://travis-ci.org/enterprisemediawiki/meza/jobs/226481749#L328)

