### PR TITLE
Use Extension:SimpleMathJax instead of Extension:Math

### DIFF
--- a/config/core/MezaCoreExtensions.yml
+++ b/config/core/MezaCoreExtensions.yml
@@ -131,15 +131,10 @@ list:
   - name: CollapsibleVector
     repo: https://gerrit.wikimedia.org/r/mediawiki/extensions/CollapsibleVector
     version: REL1_27
-  - name: Math
-    repo: https://gerrit.wikimedia.org/r/mediawiki/extensions/Math.git
-    version: REL1_27
-    config: |
-      $wgMathValidModes[] = 'MW_MATH_MATHJAX'; // Define MathJax as one of the valid math rendering modes
-      $wgUseMathJax = true; // Enable MathJax as a math rendering option for users to pick
-      $wgDefaultUserOptions['math'] = 'MW_MATH_MATHJAX'; // Set MathJax as the default rendering option for all users (optional)
-      $wgMathDisableTexFilter = true; // or compile "texvccheck"
-      $wgDefaultUserOptions['mathJax'] = true; // Enable the MathJax checkbox option
+  - name: SimpleMathJax
+    repo: https://github.com/jamesmontalvo3/SimpleMathJax.git
+    version: master
+    legacy_load: True
   - name: ImageMap
     repo: https://gerrit.wikimedia.org/r/mediawiki/extensions/ImageMap
     version: REL1_27


### PR DESCRIPTION
Extension:Math after MediaWiki 1.25 does not allow client-side rendering
of Math via the MathJax javascript library. Without this it is required to
install a server side renderer such as Mathoid, texvc, or LaTeXML. All of
these are complicated. At some point down the road perhaps we'll add one
(or more) of these, but for now it is much simpler to maintain previous
functionality with this other extension.

Note that the original SimpleMathJax had two issues:

  1. The MathJax library was loaded from a CDN, which is a
     security/privacy concern
  2. MathJax JS and CSS was loaded with every page load, regardless of
     whether or not <math> or <chem> tags were used

As such, the GitHub jmnote/SimpleMathJax repo was forked to
jamesmontalvo3/SimpleMathJax. The changes made in this fork have been
pull-requested back into the trunk, but at this time have not been
accepted. If they are accepted it will have to be determined whether or
not we use an unknown repository or continue to maintain this one. If we
continue to maintain it, jamesmontalvo3 will transfer the repo to
enterprisemediawiki.