### PR TITLE
Maps not Semantic Maps; Install netcat

### DIFF
--- a/config/core/MezaCoreExtensions.yml
+++ b/config/core/MezaCoreExtensions.yml
@@ -40,9 +40,9 @@ list:
   - name: SubPageList
     composer: "mediawiki/sub-page-list"
     version: "~1.1"
-  - name: Semantic Maps
-    composer: "mediawiki/semantic-maps"
-    version: "~3.2"
+  - name: Maps
+    composer: "mediawiki/maps"
+    version: "~4.1"
 
 
 

--- a/src/roles/memcached/tasks/main.yml
+++ b/src/roles/memcached/tasks/main.yml
@@ -1,10 +1,22 @@
 ---
-- name: Install memcached package
-  yum: name=memcached state=installed
-- name: write the memcached config file
-  template: "src=memcached.j2 dest={{ m_memcached_conf }}"
+- name: Ensure memcached and netcat packages latest
+  yum:
+    name: "{{ item }}"
+    state: latest
+  with_items:
+  - memcached
+  - nmap-ncat
+
+- name: Write the memcached config file
+  template:
+    src: memcached.j2
+    dest: "{{ m_memcached_conf }}"
   notify:
   - restart memcached
-- name: ensure memcached is running (and enable it at boot)
-  service: name=memcached state=started enabled=yes
+
+- name: Ensure memcached is running (and enable it at boot)
+  service:
+    name: memcached
+    state: started
+    enabled: yes
   when: docker_skip_tasks is not defined or not docker_skip_tasks


### PR DESCRIPTION
This PR closes two issues:

* Closes #602: Swap out Maps for Semantic Maps. Semantic Maps was discontinued at v3.8 (we had ~3.2 specified, which via Composer rules gave us the latest v3.8). Semantic Maps was then merged into Extension:Maps, which as of this writing has stable version 4.1. This PR switches to using that.
* Closes #416: Install netcat. This is already present on meza monoliths, but it is possible that it may not be installed on standalone memcached servers. As such, it was added to role:memcached. Additionally, several cleanup/standardization changes were made to this file.