### PR TITLE
Fix Extensions.php to use meza_local_extensions where appropriate

### DIFF
--- a/src/roles/mediawiki/templates/Extensions.php.j2
+++ b/src/roles/mediawiki/templates/Extensions.php.j2
@@ -52,7 +52,7 @@
  *  of this local meza installation. This section may be blank if no Composer
  *  extensions are required for this local installation.
  **/
-{% for ext in meza_core_extensions['list'] if ext.composer is defined and ext.config is defined %}
+{% for ext in meza_local_extensions['list'] if ext.composer is defined and ext.config is defined %}
 
 #
 # Config for Extension:{{ ext.name }}


### PR DESCRIPTION
The contents of `Extensions.php` (a PHP script generated by Ansible with data from `MezaCoreExtensions.yml` and `MezaLocalExtensions.yml`) had duplicate config entries for meza-core Composer-installed extensions due to a type (copy-paste error). See #598. This fixes that.

* Closes #598 
