### PR TITLE
Reorg (#619) complete and meza-docker-full rebuilt: use latest image

### DIFF
--- a/tests/docker/init-controller.sh
+++ b/tests/docker/init-controller.sh
@@ -4,7 +4,7 @@
 
 
 # Initiate container
-docker_repo="jamesmontalvo3/meza-docker-full:meza-reorg"
+docker_repo="jamesmontalvo3/meza-docker-full:latest"
 source "$m_meza_host/tests/docker/init-container.sh" "none"
 
 


### PR DESCRIPTION
Cleaning up Docker image used after chicken-and-egg problem created by #619