### PR TITLE
Optionally allow <img> in wikitext, and make work in VE

### DIFF
--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -477,7 +477,11 @@ $wgExternalLinkTarget = '_blank';
 
 // added this line to allow linking. specifically to Imagery Online.
 $wgAllowExternalImages = true;
+{% if allow_image_tags is defined and allow_image_tags %}
 $wgAllowImageTag = true;
+{% else %}
+$wgAllowImageTag = false;
+{% endif %}
 
 $wgVectorUseSimpleSearch = true;
 

--- a/src/roles/parsoid/tasks/main.yml
+++ b/src/roles/parsoid/tasks/main.yml
@@ -15,10 +15,7 @@
 
 # FIXME: Get MW-core and Parsoid patched so this isn't required anymore
 - name: Patch Parsoid so it allows image tags
-  shell: <
-    sudo sed -i -e
-    's/JSUtils.deepFreeze(WikitextConstants);/WikitextConstants.Sanitizer.TagWhiteList.add( "IMG" );\nJSUtils.deepFreeze(WikitextConstants);/'
-    /etc/parsoid/lib/config/WikitextConstants.js
+  shell: "sed -i -e 's/JSUtils.deepFreeze(WikitextConstants);/WikitextConstants.Sanitizer.TagWhiteList.add( \"IMG\" );\\nJSUtils.deepFreeze(WikitextConstants);/' /etc/parsoid/lib/config/WikitextConstants.js"
   when: allow_image_tags is defined and allow_image_tags
 
 - name: Ensure parsoid group exists

--- a/src/roles/parsoid/tasks/main.yml
+++ b/src/roles/parsoid/tasks/main.yml
@@ -3,16 +3,23 @@
 
 # Get Parsoid
 #
-# Notes:
-#   "Force: no" will make it so changes to working directory will not be
-#   overwritten. Long-term we may want this, but right now we have to modify
-#   Parsoid for it to display external images.
+# Due to #149 (VE doesn't allow image tags) we set force:yes so this repo's
+# working directory is wiped out on each run. Then We can immediately patch
+# the repo in the following step (optionally, if we want <img> tags)
 - name: Get Parsoid repository
   git:
     repo: https://gerrit.wikimedia.org/r/p/mediawiki/services/parsoid
     dest: "{{ m_parsoid_path }}"
     version: "{{ m_parsoid_version }}"
-    force: no
+    force: yes
+
+# FIXME: Get MW-core and Parsoid patched so this isn't required anymore
+- name: Patch Parsoid so it allows image tags
+  shell: <
+    sudo sed -i -e
+    's/JSUtils.deepFreeze(WikitextConstants);/WikitextConstants.Sanitizer.TagWhiteList.add( "IMG" );\nJSUtils.deepFreeze(WikitextConstants);/'
+    /etc/parsoid/lib/config/WikitextConstants.js
+  when: allow_image_tags is defined and allow_image_tags
 
 - name: Ensure parsoid group exists
   group:

--- a/tests/docker/import-from-remote.setup.sh
+++ b/tests/docker/import-from-remote.setup.sh
@@ -48,6 +48,11 @@ ${docker_exec_1[@]} sed -r -i "s/localhost/$docker_ip_1/g;" \
 ${docker_exec_1[@]} sed -r -i "s/INSERT_FQDN/$docker_ip_1/g;" \
 	"/opt/conf-meza/secret/$env_name/group_vars/all.yml"
 
+# Test allow_image_tags (which requires patching Parsoid, plus an item in
+# LocalSettings.php)
+${docker_exec_1[@]} bash -c "echo -e 'allow_image_tags: True\n' >> '/opt/conf-meza/secret/$env_name/group_vars/all.yml'"
+
+
 
 # CONTAINER 2: get backup files
 ${docker_exec_2[@]} git clone \


### PR DESCRIPTION
Parsoid does not allow <img> tags and doesn't show no respect for `$wgAllowImageTag`. This PR adds a config variable `allow_image_tags` which:

1. Sets `$wgAllowImageTag` to true or false, accordingly
2. If `allow_image_tags` is true, patches Parsoid to allow image tags

This is a sort of temporary fix until MediaWiki/Parsoid are fixed. This may take some time, though, since it first requires a MediaWiki core patch, then a Parsoid patch, then we have to wait to catch up with the versions we use (or get them to back-port to MW 1.27 (possibly doable) and to our Parsoid version (not likely)). This will continue to be followed in #149.