### PR TITLE
Setup cron for Parsoid-restart, runJobs, and custom commands

### DIFF
--- a/src/roles/cron/defaults/main.yml
+++ b/src/roles/cron/defaults/main.yml
@@ -19,14 +19,16 @@ parsoid_restart_crontime: "0 2 * * *"
 # How often to run small frequent job runs
 run_jobs_freq_crontime: "*/3 * * * *"
 
-# Max CPU and IO load, above which the script won't run
-run_jobs_freq_maxload: ""
+# Max CPU and IO load, above which the script won't run; default 50%
+run_jobs_freq_maxload: "50"
 
 # Max number of jobs to run PER WIKI
-run_jobs_freq_maxjobs: ""
+run_jobs_freq_maxjobs: "30"
 
 # Max execution time for the script
-run_jobs_freq_totalmaxtime: ""
+run_jobs_freq_totalmaxtime: "150"
 
 # Max execution time PER WIKI
-run_jobs_freq_maxtime: ""
+run_jobs_freq_maxtime: "30"
+
+

--- a/src/roles/cron/defaults/main.yml
+++ b/src/roles/cron/defaults/main.yml
@@ -1,10 +1,32 @@
 ---
+# Time to run server-performance.sh script
+server_performance_crontime: "*/10 * * * *"
+
+# When to run disk-space-usage script
+disk_space_usage_crontime: "0 1 * * *"
+
+# Run all jobs on all wikis at 22:00 each night
+run_all_jobs_crontime: "0 22 * * *"
 
 # Restart Parsoid periodically on parsoid-servers
-parsoid_periodic_restart: True
+parsoid_restart_crontime: "0 2 * * *"
 
-parsoid_restart_minute: 0
-parsoid_restart_hour: 2
-parsoid_restart_day: "*"
-parsoid_restart_month: "*"
-parsoid_restart_day_of_week: "*"
+
+#
+# Frequent job running
+#
+
+# How often to run small frequent job runs
+run_jobs_freq_crontime: "*/3 * * * *"
+
+# Max CPU and IO load, above which the script won't run
+run_jobs_freq_maxload: ""
+
+# Max number of jobs to run PER WIKI
+run_jobs_freq_maxjobs: ""
+
+# Max execution time for the script
+run_jobs_freq_totalmaxtime: ""
+
+# Max execution time PER WIKI
+run_jobs_freq_maxtime: ""

--- a/src/roles/cron/defaults/main.yml
+++ b/src/roles/cron/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+
+# Restart Parsoid periodically on parsoid-servers
+parsoid_periodic_restart: True
+
+parsoid_restart_minute: 0
+parsoid_restart_hour: 2
+parsoid_restart_day: "*"
+parsoid_restart_month: "*"
+parsoid_restart_day_of_week: "*"

--- a/src/roles/cron/tasks/main.yml
+++ b/src/roles/cron/tasks/main.yml
@@ -19,6 +19,14 @@
     group: wheel
     mode: 0755
 
+- name: Ensure runAllJobs.php in place
+  template:
+    src: runAllJobs.php.j2
+    dest: /opt/.deploy-meza/runAllJobs.php
+    owner: meza-ansible
+    group: wheel
+    mode: 0755
+
 # Make sure sudo can be used in cron jobs
 - lineinfile:
     dest: /etc/sudoers

--- a/src/roles/cron/templates/meza-ansible.crontab.j2
+++ b/src/roles/cron/templates/meza-ansible.crontab.j2
@@ -27,12 +27,14 @@
 #
 # Run a small set of jobs across all wikis periodically
 #
-{{ run_jobs_freq_crontime }} php {{ m_deploy }}/runAllJobs.php --maxload={{ run_jobs_freq_maxload }} --maxjobs={{ run_jobs_freq_maxjobs }} --totalmaxtime={{ run_jobs_freq_totalmaxtime }} --maxtime={{ run_jobs_freq_maxtime }} >> {{ m_logs }}/jobs_`date "+\%Y\%m\%d"`_cron.log 2>&1
+{{ run_jobs_freq_crontime }} WIKI={{ list_of_wikis[0] }} php {{ m_deploy }}/runAllJobs.php --maxload={{ run_jobs_freq_maxload }} --maxjobs={{ run_jobs_freq_maxjobs }} --totalmaxtime={{ run_jobs_freq_totalmaxtime }} --maxtime={{ run_jobs_freq_maxtime }} >> {{ m_logs }}/jobs_`date "+\%Y\%m\%d"`_cron.log 2>&1
 
 #
 # Run all jobs on all wikis
+# Note: WIKI=<wiki_id> does not matter which wiki. Just needs one to load
+# settings.
 #
-{{ run_all_jobs_crontime }} php {{ m_deploy }}/runAllJobs.php >> {{ m_logs }}/jobs_`date "+\%Y\%m\%d"`_cron.log 2>&1
+{{ run_all_jobs_crontime }} WIKI={{ list_of_wikis[0] }} php {{ m_deploy }}/runAllJobs.php >> {{ m_logs }}/jobs_`date "+\%Y\%m\%d"`_cron.log 2>&1
 
 {% endif %}
 

--- a/src/roles/cron/templates/meza-ansible.crontab.j2
+++ b/src/roles/cron/templates/meza-ansible.crontab.j2
@@ -5,7 +5,6 @@
 {% if 'logging-servers' in groups and inventory_hostname in groups['logging-servers'] and server_performance_crontime %}
 #
 # Cron job for logging server performance info
-# FIXME: Currently this does it every 2 minutes. Make this value configurable.
 #
 {{ server_performance_crontime }} {{ m_scripts }}/server-performance.sh
 {% endif %}
@@ -24,7 +23,7 @@
 {{ parsoid_restart_crontime }} systemctl restart parsoid > /opt/data-meza/logs/parsoid-restart.log 2>&1
 {% endif %}
 
-{% inventory_hostname in groups['app-servers'] %}
+{% if inventory_hostname in groups['app-servers'] %}
 #
 # Run a small set of jobs across all wikis periodically
 #

--- a/src/roles/cron/templates/meza-ansible.crontab.j2
+++ b/src/roles/cron/templates/meza-ansible.crontab.j2
@@ -27,7 +27,7 @@
 #
 # Run a small set of jobs across all wikis periodically
 #
-{{ run_jobs_freq_crontime }} WIKI={{ list_of_wikis[0] }} php {{ m_deploy }}/runAllJobs.php --maxload={{ run_jobs_freq_maxload }} --maxjobs={{ run_jobs_freq_maxjobs }} --totalmaxtime={{ run_jobs_freq_totalmaxtime }} --maxtime={{ run_jobs_freq_maxtime }} >> {{ m_logs }}/jobs_`date "+\%Y\%m\%d"`_cron.log 2>&1
+{{ run_jobs_freq_crontime }} WIKI={{ list_of_wikis[0] }} php {{ m_deploy }}/runAllJobs.php {{ run_jobs_freq_maxtime }} {{ run_jobs_freq_totalmaxtime }} {{ run_jobs_freq_maxjobs }} {{ run_jobs_freq_maxload }} >> {{ m_logs }}/jobs_`date "+\%Y\%m\%d"`_cron.log 2>&1
 
 #
 # Run all jobs on all wikis

--- a/src/roles/cron/templates/meza-ansible.crontab.j2
+++ b/src/roles/cron/templates/meza-ansible.crontab.j2
@@ -2,53 +2,50 @@
 #
 # crontab for meza
 
-{% if 'logging-servers' in groups and inventory_hostname in groups['logging-servers'] %}
+{% if 'logging-servers' in groups and inventory_hostname in groups['logging-servers'] and server_performance_crontime %}
+#
 # Cron job for logging server performance info
 # FIXME: Currently this does it every 2 minutes. Make this value configurable.
-*/10 * * * * {{ m_scripts }}/server-performance.sh
+#
+{{ server_performance_crontime }} {{ m_scripts }}/server-performance.sh
 {% endif %}
 
 {% if disk_space_usage_mount_name is defined and 'logging-servers' in groups and inventory_hostname in groups['logging-servers'] %}
+#
 # Check disk space usage
-0 1 * * * {{ m_scripts }}/disk-space-usage.sh
+#
+{{ disk_space_usage_crontime }} {{ m_scripts }}/disk-space-usage.sh
 {% endif %}
 
-{% if parsoid_periodic_restart and inventory_hostname in groups['parsoid-servers'] %}
+{% if parsoid_restart_crontime and inventory_hostname in groups['parsoid-servers'] %}
+#
 # Restart Parsoid periodically on parsoid-servers
-{{ parsoid_restart_minute }} {{ parsoid_restart_hour}} {{ parsoid_restart_day }} {{ parsoid_restart_month }} {{ parsoid_restart_day_of_week }} systemctl restart parsoid > /opt/data-meza/logs/parsoid-restart.log 2>&1
+#
+{{ parsoid_restart_crontime }} systemctl restart parsoid > /opt/data-meza/logs/parsoid-restart.log 2>&1
+{% endif %}
+
+{% inventory_hostname in groups['app-servers'] %}
+#
+# Run a small set of jobs across all wikis periodically
+#
+{{ run_jobs_freq_crontime }} php {{ m_deploy }}/runAllJobs.php --maxload={{ run_jobs_freq_maxload }} --maxjobs={{ run_jobs_freq_maxjobs }} --totalmaxtime={{ run_jobs_freq_totalmaxtime }} --maxtime={{ run_jobs_freq_maxtime }} >> {{ m_logs }}/jobs_`date "+\%Y\%m\%d"`_cron.log 2>&1
+
+#
+# Run all jobs on all wikis
+#
+{{ run_all_jobs_crontime }} php {{ m_deploy }}/runAllJobs.php >> {{ m_logs }}/jobs_`date "+\%Y\%m\%d"`_cron.log 2>&1
+
 {% endif %}
 
 
-
-
-{% if custom_crons is defined %}
+{% if custom_crons is defined  %}
 #
 # The following jobs are custom definitions from this meza-instance's config
 #
-
-{% for cron in custom_crons %}
-
-{% if inventory_hostname in groups[cron.server_type] %}
+{% for cron in custom_crons %}{% if inventory_hostname in groups[cron.server_type] %}
 {{ cron.time }} {{ cron.job }}
-{% endif %}
 
-{% endfor %}
+{% endif %}{% endfor %}
 
 # END custom crons
 {% endif %}
-
-
-#
-# COMMENTS BELOW NEED TO BE INCORPORATED AS REGULARLY RUN COMMANDS. THEY ARE
-# TAKEN FROM A PRODUCTION SERVER THAT DOESN'T HAVE CRONTAB MANAGED BY MEZA (BUT
-# SHOULD)
-#
-
-# FIXME: Run all jobs nightly on just one application server (or does doing it\
-# on all make sense?) and run it regularly (every minute? every few minutes?)
-# for just a small number of jobs on each wiki (again, on how many app servers?).
-# if inventory_hostname in groups['app-servers']
-# */3 * * * * php /opt/meza/scripts/runAllJobs.php >> /opt/meza/logs/runAllJobs_`date "+\%Y\%m\%d"`_cron.log 2>&1
-# 0 22 * * * /opt/meza/scripts/runAllJobs.sh > /opt/meza/logs/runAllJobs_`date "+\%Y\%m\%d\%H\%M\%S"`_cron.log 2>&1
-# endif
-

--- a/src/roles/cron/templates/meza-ansible.crontab.j2
+++ b/src/roles/cron/templates/meza-ansible.crontab.j2
@@ -13,6 +13,31 @@
 0 1 * * * {{ m_scripts }}/disk-space-usage.sh
 {% endif %}
 
+{% if parsoid_periodic_restart and inventory_hostname in groups['parsoid-servers'] %}
+# Restart Parsoid periodically on parsoid-servers
+{{ parsoid_restart_minute }} {{ parsoid_restart_hour}} {{ parsoid_restart_day }} {{ parsoid_restart_month }} {{ parsoid_restart_day_of_week }} systemctl restart parsoid > /opt/data-meza/logs/parsoid-restart.log 2>&1
+{% endif %}
+
+
+
+
+{% if custom_crons is defined %}
+#
+# The following jobs are custom definitions from this meza-instance's config
+#
+
+{% for cron in custom_crons %}
+
+{% if inventory_hostname in groups[cron.server_type] %}
+{{ cron.time }} {{ cron.job }}
+{% endif %}
+
+{% endfor %}
+
+# END custom crons
+{% endif %}
+
+
 #
 # COMMENTS BELOW NEED TO BE INCORPORATED AS REGULARLY RUN COMMANDS. THEY ARE
 # TAKEN FROM A PRODUCTION SERVER THAT DOESN'T HAVE CRONTAB MANAGED BY MEZA (BUT
@@ -27,9 +52,3 @@
 # 0 22 * * * /opt/meza/scripts/runAllJobs.sh > /opt/meza/logs/runAllJobs_`date "+\%Y\%m\%d\%H\%M\%S"`_cron.log 2>&1
 # endif
 
-# FIXME: This is a custom cron job, perhaps not applicable outside one
-# particular wiki. Make a method to handle custom cron jobs.
-# 0 12 * * 1 ~/delinquent-approved-revs-report.sh > /opt/meza/logs/delinquent-approved-revs-report_`date "+\%Y\%m\%d\%H\%M\%S"`_cron.log 2>&1
-
-# FIXME: Restart Parsoid periodically on parsoid-servers
-# 0 4 * * * /usr/sbin/service parsoid restart > /opt/meza/logs/parsoid-restart.log 2>&1

--- a/src/roles/cron/templates/runAllJobs.php.j2
+++ b/src/roles/cron/templates/runAllJobs.php.j2
@@ -1,124 +1,52 @@
 <?php
-/**
- * Wrapper for mediawiki/maintenance/runJobs.php for all wikis
- * Use with cron to run jobs for all wikis periodically
- *
- * Usage:
- *  no parameters
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- * http://www.gnu.org/copyleft/gpl.html
- *
- * @author Daren Welsh
- * @ingroup Maintenance
- */
-require_once( '{{ m_mediawiki }}/maintenance/Maintenance.php' );
+#
+# Wrapper for mediawiki/maintenance/runJobs.php
+# Allows cron to run jobs for all wikis periodically
+#
 
-class RunAllJobs extends Maintenance {
+// script start time
+$startTime = time();
 
-	public function __construct() {
-		parent::__construct();
+// Argument positions when calling script
+$maxtime_pos = 1;
+$totalmaxtime_pos = 2;
+$maxjobs_pos = 3;
+$maxload_pos = 4;
+$wikis_pos = 5;
 
-		$this->mDescription = "Run all jobs for all wikis";
+$allWikis = array(
+	{% for wiki in list_of_wikis %}
+	'{{ wiki }}',
+	{% endfor %}
+);
 
-		// addOption ($name, $description, $required=false, $withArg=false, $shortName=false)
-		$this->addOption(
-			'maxtime',
-			'Max execution time PER WIKI',
-			false, true );
+$maxtime      = isset( $argv[$maxtime_pos] )      ? ' --maxtime=' . $argv[$maxtime_pos] . ' ' : '';
+$totalmaxtime = isset( $argv[$totalmaxtime_pos] ) ? (int) $argv[$totalmaxtime_pos]            : 0;
+$maxjobs      = isset( $argv[$maxjobs_pos] )      ? ' --maxjobs=' . $argv[$maxjobs_pos] . ' ' : '';
+$maxload      = isset( $argv[$maxload_pos] )      ? (int) $argv[$maxload_pos]                 : 0;
+$wikis        = isset( $argv[$wikis_pos] )        ? explode( ',', $argv[$wikis_pos] )         : $allWikis;
 
-		$this->addOption(
-			'totalmaxtime',
-			'Max execution time for the script',
-			false, true );
+foreach ($wikis as $wiki_id) {
 
-		$this->addOption(
-			'maxjobs',
-			'Max number of jobs to run PER WIKI',
-			false, true );
+	if ( ! in_array( $wiki_id, $allWikis ) ) {
+		echo "Wiki ID $wiki_id is not a valid wiki";
+		continue;
+	}
 
-		$this->addOption(
-			'maxload',
-			'Max CPU and IO load, above which the script won\'t run',
-			false, true );
+	// see if max load in the last minute is higher than desired to run script
+	if ( sys_getloadavg()[0] < $maxload ) {
 
-		$this->addOption(
-			'wikis',
-			'Wikis from which to run jobs',
-			false, true );
+		echo "Running jobs for $wiki_id\n";
+		$command = "WIKI=$wiki_id php {{ m_mediawiki }}/maintenance/runJobs.php $maxtime $maxjobs";
+		$output = shell_exec( $command );
+		echo $output . "\n";
 
 	}
 
-	public function execute () {
-
-		$totalmaxtime = (int) $this->getOption( 'totalmaxtime', 0 );
-		$startTime = time();
-
-		$maxtime = (int) $this->getOption( 'maxtime', 0 );
-		$maxtime = $maxtime > 0 ? " --maxtime=$maxtime " : '';
-
-		$maxjobs = (int) $this->getOption( 'maxjobs', 0 );
-		$maxjobs = $maxjobs > 0 ? " --maxjobs=$maxjobs " : '';
-
-		$maxload = (float) $this->getOption( 'maxload', 100 ); // default big number, load always lower
-
-		$allWikis = array(
-			{% for wiki in list_of_wikis %}
-			'{{ wiki }}',
-			{% endfor %}
-		);
-
-		$wikiIds = $this->getOption( 'wikis', false );
-		if ( ! $wikiIds ) {
-			$wikiIds = $allWikis;
-		}
-		else {
-			// split comma-separate list of wiki IDs, trim whitespace from each
-			$wikiIds = array_map( 'trim', explode( ',', $wikiIds ) );
-		}
-
-		// put keys in random order so wikis starting with A don't always get their
-		// jobs prioritized over wikis starting with Z.
-		shuffle( $wikiIds );
-		echo "\nRunning jobs in order: " . implode( ',', $wikiIds ) . "\n";
-
-		foreach ($wikiIds as $wikiId) {
-
-			if ( ! in_array( $wikiId, $allWikis) ) {
-				echo "Wiki ID $wikiId is not a valid wiki";
-				continue;
-			}
-
-			// see if max load in the last minute is higher than desired to run script
-			if ( sys_getloadavg()[0] < $maxload ) {
-
-				echo "Running jobs for $wikiId\n";
-				$command = "WIKI=$wikiId php {{ m_mediawiki }}/maintenance/runJobs.php $maxtime $maxjobs";
-				$output = shell_exec( $command );
-				echo $output . "\n";
-
-			}
-
-			if ( $totalmaxtime > 0 && ( time() - $startTime ) > $totalmaxtime ) {
-				echo "Script exceeded total max time of $totalmaxtime\n";
-				break;
-			}
-		}
-
+	if ( $totalmaxtime > 0 && ( time() - $startTime ) > $totalmaxtime ) {
+		echo "Script exceeded total max time of $totalmaxtime\n";
+		break;
 	}
 
 }
-$maintClass = "RunAllJobs";
-require_once( DO_MAINTENANCE );
+

--- a/src/roles/cron/templates/runAllJobs.php.j2
+++ b/src/roles/cron/templates/runAllJobs.php.j2
@@ -24,7 +24,7 @@
  * @author Daren Welsh
  * @ingroup Maintenance
  */
-require_once( '/opt/htdocs/mediawiki/maintenance/Maintenance.php' );
+require_once( '{{ m_mediawiki }}/maintenance/Maintenance.php' );
 
 class RunAllJobs extends Maintenance {
 
@@ -63,8 +63,6 @@ class RunAllJobs extends Maintenance {
 
 	public function execute () {
 
-		global $m_htdocs;
-
 		$totalmaxtime = (int) $this->getOption( 'totalmaxtime', 0 );
 		if ( $totalmaxtime > 0 ) {
 			// override default script timeout
@@ -79,9 +77,15 @@ class RunAllJobs extends Maintenance {
 
 		$maxload = (float) $this->getOption( 'maxload', 100 ); // default big number, load always lower
 
+		$allWikis = array(
+			{% for wiki in list_of_wikis %}
+			'{{ wiki }}',
+			{% endfor %}
+		);
+
 		$wikiIds = $this->getOption( 'wikis', false );
 		if ( ! $wikiIds ) {
-			$wikiIds = scandir( "$m_htdocs/wikis" );
+			$wikiIds = $allWikis;
 		}
 		else {
 			// split comma-separate list of wiki IDs, trim whitespace from each
@@ -94,9 +98,8 @@ class RunAllJobs extends Maintenance {
 
 		foreach ($wikiIds as $wikiId) {
 
-			// remove . and .. directories, and anything that's not a directory
-			// in the /opt/htdocs/wikis directory
-			if ( $wikiId === '.' || $wikiId === '..' || ! is_dir( "$m_htdocs/wikis/$wikiId" ) ) {
+			if ( ! in_array( $wikiId, $allWikis) ) {
+				echo "Wiki ID $wikiId is not a valid wiki";
 				continue;
 			}
 
@@ -104,7 +107,7 @@ class RunAllJobs extends Maintenance {
 			if ( sys_getloadavg()[0] < $maxload ) {
 
 				echo "Running jobs for $wikiId\n";
-				$command = "WIKI=$wikiId php $m_htdocs/mediawiki/maintenance/runJobs.php $maxtime $maxjobs";
+				$command = "WIKI=$wikiId php {{ m_mediawiki }}/maintenance/runJobs.php $maxtime $maxjobs";
 				$output = shell_exec( $command );
 				echo $output . "\n";
 

--- a/src/roles/cron/templates/runAllJobs.php.j2
+++ b/src/roles/cron/templates/runAllJobs.php.j2
@@ -23,7 +23,7 @@ $allWikis = array(
 $maxtime      = isset( $argv[$maxtime_pos] )      ? ' --maxtime=' . $argv[$maxtime_pos] . ' ' : '';
 $totalmaxtime = isset( $argv[$totalmaxtime_pos] ) ? (int) $argv[$totalmaxtime_pos]            : 0;
 $maxjobs      = isset( $argv[$maxjobs_pos] )      ? ' --maxjobs=' . $argv[$maxjobs_pos] . ' ' : '';
-$maxload      = isset( $argv[$maxload_pos] )      ? (int) $argv[$maxload_pos]                 : 0;
+$maxload      = isset( $argv[$maxload_pos] )      ? (int) $argv[$maxload_pos]                 : 1000;
 $wikis        = isset( $argv[$wikis_pos] )        ? explode( ',', $argv[$wikis_pos] )         : $allWikis;
 
 foreach ($wikis as $wiki_id) {

--- a/src/roles/cron/templates/runAllJobs.php.j2
+++ b/src/roles/cron/templates/runAllJobs.php.j2
@@ -64,10 +64,7 @@ class RunAllJobs extends Maintenance {
 	public function execute () {
 
 		$totalmaxtime = (int) $this->getOption( 'totalmaxtime', 0 );
-		if ( $totalmaxtime > 0 ) {
-			// override default script timeout
-			set_time_limit( $totalmaxtime );
-		}
+		$startTime = time();
 
 		$maxtime = (int) $this->getOption( 'maxtime', 0 );
 		$maxtime = $maxtime > 0 ? " --maxtime=$maxtime " : '';
@@ -95,6 +92,7 @@ class RunAllJobs extends Maintenance {
 		// put keys in random order so wikis starting with A don't always get their
 		// jobs prioritized over wikis starting with Z.
 		shuffle( $wikiIds );
+		echo "\nRunning jobs in order: " . implode( ',', $wikiIds ) . "\n";
 
 		foreach ($wikiIds as $wikiId) {
 
@@ -113,6 +111,10 @@ class RunAllJobs extends Maintenance {
 
 			}
 
+			if ( $totalmaxtime > 0 && ( time() - $startTime ) > $totalmaxtime ) {
+				echo "Script exceeded total max time of $totalmaxtime\n";
+				break;
+			}
 		}
 
 	}


### PR DESCRIPTION
Closes #496

* Allow configure cron time for server performance, disk space scripts
* configure cron time for frequent and full runJobs.php
* configure frequent runJobs.php with number of jobs, max wiki time, max total time, max server load
* parsoid restart nightly or whenever desired
* allow custom cron jobs to be specified in setting in the form below

### custom crons
```yaml
custom_crons:
  - server_type: app-servers
    time: "* * * * *"
    job: echo "test" >> /some/path.log
```