### PR TITLE
Allow access to API despite SAML SSO

### DIFF
--- a/src/roles/saml/templates/samlLocalSettings.php.j2
+++ b/src/roles/saml/templates/samlLocalSettings.php.j2
@@ -39,9 +39,9 @@ if ( isset( $_SERVER['HTTP_X_SKIP_SAML'] ) ) {
 	{% if allow_skip_saml_users is defined -%}
 		$wgMezaAllowSkipSamlUsers = array();
 		{% for user, ipaddrs in allow_skip_saml_users.iteritems() -%}
-			$wgMezaAllowSkipSamlUsers['{{ user }}'] = array(
-				{% for ipaddr in ipaddrs %}'{{ ipaddr }}',{% endfor %}
-			);
+		$wgMezaAllowSkipSamlUsers['{{ user }}'] = array(
+			{%- for ipaddr in ipaddrs -%}'{{ ipaddr }}',{%- endfor -%}
+		);
 		{%- endfor %}
 	{% else -%}
 		$wgMezaAllowSkipSamlUsers = false;
@@ -56,14 +56,35 @@ if ( isset( $_SERVER['HTTP_X_SKIP_SAML'] ) ) {
 		$username = $user->getName();
 		$ipaddr = $_SERVER['HTTP_X_FORWARDED_FOR'];
 
-		// allow option to greenlight all users
-		if ( $wgMezaAllowSkipSamlUsers === '*' ) {
-			return true;
+		$forbidden = function () {
+			// lightly copied from MediaWiki's img_auth.php
+			HttpStatus::header( 403 );
+			header( 'Cache-Control: no-cache' );
+			header( 'Content-Type: text/html; charset=utf-8' );
+			echo "You do not have rights to access this wiki in this way.";
+			die();
+		};
+
+		if ( ! is_array( $wgMezaAllowSkipSamlUsers ) ) {
+			$forbidden();
+			return false; // pointless due to die() in forbidden
 		}
 
-		elseif ( is_array( $wgMezaAllowSkipSamlUsers )
-			&& in_array( $username, array_keys( $wgMezaAllowSkipSamlUsers ) ) )
-		{
+		// allow option to greenlight all users
+		if ( isset( $wgMezaAllowSkipSamlUsers['*'] ) ) {
+
+			// if * users can access via * ip addresses
+			if ( $wgMezaAllowSkipSamlUsers['*'][0] === '*' ) {
+				return true
+			}
+
+			// if * users can access via the current IP address
+			elseif ( in_array( $ipaddr, $wgMezaAllowSkipSamlUsers['*'] ) ) {
+				return true;
+			}
+		}
+
+		if ( isset( $wgMezaAllowSkipSamlUsers[$username] ) ) {
 
 			// user allowed from all IP addresses
 			if ( $wgMezaAllowSkipSamlUsers[$username] === '*' ) {
@@ -71,22 +92,13 @@ if ( isset( $_SERVER['HTTP_X_SKIP_SAML'] ) ) {
 			}
 
 			// user allowed from this IP address only -OR- this IP address is one of many allowed
-			elseif ( $wgMezaAllowSkipSamlUsers[$username] === $ipaddr
-				||  in_array( $ipaddr, $wgMezaAllowSkipSamlUsers[$username] ) )
-			{
+			elseif ( in_array( $ipaddr, $wgMezaAllowSkipSamlUsers[$username] ) ) {
 				return true;
 			}
 		}
 
-		// lightly copied from MediaWiki's img_auth.php
-		HttpStatus::header( 403 );
-		header( 'Cache-Control: no-cache' );
-		header( 'Content-Type: text/html; charset=utf-8' );
-		echo "You do not have rights to access this wiki in this way."
-		die();
-
-		// not really necessary due to die.
-		return false;
+		$forbidden();
+		return false; // pointless due to die() in forbidden
 	};
 }
 

--- a/src/roles/saml/templates/samlLocalSettings.php.j2
+++ b/src/roles/saml/templates/samlLocalSettings.php.j2
@@ -11,7 +11,8 @@ if ( $_SERVER['HTTP_X_SKIP_SAML'] ) {
 
 	# But allow them to access the login page or else there will be no way to log in!
 	# (You also might want to add access to "Main Page", "Help:Contents", etc.)
-	$wgWhitelistRead = array ("Special:Userlogin");
+	// WILL API LOGIN WORK WITHOUT THIS?
+	// $wgWhitelistRead = array ("Special:Userlogin");
 
 	# Disable anonymous editing
 	$wgGroupPermissions['*']['edit'] = false;
@@ -19,6 +20,19 @@ if ( $_SERVER['HTTP_X_SKIP_SAML'] ) {
 	# Prevent new user registrations except by sysops
 	$wgGroupPermissions['*']['createaccount'] = false;
 
+	# Disable API modules that could allow someone to circumvent SAML auth
+	# ref: https://www.mediawiki.org/wiki/API:Restricting_API_usage
+	# ref: https://www.mediawiki.org/wiki/API:Changing_wiki_content
+	$wgAPIModules['createaccount'] = 'ApiDisabled';
+	$wgAPIModules['options'] = 'ApiDisabled';
+	$wgAPIModules['resetpassword'] = 'ApiDisabled';
+
+	// A bit heavy handed:
+	// $wgEnableWriteAPI = false;
+
+	// consider an extension that basically just allows this hook to check who
+	// a user is and check if they're in a list of allowed API users.
+	// $wgHooks['UserLoggedIn'][] = 'MyExtensionHooks::onUserLoggedIn';
 }
 
 #

--- a/src/roles/saml/templates/samlLocalSettings.php.j2
+++ b/src/roles/saml/templates/samlLocalSettings.php.j2
@@ -6,19 +6,11 @@
 #
 if ( $_SERVER['HTTP_X_SKIP_SAML'] ) {
 
-	# Disable reading by anonymous users
+	# Disable reading, editing and account creation by anonymous users
 	$wgGroupPermissions['*']['read'] = false;
-
-	# But allow them to access the login page or else there will be no way to log in!
-	# (You also might want to add access to "Main Page", "Help:Contents", etc.)
-	// WILL API LOGIN WORK WITHOUT THIS?
-	// $wgWhitelistRead = array ("Special:Userlogin");
-
-	# Disable anonymous editing
 	$wgGroupPermissions['*']['edit'] = false;
-
-	# Prevent new user registrations except by sysops
 	$wgGroupPermissions['*']['createaccount'] = false;
+	# Note: account creation disabled for everyone at bottom of this file
 
 	# Disable API modules that could allow someone to circumvent SAML auth
 	# ref: https://www.mediawiki.org/wiki/API:Restricting_API_usage
@@ -27,12 +19,78 @@ if ( $_SERVER['HTTP_X_SKIP_SAML'] ) {
 	$wgAPIModules['options'] = 'ApiDisabled';
 	$wgAPIModules['resetpassword'] = 'ApiDisabled';
 
-	// A bit heavy handed:
+	// A bit heavy-handed:
 	// $wgEnableWriteAPI = false;
 
-	// consider an extension that basically just allows this hook to check who
-	// a user is and check if they're in a list of allowed API users.
-	// $wgHooks['UserLoggedIn'][] = 'MyExtensionHooks::onUserLoggedIn';
+	// Add to config like:
+	//
+	// allow_skip_saml_users: "*"
+	//  -- or --
+	// allow_skip_saml_users:
+	//   - James: ["192.168.56.62","23.243.32.123"]
+	//   - Daren: "*"
+	//   - Lauren:
+	//     - "192.54.43.13"
+	//     - "3.3.2.1"
+	//   - Willa: "192.169.34.23"
+	//
+	// FIXME: The indenting below will be heinous when Ansible does its templating
+	{% if allow_skip_saml_users is defined and isinstance(allow_skip_saml_users, basestring) %}
+	$wgMezaAllowSkipSamlUsers = '{{ allow_skip_saml_users }}';
+	{% else %}
+		$wgMezaAllowSkipSamlUsers = array();
+		{% for user, ipaddrs in allow_skip_saml_users.iteritems() %}
+			{% if isinstance(ipaddrs, basestring) %}
+			$wgMezaAllowSkipSamlUsers['{{ user }}'] = '{{ ipaddrs }}';
+			{% else %}
+				$wgMezaAllowSkipSamlUsers['{{ user }}'] = array();
+				{% for ipaddr in ipaddrs %}
+				$wgMezaAllowSkipSamlUsers['{{ user }}']][] = '{{ ipaddr }}';
+				{% endfor %}
+			{% endif %}
+		{% endfor %}
+	{% endif %}
+
+	// Upon login if user is allowed to skip SAML (and therefore use the API
+	// externally)
+	$wgHooks['UserLoggedIn'][] = function ( $user ) {
+		global $wgMezaAllowSkipSamlUsers;
+
+		$username = $user->getName();
+		$ipaddr = $_SERVER['HTTP_X_FORWARDED_FOR'];
+
+		// allow option to greenlight all users
+		if ( $wgMezaAllowSkipSamlUsers === '*' ) {
+			return true;
+		}
+
+		elseif ( is_array( $wgMezaAllowSkipSamlUsers )
+			&& in_array( $username, array_keys( $wgMezaAllowSkipSamlUsers ) ) )
+		{
+
+			// user allowed from all IP addresses
+			if ( $wgMezaAllowSkipSamlUsers[$username] === '*' ) {
+				return true;
+			}
+
+			// user allowed from this IP address only -OR- this IP address is one of many allowed
+			elseif ( $wgMezaAllowSkipSamlUsers[$username] === $ipaddr
+				||  in_array( $ipaddr, $wgMezaAllowSkipSamlUsers[$username] ) )
+			{
+				return true;
+			}
+		}
+
+		// lightly copied from MediaWiki's img_auth.php
+		HttpStatus::header( 403 );
+		header( 'Cache-Control: no-cache' );
+		header( 'Content-Type: text/html; charset=utf-8' );
+		echo "You do not have rights to access this wiki in this way."
+		die();
+
+		// not really necessary due to die.
+		return false;
+	};
 }
 
 #

--- a/src/roles/saml/templates/samlLocalSettings.php.j2
+++ b/src/roles/saml/templates/samlLocalSettings.php.j2
@@ -75,7 +75,7 @@ if ( isset( $_SERVER['HTTP_X_SKIP_SAML'] ) ) {
 
 			// if * users can access via * ip addresses
 			if ( $wgMezaAllowSkipSamlUsers['*'][0] === '*' ) {
-				return true
+				return true;
 			}
 
 			// if * users can access via the current IP address
@@ -87,7 +87,7 @@ if ( isset( $_SERVER['HTTP_X_SKIP_SAML'] ) ) {
 		if ( isset( $wgMezaAllowSkipSamlUsers[$username] ) ) {
 
 			// user allowed from all IP addresses
-			if ( $wgMezaAllowSkipSamlUsers[$username] === '*' ) {
+			if ( $wgMezaAllowSkipSamlUsers[$username][0] === '*' ) {
 				return true;
 			}
 

--- a/src/roles/saml/templates/samlLocalSettings.php.j2
+++ b/src/roles/saml/templates/samlLocalSettings.php.j2
@@ -37,7 +37,7 @@ if ( $_SERVER['HTTP_X_SKIP_SAML'] ) {
 	// FIXME: The indenting below will be heinous when Ansible does its templating
 	{% if allow_skip_saml_users is defined and isinstance(allow_skip_saml_users, basestring) %}
 	$wgMezaAllowSkipSamlUsers = '{{ allow_skip_saml_users }}';
-	{% else %}
+	{% elif allow_skip_saml_users is defined %}
 		$wgMezaAllowSkipSamlUsers = array();
 		{% for user, ipaddrs in allow_skip_saml_users.iteritems() %}
 			{% if isinstance(ipaddrs, basestring) %}
@@ -49,6 +49,8 @@ if ( $_SERVER['HTTP_X_SKIP_SAML'] ) {
 				{% endfor %}
 			{% endif %}
 		{% endfor %}
+	{% else %}
+	$wgMezaAllowSkipSamlUsers = false;
 	{% endif %}
 
 	// Upon login if user is allowed to skip SAML (and therefore use the API

--- a/src/roles/saml/templates/samlLocalSettings.php.j2
+++ b/src/roles/saml/templates/samlLocalSettings.php.j2
@@ -1,6 +1,27 @@
 <?php
 
 #
+# If X-SKIP-SAML header is present, disallow anonymous viewing and editing and
+# skip SAML login. Allow standard MediaWiki login.
+#
+if ( $_SERVER['HTTP_X_SKIP_SAML'] ) {
+
+	# Disable reading by anonymous users
+	$wgGroupPermissions['*']['read'] = false;
+
+	# But allow them to access the login page or else there will be no way to log in!
+	# (You also might want to add access to "Main Page", "Help:Contents", etc.)
+	$wgWhitelistRead = array ("Special:Userlogin");
+
+	# Disable anonymous editing
+	$wgGroupPermissions['*']['edit'] = false;
+
+	# Prevent new user registrations except by sysops
+	$wgGroupPermissions['*']['createaccount'] = false;
+
+}
+
+#
 # Extension:SimpleSamlAuth
 #
 # Only do auth on requests from outside the server. Requests from inside are a
@@ -9,7 +30,7 @@
 #
 # Ref: https://www.mediawiki.org/wiki/Talk:Parsoid/Archive#Running_Parsoid_on_a_.22private.22_wiki_-_AccessDeniedError
 # Ref: https://www.mediawiki.org/wiki/Extension:VisualEditor#Linking_with_Parsoid_in_private_wikis
-if ( isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
+elseif ( isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
 
 	// wfLoadExtension( 'SimpleSamlAuth' );
 	require_once "$IP/extensions/SimpleSamlAuth/SimpleSamlAuth.php";

--- a/src/roles/saml/templates/samlLocalSettings.php.j2
+++ b/src/roles/saml/templates/samlLocalSettings.php.j2
@@ -24,9 +24,8 @@ if ( isset( $_SERVER['HTTP_X_SKIP_SAML'] ) ) {
 
 	// Add to config like:
 	//
-	// allow_skip_saml_users: "*"
-	//  -- or --
 	// allow_skip_saml_users:
+	//   - __allusers: ["*"]
 	//   - James: ["192.168.56.62","23.243.32.123"]
 	//   - Daren: ["*"]
 	//   - Lauren:

--- a/src/roles/saml/templates/samlLocalSettings.php.j2
+++ b/src/roles/saml/templates/samlLocalSettings.php.j2
@@ -4,7 +4,7 @@
 # If X-SKIP-SAML header is present, disallow anonymous viewing and editing and
 # skip SAML login. Allow standard MediaWiki login.
 #
-if ( $_SERVER['HTTP_X_SKIP_SAML'] ) {
+if ( isset( $_SERVER['HTTP_X_SKIP_SAML'] ) ) {
 
 	# Disable reading, editing and account creation by anonymous users
 	$wgGroupPermissions['*']['read'] = false;
@@ -28,30 +28,25 @@ if ( $_SERVER['HTTP_X_SKIP_SAML'] ) {
 	//  -- or --
 	// allow_skip_saml_users:
 	//   - James: ["192.168.56.62","23.243.32.123"]
-	//   - Daren: "*"
+	//   - Daren: ["*"]
 	//   - Lauren:
 	//     - "192.54.43.13"
 	//     - "3.3.2.1"
-	//   - Willa: "192.169.34.23"
+	//   - Willa:
+	//     - "192.169.34.23"
 	//
 	// FIXME: The indenting below will be heinous when Ansible does its templating
-	{% if allow_skip_saml_users is defined and isinstance(allow_skip_saml_users, basestring) %}
-	$wgMezaAllowSkipSamlUsers = '{{ allow_skip_saml_users }}';
-	{% elif allow_skip_saml_users is defined %}
+	{% if allow_skip_saml_users is defined -%}
 		$wgMezaAllowSkipSamlUsers = array();
-		{% for user, ipaddrs in allow_skip_saml_users.iteritems() %}
-			{% if isinstance(ipaddrs, basestring) %}
-			$wgMezaAllowSkipSamlUsers['{{ user }}'] = '{{ ipaddrs }}';
-			{% else %}
-				$wgMezaAllowSkipSamlUsers['{{ user }}'] = array();
-				{% for ipaddr in ipaddrs %}
-				$wgMezaAllowSkipSamlUsers['{{ user }}']][] = '{{ ipaddr }}';
-				{% endfor %}
-			{% endif %}
-		{% endfor %}
-	{% else %}
-	$wgMezaAllowSkipSamlUsers = false;
-	{% endif %}
+		{% for user, ipaddrs in allow_skip_saml_users.iteritems() -%}
+			$wgMezaAllowSkipSamlUsers['{{ user }}'] = array(
+				{% for ipaddr in ipaddrs %}'{{ ipaddr }}',{% endfor %}
+			);
+		{%- endfor %}
+	{% else -%}
+		$wgMezaAllowSkipSamlUsers = false;
+	{%- endif %}
+
 
 	// Upon login if user is allowed to skip SAML (and therefore use the API
 	// externally)

--- a/src/roles/saml/templates/samlLocalSettings.php.j2
+++ b/src/roles/saml/templates/samlLocalSettings.php.j2
@@ -56,13 +56,13 @@ if ( isset( $_SERVER['HTTP_X_SKIP_SAML'] ) ) {
 		$username = $user->getName();
 		$ipaddr = $_SERVER['HTTP_X_FORWARDED_FOR'];
 
-		$forbidden = function () {
+		$forbidden = function ($msg='') {
 			// lightly copied from MediaWiki's img_auth.php
 			HttpStatus::header( 403 );
 			header( 'Cache-Control: no-cache' );
 			header( 'Content-Type: text/html; charset=utf-8' );
 			echo "You do not have rights to access this wiki in this way.";
-			die();
+			die($msg);
 		};
 
 		if ( ! is_array( $wgMezaAllowSkipSamlUsers ) ) {
@@ -71,15 +71,15 @@ if ( isset( $_SERVER['HTTP_X_SKIP_SAML'] ) ) {
 		}
 
 		// allow option to greenlight all users
-		if ( isset( $wgMezaAllowSkipSamlUsers['*'] ) ) {
+		if ( isset( $wgMezaAllowSkipSamlUsers['__allusers'] ) ) {
 
 			// if * users can access via * ip addresses
-			if ( $wgMezaAllowSkipSamlUsers['*'][0] === '*' ) {
+			if ( $wgMezaAllowSkipSamlUsers['__allusers'][0] === '*' ) {
 				return true;
 			}
 
 			// if * users can access via the current IP address
-			elseif ( in_array( $ipaddr, $wgMezaAllowSkipSamlUsers['*'] ) ) {
+			elseif ( in_array( $ipaddr, $wgMezaAllowSkipSamlUsers['__allusers'] ) ) {
 				return true;
 			}
 		}


### PR DESCRIPTION
Allow API access despite SAML SSO. Add configuration like:

```yaml
allow_skip_saml_users:
  James: ["192.168.56.62","23.243.32.123"]
  Daren: ["*"]
  Lauren:
    - "192.54.43.13"
    - "3.3.2.1"
  Willa:
    - "192.169.34.23"
```

Alternatively, allow all users from all IP addresses:

```yaml
allow_skip_saml_users:
  __allusers: ["*"]
```

Then you can hit the API from the command line or any other external source by adding the `X-SKIP-SAML` header (which tells the system to not use SAML). Per the config above you can limit this to specific users and IP addresses. 

An example of accessing the API in Bash looks like:

```bash
#!/usr/bin/env bash

#Needs curl and jq

USERNAME="Someuser"
USERPASS="1234"
QUERY="action=query&list=recentchanges&format=json"
WIKIAPI="https://example.com/wiki/api.php"
cookie_jar="wikicj"
#Will store file in wikifile

# if your SSL cert isn't good you may need this...or you should fix your SSL
insecure="--insecure"
# insecure=""

echo "UTF8 check: ☠"
#################login
echo "Logging into $WIKIAPI as $USERNAME..."

###############
#Login part 1
#printf "%s" "Logging in (1/2)..."
echo "Get login token..."
CR=$(curl -S \
	--location $insecure \
	--retry 2 \
	--retry-delay 5\
	--cookie $cookie_jar \
	--cookie-jar $cookie_jar \
	--user-agent "Curl Shell Script" \
	--keepalive-time 60 \
	--header "Accept-Language: en-us" \
	--header "Connection: keep-alive" \
	--header "X-SKIP-SAML: True" \
	--compressed \
	--request "GET" "${WIKIAPI}?action=query&meta=tokens&type=login&format=json")

echo "$CR" | jq .

rm login.json
echo "$CR" > login.json
TOKEN=$(jq --raw-output '.query.tokens.logintoken' login.json)
TOKEN="${TOKEN//\"/}" #replace double quote by nothing

#Remove carriage return!
printf "%s" "$TOKEN" > token.txt
TOKEN=$(cat token.txt | sed 's/\r$//')


if [ "$TOKEN" == "null" ]; then
	echo "Getting a login token failed."
	exit
else
	echo "Login token is $TOKEN"
	echo "-----"
fi

###############
#Login part 2
echo "Logging in..."
CR=$(curl -S \
	--location $insecure \
	--cookie $cookie_jar \
	--cookie-jar $cookie_jar \
	--user-agent "Curl Shell Script" \
	--keepalive-time 60 \
	--header "Accept-Language: en-us" \
	--header "Connection: keep-alive" \
	--header "X-SKIP-SAML: True" \
	--compressed \
	--data-urlencode "username=${USERNAME}" \
	--data-urlencode "password=${USERPASS}" \
	--data-urlencode "rememberMe=1" \
	--data-urlencode "logintoken=${TOKEN}" \
	--data-urlencode "loginreturnurl=http://en.wikipedia.org" \
	--request "POST" "${WIKIAPI}?action=clientlogin&format=json")

echo "$CR" | jq .

STATUS=$(echo $CR | jq '.clientlogin.status')
if [[ $STATUS == *"PASS"* ]]; then
	echo "Successfully logged in as $USERNAME, STATUS is $STATUS."
	echo "-----"
else
	echo "Unable to login, is logintoken ${TOKEN} correct?"
	exit
fi

###################
#Get recent changes
echo "Fetching recent changes..."
CR=$(curl -S \
	--location $insecure \
	--cookie $cookie_jar \
	--cookie-jar $cookie_jar \
	--user-agent "Curl Shell Script" \
	--keepalive-time 60 \
	--header "Accept-Language: en-us" \
	--header "Connection: keep-alive" \
	--header "X-SKIP-SAML: True" \
	--compressed \
	--request "GET" "${WIKIAPI}?${QUERY}")

echo "$CR" | jq .
echo "$CR" > recentchanges.json
```