### PR TITLE
Add wgUsePrivateIPs and list of load balancers

### DIFF
--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -381,9 +381,13 @@ $wgSharedTables = array(
 // proxy setup
 $wgUsePrivateIPs = true;
 $wgSquidServersNoPurge = array(
-    {% for server in groups['load-balancers'] -%}
-    '{{ server }}',
-    {%- endfor %}
+	{% for server in groups['load-balancers'] -%}
+	{%- if server == inventory_hostname or server == 'localhost' -%}
+	'localhost','127.0.0.1',
+	{%- else -%}
+	'{{ server }}',
+	{%- endif -%}
+	{%- endfor %}
 );
 
 // memcached settings

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -378,6 +378,14 @@ $wgSharedTables = array(
  *
  *
  **/
+// proxy setup
+$wgUsePrivateIPs = true;
+$wgSquidServersNoPurge = array(
+    {% for server in groups['load-balancers'] -%}
+    '{{ server }}',
+    {%- endfor %}
+);
+
 // memcached settings
 $wgMainCacheType = CACHE_MEMCACHED;
 // If parser cache set to CACHE_MEMCACHED, templates used to format SMW query


### PR DESCRIPTION
Need to specify that MediaWiki should use the `X-Forwarded-For` header sent from HAProxy when recording user IP addresses. This is done via [`$wgUsePrivateIPs`](https://www.mediawiki.org/wiki/Manual:$wgUsePrivateIPs) and [`$wgSquidServersNoPurge`](https://www.mediawiki.org/wiki/Manual:$wgSquidServersNoPurge).

Closes #644 