### PR TITLE
Use SMW 2.5.x branch until 2.5.2 release, specify SRF 2.4.x

### DIFF
--- a/config/core/MezaCoreExtensions.yml
+++ b/config/core/MezaCoreExtensions.yml
@@ -3,7 +3,7 @@ list:
 
   - name: Semantic MediaWiki
     composer: "mediawiki/semantic-media-wiki"
-    version: "~2.4"
+    version: "2.5.x-dev"
     config: |
       // Enable Semantic MediaWiki semantics
       enableSemantics( $wikiId );
@@ -18,7 +18,7 @@ list:
 
   - name: Semantic Result Formats
     composer: "mediawiki/semantic-result-formats"
-    version: "~2.0"
+    version: "2.4.x"
     config: |
       // SemanticResultFormats formats enabled (beyond defaults)
       // These are disabled by default because they send data to external


### PR DESCRIPTION
SMW 2.5.2 should be released soon (perhaps today), but as it stands SRF does not work properly with SMW 2.5.1 and we need to make meza fully functional. Use the 2.5.x branch, which in composer is specified with `2.5.x-dev`.

Also more tightly specify SRF version, e.g. `2.4.x` (which allows `2.4.0` through `2.4.999+`) instead of `~2.0` (which allows `2.0` through `2.999+`). Bugfix changes (the third digit in [semantic versioning](http://semver.org/)) are much less likely to cause breaking changes than the minor version changes (second digit), even though technically minor version changes shouldn't cause breaking changes.

Addresses #636 