### PR TITLE
Disable cron jobs when running an overwriting import

### DIFF
--- a/src/roles/base/tasks/main.yml
+++ b/src/roles/base/tasks/main.yml
@@ -105,6 +105,7 @@
     - rsyslog
     - jq
     - tree
+    - cronie
 - name: put SELinux in permissive mode
   selinux:
     policy: targeted
@@ -187,3 +188,8 @@
     mode: 0755
     state: directory
 
+# Prevent runJobs and other scripts from running when application may be in
+# indeterminate state
+- name: Ensure crontab empty for meza-ansible when overwriting wikis
+  shell: crontab -u meza-ansible -r
+  when: force_overwrite_from_backup is defined and force_overwrite_from_backup == true

--- a/src/roles/cron/tasks/main.yml
+++ b/src/roles/cron/tasks/main.yml
@@ -1,9 +1,10 @@
 ---
 
-- name: Ensure cron installed
-  yum:
-    name: cronie
-    state: installed
+# Handled in role:base now
+# - name: Ensure cron installed
+#   yum:
+#     name: cronie
+#     state: installed
 
 - name: Ensure cron is running (and enable it at boot)
   service:


### PR DESCRIPTION
When running a deploy with `--overwrite`, databases/wikis are in an indeterminate state through the process. They may exist but be old data, they may not exist, they may have new data but not be updated yet (e.g. update.php), or they may be in the final state. Running cron jobs like `runJobs.php` could have strange results, and could possibly cause damage. For now, fully disable cron during `--overwrite` deploys. Note that at some point if we have the ability to just overwrite certain wikis this heavy-handed method may need to be rethought.