### PR TITLE
Fix discrepant email settings

### DIFF
--- a/src/roles/init-controller-config/templates/vars.yml.j2
+++ b/src/roles/init-controller-config/templates/vars.yml.j2
@@ -12,7 +12,7 @@ blender_landing_page_title: Test of Meza Wikis
 
 # Enable emails. Can be disabled on a per-wiki basis in a wiki's
 # preLocalSettings.d directory
-enable_all_wiki_email: True
+enable_wiki_emails: True
 
 # Email senders
 # Refs:

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -255,7 +255,7 @@ $wgResourceBasePath = $wgScriptPath;
  *
  *  Email configuration
  **/
-{% if enable_all_wiki_email is defined and enable_all_wiki_email %}
+{% if enable_wiki_emails is defined and enable_wiki_emails %}
 if ( isset( $mezaEnableWikiEmail ) && $mezaEnableWikiEmail ) {
 	$wgEnableEmail = true;
 }


### PR DESCRIPTION
Both `enable_all_wiki_email` and `enable_wiki_emails` were being used. Just use `enable_wiki_emails` since it's used in more places.