### PR TITLE
Specify commit for SimpleMathJax

### DIFF
--- a/config/core/MezaCoreExtensions.yml
+++ b/config/core/MezaCoreExtensions.yml
@@ -131,7 +131,7 @@ list:
     version: REL1_27
   - name: SimpleMathJax
     repo: https://github.com/jamesmontalvo3/SimpleMathJax.git
-    version: master
+    version: e94afaffcdde8d926b166fdd166162f9519beaa1
     legacy_load: True
   - name: ImageMap
     repo: https://gerrit.wikimedia.org/r/mediawiki/extensions/ImageMap


### PR DESCRIPTION
A PR [1] was submitted to Extension:SimpleMathJax from the fork we use [2] to fix some issues that Meza needed. Meza then used the fork's `master` branch. When the PR was merged with other changes, the master branch of our fork was modified in such a way that the code broke. In the image below, the commit indicated by the arrow was the version being used by Meza for the last few weeks. The red-circled commits were our changes. Upon merge the other changes were merged in and master changed. This caused the daily build to fail [3].

This has been resolved by specifying the git commit hash to use from our fork. Ultimately a release tag would be better.

![image](https://cloud.githubusercontent.com/assets/716482/26170001/68eae958-3b05-11e7-8d0e-cc6e7a843e5b.png)

[1] jmnote/SimpleMathJax#7
[2] Our fork: https://github.com/jamesmontalvo3/SimpleMathJax
[3] https://travis-ci.org/enterprisemediawiki/meza/builds/233323297

