### PR TITLE
Remove 'localhost' as valid $wgSquidServersNoPurge

### DIFF
--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -383,7 +383,7 @@ $wgUsePrivateIPs = true;
 $wgSquidServersNoPurge = array(
 	{% for server in groups['load-balancers'] -%}
 	{%- if server == inventory_hostname or server == 'localhost' -%}
-	'localhost','127.0.0.1',
+	'127.0.0.1',
 	{%- else -%}
 	'{{ server }}',
 	{%- endif -%}


### PR DESCRIPTION
Else get:

> Warning: inet_pton(): Unrecognized address localhost in /opt/htdocs/mediawiki/vendor/wikimedia/ip-set/src/IPSet.php on line 132

Closes #665 