### PR TITLE
Fix composer cache issues on Travis CI

### DIFF
--- a/src/roles/composer/tasks/main.yml
+++ b/src/roles/composer/tasks/main.yml
@@ -34,6 +34,11 @@
   changed_when: "'Updating to version' in composer_update.stdout"
   when: composer_keep_updated
 
+- name: Ensure composer cache is clear
+  shell: "{{ composer_path }} clear-cache"
+  when: "'Updating to version' in composer_update.stdout"
+
+
 - name: Ensure composer directory exists.
   file:
     path: "{{ composer_home_path }}"


### PR DESCRIPTION
Composer was installed a long time ago on the Docker images used on Travis CI. Composer cache-clearing required. For now just clear cache if Composer version updates. Perhaps it would be better to figure out how to read the age of the cache and update only after a certain age. This should work for now, though, and should get master to stop failing builds.
