### PR TITLE
Misc: saml config, empty crontab fix, primewiki first, external load balancer

### DIFF
--- a/src/playbooks/site.yml
+++ b/src/playbooks/site.yml
@@ -61,7 +61,7 @@
 # servers in "exclude-all" group. At present, the intent of this group is to
 # allow servers which serve as sources for database and user-uploaded files,
 # but are not managed by this meza install.
-- hosts: all:!exclude-all
+- hosts: all:!exclude-all:!load-balancers-unmanaged
   become: yes
   roles:
     - set-vars
@@ -94,6 +94,12 @@
       firewalld_protocol: tcp
       firewalld_servers: "{{ groups['load-balancers'] }}"
       firewalld_zone: "{{m_private_networking_zone|default('public')}}"
+    - role: firewalld
+      firewalld_port: 8080
+      firewalld_protocol: tcp
+      firewalld_servers: "{{ groups['load-balancers-unmanaged'] }}"
+      firewalld_zone: "{{m_private_networking_zone|default('public')}}"
+      when: "'load-balancers-unmanaged' in groups"
     - role: firewalld
       firewalld_port: 8080
       firewalld_protocol: tcp
@@ -224,7 +230,7 @@
     - set-vars
     - meza-log
 
-- hosts: all:!exclude-all
+- hosts: all:!exclude-all:!load-balancers-unmanaged
   become: yes
   tags: cron
   roles:

--- a/src/roles/base/tasks/main.yml
+++ b/src/roles/base/tasks/main.yml
@@ -193,3 +193,7 @@
 - name: Ensure crontab empty for meza-ansible when overwriting wikis
   shell: crontab -u meza-ansible -r
   when: force_overwrite_from_backup is defined and force_overwrite_from_backup == true
+
+  # Ignore errors due issue #699: If a crontab doesn't exist yet this command
+  # will fail
+  ignore_errors: yes

--- a/src/roles/haproxy/tasks/main.yml
+++ b/src/roles/haproxy/tasks/main.yml
@@ -44,7 +44,7 @@
 - name: If not exists, create self-signed SSL cert on CONTROLLER
   command: |
     openssl req -new -newkey rsa:2048 -days 365 -nodes -x509 \
-      -subj "/C=US/ST=TX/L=Houston/O=EnterpriseMediaWiki/CN=${ansible_fqdn}" \
+      -subj "/C=US/ST=TX/L=Houston/O=EnterpriseMediaWiki/CN={{ wiki_app_fqdn}}" \
       -keyout {{ m_local_secret }}/{{ env }}/ssl/meza.key \
       -out {{ m_local_secret }}/{{ env }}/ssl/meza.crt
   when: ssl_cert_stat_result.stat.exists == False

--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -206,13 +206,15 @@
   delegate_to: localhost
   run_once: yes
 
-- set_fact:
+- name: Set fact - list of wikis
+  set_fact:
     list_of_wikis: "{{ wikis_dirs.files | map(attribute='path') | map('basename') | list }}"
 
 # Sort list of wikis so primary wiki is first. Need to have primary wiki's
 # `user` table in place before other wikis are imported, otherwise will get
 # errors when running update.php and such
-- set_fact:
+- name: Set fact - list of wikis ordered with primary wiki first (if primary_wiki_id set)
+  set_fact:
     list_of_wikis: "['{{ primary_wiki_id }}'] + {{ list_of_wikis | difference([primary_wiki_id]) }}"
   when: primary_wiki_id is defined
 

--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -209,6 +209,13 @@
 - set_fact:
     list_of_wikis: "{{ wikis_dirs.files | map(attribute='path') | map('basename') | list }}"
 
+# Sort list of wikis so primary wiki is first. Need to have primary wiki's
+# `user` table in place before other wikis are imported, otherwise will get
+# errors when running update.php and such
+- set_fact:
+    list_of_wikis: "['{{ primary_wiki_id }}'] + {{ list_of_wikis | difference([primary_wiki_id]) }}"
+  when: primary_wiki_id is defined
+
 - debug: { var: list_of_wikis }
 
 # Check that all wikis in config are present on app and DB servers

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -388,6 +388,13 @@ $wgSquidServersNoPurge = array(
 	'{{ server }}',
 	{%- endif -%}
 	{%- endfor %}
+	{% if 'load-balancers-unmanaged' in groups and groups['load-balancers-unmanaged']|length|int > 0 %}
+	# unmanaged load-balancers, e.g. load balancers not maintained by meza,
+	# such as AWS or Digital Ocean
+	{% for server in groups['load-balancers-unmanaged'] -%}
+	'{{ server }}',
+	{%- endfor %}
+	{% endif %}
 );
 
 // memcached settings

--- a/src/roles/saml/templates/authsources.php.j2
+++ b/src/roles/saml/templates/authsources.php.j2
@@ -19,7 +19,14 @@ $config = array(
 
         // The entity ID of this SP.
         // Can be NULL/unset, in which case an entity ID is generated based on the metadata URL.
+        {% if saml_secret.sp_entity_id is defined %}
+        'entityID' => '{{ saml_secret.sp_entity_id }}',
+        {% elif saml_public.sp_entity_id is defined %}
         'entityID' => '{{ saml_public.sp_entity_id }}',
+        {% else %}
+        'entityID' => null,
+        {% endif %}
+
         'NameIDPolicy' => '{{ saml_public.name_id_policy }}',
 
         // The entity ID of the IdP this should SP should contact.


### PR DESCRIPTION
Address issues:
* Close #697: Allow sp_entity_id to be in secret or public
* Close #699: Fix errors when emptying empty crontab
* Close #700: Import primary wiki first
* Close #683: Create method for external load balancer
* Fix common name on self-signed certificate