### PR TITLE
On create-wiki, limit build smw and search data to new wiki

### DIFF
--- a/src/roles/create-wiki-wrapper/tasks/main.yml
+++ b/src/roles/create-wiki-wrapper/tasks/main.yml
@@ -26,13 +26,13 @@
 # FIXME: WILL ONLY WORK WHEN CONTROLLER AND APP-SERVER ARE THE SAME MACHINE
 # Not totally sure SMW-rebuild is necessary, but maybe for imported pages?
 - name: (Re-)build search index for each wiki
-  shell: "bash /opt/meza/src/scripts/elastic-rebuild-all.sh"
+  shell: "bash /opt/meza/src/scripts/elastic-rebuild-all.sh {{ wiki_id }}"
   run_once: true
   tags:
   - search-index
 
 - name: Rebuild SemanticMediaWiki data for each wiki
-  shell: "bash /opt/meza/src/scripts/smw-rebuild-all.sh"
+  shell: "bash /opt/meza/src/scripts/smw-rebuild-all.sh {{ wiki_id }}"
   run_once: true
   tags:
   - smw-data

--- a/src/scripts/elastic-rebuild-all.sh
+++ b/src/scripts/elastic-rebuild-all.sh
@@ -2,30 +2,50 @@
 
 source "/opt/.deploy-meza/config.sh"
 
-cd /opt/htdocs/wikis
-for d in */; do
+if [ -z "$1" ]; then
+	do_wikis="*/"
+else
+	do_wikis="$1"
+fi
 
-    wiki_id=${d%/}
-	timestamp=$(date +%s)
+wiki_dir="$m_htdocs/wikis"
+
+cd "$wiki_dir"
+for d in $do_wikis; do
+
+	if [ -z "$1" ]; then
+		wiki_id=${d%/}
+	else
+		wiki_id="$d"
+	fi
+
+	if [ ! -d "$wiki_dir/$wiki_id" ]; then
+		echo "\"$wiki_id\" not a valid wiki ID"
+		continue
+	fi
+
+	timestamp=$(date +"%F_%T")
 
 	out_log="$m_logs/search-index.$wiki_id.$timestamp.log"
 
-    echo "Rebuilding index for $wiki_id"
-    echo "  Output log:"
-    echo "    $out_log"
+	echo "Rebuilding index for $wiki_id"
+	echo "  Output log:"
+	echo "    $out_log"
 
 
-	wiki_id="$wiki_id" bash /opt/meza/src/scripts/elastic-build-index.sh > "$out_log"
+	wiki_id="$wiki_id" bash /opt/meza/src/scripts/elastic-build-index.sh > "$out_log"  2>&1
+
+	endtimestamp=$(date +"%F_%T")
 
 	# If the above command had a failing exit code
 	if [[ $? -ne 0 ]]; then
 
 		# FIXME: add notification/warning system here
-		echo "elastic-build-index FAILED for $wiki_id"
+		echo "elastic-build-index FAILED for \"$wiki_id\" at $endtimestamp"
 
 	#if the above command had a passing exit code (e.g. zero)
 	else
-		echo "elastic-build-index completed for $wiki_id"
+		echo "elastic-build-index completed for \"$wiki_id\" at $endtimestamp"
 	fi
 
 done

--- a/src/scripts/smw-rebuild-all.sh
+++ b/src/scripts/smw-rebuild-all.sh
@@ -2,36 +2,55 @@
 
 source "/opt/.deploy-meza/config.sh"
 
-cd "$m_htdocs/wikis"
-for d in */; do
+if [ -z "$1" ]; then
+	do_wikis="*/"
+else
+	do_wikis="$1"
+fi
 
-    wiki_id=${d%/}
+wiki_dir="$m_htdocs/wikis"
 
-	timestamp=$(date +%s)
+cd "$wiki_dir"
+for d in $do_wikis; do
+
+	if [ -z "$1" ]; then
+		wiki_id=${d%/}
+	else
+		wiki_id="$d"
+	fi
+
+	if [ ! -d "$wiki_dir/$wiki_id" ]; then
+		echo "\"$wiki_id\" not a valid wiki ID"
+		continue
+	fi
+
+	timestamp=$(date +"%F_%T")
 	exception_log="$m_logs/smw-rebuilddata-exceptions-$wiki_id-$timestamp.log"
 	out_log="$m_logs/smw-rebuilddata-out.$wiki_id.$timestamp.log"
 
-    echo "Rebuilding SMW data for $wiki_id"
-    echo "  Exception log (if req'd):"
-    echo "    $exception_log"
-    echo "  Output log:"
-    echo "    $out_log"
+	echo "Start rebuilding SMW data for \"$wiki_id\" at $timestamp"
+	echo "  Exception log (if req'd):"
+	echo "    $exception_log"
+	echo "  Output log:"
+	echo "    $out_log"
 
 	WIKI="$wiki_id" \
 	php "$m_mediawiki/extensions/SemanticMediaWiki/maintenance/rebuildData.php" \
 	-d 5 -v --ignore-exceptions \
 	--exception-log="$exception_log" \
-	> "$out_log"
+	> "$out_log" 2>&1
+
+	endtimestamp=$(date +"%F_%T")
 
 	# If the above command had a failing exit code
 	if [[ $? -ne 0 ]]; then
 
 		# FIXME: add notification/warning system here
-		echo "rebuildData FAILED for $wiki_id"
+		echo "rebuildData FAILED for \"$wiki_id\" at $endtimestamp"
 
 	#if the above command had a passing exit code (e.g. zero)
 	else
-		echo "rebuildData completed for $wiki_id"
+		echo "rebuildData completed for \"$wiki_id\" at $endtimestamp"
 	fi
 
 done


### PR DESCRIPTION
Previously, `meza create wiki <env>` was running rebuild smw-data and search-index on all wikis.

Also:
* Close #590 