### PR TITLE
Limit rebuild SMW and search index data to when DB has been imported

### DIFF
--- a/src/playbooks/backup.yml
+++ b/src/playbooks/backup.yml
@@ -20,7 +20,7 @@
 #
 
 # Define a timestamp fact to persist throughout this playbook
-- hosts: all
+- hosts: all:!exclude-all:!load-balancers-unmanaged
   tasks:
     - set_fact:
         backup_timestamp: "{{lookup('pipe','date +%Y%m%d%H%M%S')}}"

--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -220,6 +220,10 @@
 
 - debug: { var: list_of_wikis }
 
+- name: Set fact - initiate empty list of wikis to rebuild smw and search data
+  set_fact:
+    wikis_to_rebuild_data: []
+
 # Check that all wikis in config are present on app and DB servers
 - name: Ensure defined wikis exist
   include_role:
@@ -235,17 +239,19 @@
   - verify-wiki
   when: docker_skip_tasks is not defined or not docker_skip_tasks
 
+- debug: { var: wikis_to_rebuild_data }
+
 # Wikis are totally built at this point, but SMW and search need rebuilding
 # FIXME: WILL ONLY WORK WHEN CONTROLLER AND APP-SERVER ARE THE SAME MACHINE
-- name: (Re-)build search index for each wiki
-  shell: "bash /opt/meza/src/scripts/elastic-rebuild-all.sh"
+- name: "(Re-)build search index for: {{ wikis_to_rebuild_data | join(', ') }}"
+  shell: "bash /opt/meza/src/scripts/elastic-rebuild-all.sh \"{{ wikis_to_rebuild_data | join(' ') }}\""
   when: docker_skip_tasks is not defined or not docker_skip_tasks
   run_once: true
   tags:
   - search-index
 
-- name: Rebuild SemanticMediaWiki data for each wiki
-  shell: "bash /opt/meza/src/scripts/smw-rebuild-all.sh"
+- name: "(Re-)build SemanticMediaWiki data for: {{ wikis_to_rebuild_data | join(', ') }}"
+  shell: "bash /opt/meza/src/scripts/smw-rebuild-all.sh \"{{ wikis_to_rebuild_data | join(' ') }}\""
   when: docker_skip_tasks is not defined or not docker_skip_tasks
   run_once: true
   tags:

--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -245,14 +245,14 @@
 # FIXME: WILL ONLY WORK WHEN CONTROLLER AND APP-SERVER ARE THE SAME MACHINE
 - name: "(Re-)build search index for: {{ wikis_to_rebuild_data | join(', ') }}"
   shell: "bash /opt/meza/src/scripts/elastic-rebuild-all.sh \"{{ wikis_to_rebuild_data | join(' ') }}\""
-  when: docker_skip_tasks is not defined or not docker_skip_tasks
+  when: (docker_skip_tasks is not defined or not docker_skip_tasks) and (wikis_to_rebuild_data|length > 0)
   run_once: true
   tags:
   - search-index
 
 - name: "(Re-)build SemanticMediaWiki data for: {{ wikis_to_rebuild_data | join(', ') }}"
   shell: "bash /opt/meza/src/scripts/smw-rebuild-all.sh \"{{ wikis_to_rebuild_data | join(' ') }}\""
-  when: docker_skip_tasks is not defined or not docker_skip_tasks
+  when: (docker_skip_tasks is not defined or not docker_skip_tasks) and (wikis_to_rebuild_data|length > 0)
   run_once: true
   tags:
   - smw-data

--- a/src/roles/verify-wiki/tasks/main.yml
+++ b/src/roles/verify-wiki/tasks/main.yml
@@ -256,8 +256,17 @@
     state: import
     target: "{{ m_tmp }}/wiki.sql"
   run_once: true
+  register: did_db_import
   delegate_to: "{{ groups['db-master'][0] }}"
   when: not wiki_exists or do_overwrite_db_from_backup
+
+- name: Did DB import?
+  debug: { var: did_db_import }
+
+- name: Add wiki to list of DB-imported wikis if required
+  set_fact:
+    wikis_to_rebuild_data: "{{ wikis_to_rebuild_data + [ wiki_id ] }}"
+  when: did_db_import is defined and did_db_import.changed is defined and did_db_import.changed
 
 - name: "{{ wiki_id }} - Remove SQL file from master DB"
   file:

--- a/src/roles/verify-wiki/tasks/main.yml
+++ b/src/roles/verify-wiki/tasks/main.yml
@@ -263,6 +263,11 @@
 - name: Did DB import?
   debug: { var: did_db_import }
 
+- name: Initiate wikis_to_rebuild_data if not exists
+  set_fact:
+    wikis_to_rebuild_data: []
+  when: wikis_to_rebuild_data is not defined
+
 - name: Add wiki to list of DB-imported wikis if required
   set_fact:
     wikis_to_rebuild_data: "{{ wikis_to_rebuild_data + [ wiki_id ] }}"


### PR DESCRIPTION
When a new wiki DB is created or dropped-and-reimported, rebuild data. Else, skip.

Closes #695 