### PR TITLE
Rewrite rule to thwart MS-Office pre-fetching, which breaks SSO

### DIFF
--- a/src/roles/htdocs/tasks/main.yml
+++ b/src/roles/htdocs/tasks/main.yml
@@ -40,3 +40,4 @@
   with_items:
   - ".htaccess"
   - "index.php"
+  - "office.html"

--- a/src/roles/htdocs/templates/.htaccess.j2
+++ b/src/roles/htdocs/templates/.htaccess.j2
@@ -6,6 +6,12 @@
 
     RewriteBase /
 
+    # This is needed for Links inside MS Office documents to resolve properly
+    # when using single sign on.
+    # Ref: https://groups.google.com/forum/#!topic/simplesamlphp/LcykPSQj_IQ
+    RewriteCond %{HTTP_USER_AGENT} ms-office [NC]
+    RewriteRule ^ - [L,R=200]
+
     # Allow access to root index.php
     RewriteRule ^index.php(.*) - [L]
 

--- a/src/roles/htdocs/templates/office.html.j2
+++ b/src/roles/htdocs/templates/office.html.j2
@@ -1,0 +1,6 @@
+<html>
+<head><title>Dummy file for Office docs</title></head>
+<body>
+<p>This is a dummy file to make it so office documents don't break SAML authentication. Reference <a href="https://github.com/enterprisemediawiki/meza/pull/739">meza issue #739</a></p>
+</body>
+</html>


### PR DESCRIPTION
When you click a link in a Microsoft Office document, it pre-fetches the link and if it gets a 3xx response code (redirect) then it follows the redirect until it finds a 2xx (success) or 4xx (failure) response code. If a 2xx code it then opens the default web browser to the pre-fetched link (i.e. not to the link you clicked on, but to the redirected link). If it gets a 4xx response then MS Office gives you a popup saying it's a bad link.

When this is mixed with SimpleSamlPhp, errors occur. SSP forwards requests that do not have valid sessions on to the Identity Provider (IdP) configured for the wiki. This may result in multiple redirects, which MS Office follows. When MS Office gets to a 2xx response code somewhere in the IdP it determines it's a valid link and allows the MS Office user to progress to their default web browser, but the user is directed to the IdP URL instead of the wiki URL. Since the proper session was not established by the user starting at the wiki URL, the IdP does not know what to do and throws and error.

To mitigate this, this PR adds a line to the `.htaccess` file to redirect anything with the MS Office user agent to the file `office.html`. This HTML file is just a dummy file used to ensure that MS Office gets a 2xx response code when pre-fetching URLs

Closes #515

Reference:
* https://groups.google.com/forum/#!topic/simplesamlphp/LcykPSQj_IQ
* https://www.wimpyprogrammer.com/microsoft-office-link-pre-fetching-and-single-sign-on/
* simplesamlphp/simplesamlphp#542
