### PR TITLE
Properly set server interface for parsoid

### DIFF
--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -58,6 +58,7 @@ m_php_ini: /etc/php.ini
 m_memcached_conf: /etc/sysconfig/memcached
 m_parsoid_path: /etc/parsoid
 m_simplesamlphp_path: /opt/simplesamlphp
+m_profiling_ui_directory: /usr/share/pear/xhprof_html
 
 # files
 m_i18n: /opt/meza/config/core/i18n

--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -77,4 +77,6 @@ m_language: en
 
 allow_backup_downloads: false
 
+m_force_debug: false
+
 enable_wiki_emails: true

--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -26,6 +26,9 @@ m_meza_data: /opt/data-meza
 m_tmp: /opt/data-meza/tmp
 m_logs: /opt/data-meza/logs
 
+# Only if m_setup_php_profiling: true
+m_profiling_directory: /opt/data-meza/logs/profiling
+
 # uploads dir. This WILL BE OVERIDDEN if multiple app servers are used, and
 # instead will use /opt/data-meza/uploads-gluster to use GlusterFS distributed
 # file system.
@@ -80,3 +83,7 @@ allow_backup_downloads: false
 m_force_debug: false
 
 enable_wiki_emails: true
+
+# Only useful for developers and testing performance issues
+m_setup_php_profiling: false
+

--- a/src/playbooks/getdocker.yml
+++ b/src/playbooks/getdocker.yml
@@ -50,6 +50,8 @@
         name: "docker-ce"
         state: latest
       notify: Restart Docker
+      tags:
+      - latest
 
     - name: Ensure Docker is running (and enable it at boot)
       service:

--- a/src/playbooks/site.yml
+++ b/src/playbooks/site.yml
@@ -86,6 +86,17 @@
   tags: load-balancer
   roles:
     - set-vars
+    - role: firewalld
+      firewalld_port: 8001
+      firewalld_protocol: tcp
+      firewalld_servers: "{{ groups['app-servers'] }}"
+      firewalld_zone: "{{m_private_networking_zone|default('public')}}"
+    - role: firewalld
+      firewalld_port: 8081
+      firewalld_protocol: tcp
+      firewalld_servers: "{{ groups['parsoid-servers'] }}"
+      firewalld_zone: "{{m_private_networking_zone|default('public')}}"
+    # NOTE: firewalld ports 80 and 443 opened to ALL within haproxy role
     - haproxy
 
 - hosts: app-servers
@@ -307,6 +318,17 @@
       firewalld_protocol: tcp
       firewalld_servers: "{{ groups['app-servers'] }}"
       firewalld_zone: "{{m_private_networking_zone|default('public')}}"
+    - role: firewalld
+      firewalld_port: 8000
+      firewalld_protocol: tcp
+      firewalld_servers: "{{ groups['load-balancers'] }}"
+      firewalld_zone: "{{m_private_networking_zone|default('public')}}"
+    - role: firewalld
+      firewalld_port: 8000
+      firewalld_protocol: tcp
+      firewalld_servers: "{{ groups['load-balancers-unmanaged'] }}"
+      firewalld_zone: "{{m_private_networking_zone|default('public')}}"
+      when: "'load-balancers-unmanaged' in groups"
     - nodejs
     - role: parsoid
       nodejs_install_npm_user: "nodejs"

--- a/src/roles/apache-php/tasks/main.yml
+++ b/src/roles/apache-php/tasks/main.yml
@@ -41,6 +41,8 @@
   # http://docs.ansible.com/ansible/playbooks_roles.html#dynamic-versus-static-includes
   static: yes
 
+
+
 # Only required for developers and performance testing
 - name: Install XHProf PECL package for profiling
   pear:
@@ -57,9 +59,20 @@
     state: directory
   when: m_setup_php_profiling
 
+- name: Install graphviz packages
+  yum:
+    name: graphviz
+    state: installed
+  when: m_setup_php_profiling
+
+
+
 # Now that PHP is installed, start apache
 - name: ensure apache is running (and enable it at boot)
-  service: name=httpd state=started enabled=yes
+  service:
+    name: httpd
+    state: started
+    enabled: yes
   when: docker_skip_tasks is not defined or not docker_skip_tasks
 
 

--- a/src/roles/apache-php/tasks/main.yml
+++ b/src/roles/apache-php/tasks/main.yml
@@ -38,7 +38,24 @@
 
 - name: Install PHP
   include: php.yml
+  # http://docs.ansible.com/ansible/playbooks_roles.html#dynamic-versus-static-includes
   static: yes
+
+# Only required for developers and performance testing
+- name: Install XHProf PECL package for profiling
+  pear:
+    name: pecl/xhprof-beta
+    state: present
+  when: m_setup_php_profiling
+
+- name: "Ensure {{ m_profiling_directory }} exists"
+  file:
+    path: "{{ m_profiling_directory }}"
+    owner: apache
+    group: apache
+    mode: 0755
+    state: directory
+  when: m_setup_php_profiling
 
 # Now that PHP is installed, start apache
 - name: ensure apache is running (and enable it at boot)

--- a/src/roles/apache-php/tasks/php.yml
+++ b/src/roles/apache-php/tasks/php.yml
@@ -73,6 +73,8 @@
   pear:
     name: "{{ item }}"
     state: latest
+  tags:
+  - latest
   with_items:
   - Mail
   - Net_SMTP

--- a/src/roles/apache-php/templates/httpd.conf.j2
+++ b/src/roles/apache-php/templates/httpd.conf.j2
@@ -422,6 +422,15 @@ Listen 8080
 	</Directory>
 	{%- endif %}
 
+	{% if m_setup_php_profiling -%}
+	# Use SimpleSamlPhp to handle authentication
+	Alias /xhprof-ui {{ m_profiling_ui_directory }}
+	<Directory {{ m_profiling_ui_directory }}>
+		Require all granted
+		Options All -Indexes
+	</Directory>
+	{%- endif %}
+
 </VirtualHost>
 
 # Use port 8090 to access mod_status. Not accessible outside firewall.

--- a/src/roles/apache-php/templates/php.ini.j2
+++ b/src/roles/apache-php/templates/php.ini.j2
@@ -895,6 +895,11 @@ default_socket_timeout = 60
 ;extension=php_xmlrpc.dll
 ;extension=php_xsl.dll
 
+{% if m_setup_php_profiling %}
+; Enable profiling capabilities for PHP
+extension=xhprof.so
+{% endif %}
+
 ;;;;;;;;;;;;;;;;;;;
 ; Module Settings ;
 ;;;;;;;;;;;;;;;;;;;

--- a/src/roles/apache-php/templates/php.ini.j2
+++ b/src/roles/apache-php/templates/php.ini.j2
@@ -898,6 +898,7 @@ default_socket_timeout = 60
 {% if m_setup_php_profiling %}
 ; Enable profiling capabilities for PHP
 extension=xhprof.so
+xhprof.output_dir={{ m_profiling_directory }}
 {% endif %}
 
 ;;;;;;;;;;;;;;;;;;;

--- a/src/roles/base/tasks/main.yml
+++ b/src/roles/base/tasks/main.yml
@@ -48,9 +48,14 @@
     validate: 'visudo -cf %s'
 
 - name: ensure deltarpm is installed and latest
-  yum: name=deltarpm state=installed
+  yum: name=deltarpm state=latest
+  tags:
+  - latest
+
 - name: upgrade all packages
   yum: name=* state=latest
+  tags:
+  - latest
 
 # FIXME: for RedHat may need to enable "Optional RPMs"
 - name: ensure EPEL installed

--- a/src/roles/haproxy/tasks/main.yml
+++ b/src/roles/haproxy/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-# FIXME: Eventually add the ability to get SSL cert from letsencrypt
+# FIXME #748: Eventually add the ability to get SSL cert from letsencrypt
 #     ref: https://www.digitalocean.com/community/tutorials/how-to-secure-haproxy-with-let-s-encrypt-on-centos-7
 # Other refs:
 #     https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Load_Balancer_Administration/install_haproxy_example1.html
@@ -152,7 +152,7 @@
   file:
     path: /etc/haproxy/errors
     state: directory
-    # FIXME: permissions?
+    # FIXME #530: permissions?
 
 
 - name: Ensure error pages in place
@@ -160,7 +160,7 @@
     src: "errors/{{ item }}.http.j2"
     dest: "/etc/haproxy/errors/{{ item }}.http"
   with_items:
-    # FIXME: add the others, make the 500 error one good
+    # FIXME #663: add the others, make the 500 error one good
     # - 400
     # - 403
     # - 408
@@ -169,6 +169,8 @@
     # - 503
     # - 504
 
+# FIXME #746: Why does HAProxy specify this different method for firewall? Is
+# it an SELinux thing (which at present we don't have in enforcing)?
 - name: Ensure firewalld haproxy service files in place
   template:
     src: "haproxy-{{ item }}.firewalld.xml.j2"
@@ -212,7 +214,7 @@
   when: docker_skip_tasks is not defined or not docker_skip_tasks
 
 
-# FIXME: haproxy will need to handle reverse proxy for Elasticsearch plugins
+# FIXME #747: haproxy will need to handle reverse proxy for Elasticsearch plugins
 # - name: Configure firewalld for Elasticsearch reverse proxy
 #   firewalld:
 #     port: 8008/tcp

--- a/src/roles/haproxy/tasks/main.yml
+++ b/src/roles/haproxy/tasks/main.yml
@@ -208,6 +208,7 @@
   with_items:
     - 80
     - 443
+    - 1936
   when: docker_skip_tasks is not defined or not docker_skip_tasks
 
 

--- a/src/roles/haproxy/templates/haproxy.cfg.j2
+++ b/src/roles/haproxy/templates/haproxy.cfg.j2
@@ -98,6 +98,26 @@ listen mediawiki-internal
 
 	{% endfor %}
 
+listen stats
+	bind *:1936 ssl crt /etc/haproxy/certs/meza.pem
+	stats enable
+	stats hide-version
+	stats realm Haproxy\ Statistics
+	stats uri /haproxy
+	# FIXME FIXME FIXME FIXME
+	# FIXME FIXME FIXME FIXME
+	# FIXME FIXME FIXME FIXME
+	# FIXME FIXME FIXME FIXME
+	# FIXME FIXME FIXME FIXME
+	# FIXME FIXME FIXME FIXME
+	stats auth user:password
+	# FIXME FIXME FIXME FIXME
+	# FIXME FIXME FIXME FIXME
+	# FIXME FIXME FIXME FIXME
+	# FIXME FIXME FIXME FIXME
+	# FIXME FIXME FIXME FIXME
+	# FIXME FIXME FIXME FIXME
+	stats refresh 30s
 
 # backend letsencrypt-backend
 # 	server letsencrypt 127.0.0.1:54321

--- a/src/roles/haproxy/templates/haproxy.cfg.j2
+++ b/src/roles/haproxy/templates/haproxy.cfg.j2
@@ -70,13 +70,34 @@ frontend www-https
 
 backend www-backend
 	redirect scheme https if !{ ssl_fc }
-	{% for host in groups['app-servers'] %}
-	{% if host == inventory_hostname %}
-	server apache{{ loop.index }} 127.0.0.1:8080 check
-	{% else %}
-	server apache{{ loop.index }} {{ host }}:8080 check
-	{% endif %}
+	{% for host in groups['app-servers'] -%}
+		{%- if host == inventory_hostname -%}
+			server apache{{ loop.index }} 127.0.0.1:8080 check
+		{%- else -%}
+			server apache{{ loop.index }} {{ host }}:8080 check
+		{%- endif %}
+
 	{% endfor %}
+
+
+listen parsoid-internal
+	bind *:8001
+	{% for host in groups['parsoid-servers'] -%}
+		server parsoid{{ loop.index }} {{ host }}:8000 check
+	{% endfor %}
+
+
+listen mediawiki-internal
+	bind *:8081
+	{% for host in groups['app-servers'] -%}
+		{%- if host == inventory_hostname -%}
+			server mediawiki{{ loop.index }} 127.0.0.1:8080 check
+		{%- else -%}
+			server mediawiki{{ loop.index }} {{ host }}:8080 check
+		{%- endif %}
+
+	{% endfor %}
+
 
 # backend letsencrypt-backend
 # 	server letsencrypt 127.0.0.1:54321

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -737,31 +737,20 @@ $wgHiddenPrefs[] = 'visualeditor-enable';
 {% if groups['app-servers']|length|int == 1 and groups['parsoid-servers']|length|int == 1 and groups['app-servers'][0] == groups['parsoid-servers'][0] %}
 
 	// One and only Parsoid server is localhost
-	$parsoidDomain = '127.0.0.1';
+	$parsoidURL = 'http://127.0.0.1:8000';
 
-{% elif groups['parsoid-servers']|length|int == 1 %}
+{% elif 'load-balancers' not in groups or groups['load-balancers']|length|int == 0 %}
 
-	// Since there is only one Parsoid server, always use that one
-	$parsoidDomain = '{{ groups["parsoid-servers"][0] }}';
-
-{% elif inventory_hostname in groups['parsoid-servers'] %}
-
-	// Since this app-server is also a Parsoid server, always use this
-	$parsoidDomain = '{{ inventory_hostname }}';
+        $parsoidURL = '{{ groups["load-balancers-unmanaged"][0] }}:8001';
 
 {% else %}
 
-	// Randomly choose which parsoid server to use
-	$mezaValidParsoidServers = [];
-	{% for host in groups['parsoid-servers'] %}
-	$mezaValidParsoidServers[] = '{{ host }}';
-	{% endfor %}
-	$parsoidDomain = $mezaValidParsoidServers[ array_rand( $mezaValidParsoidServers ) ];
+	$parsoidURL = '{{ groups["load-balancers"][0] }}:8001';
 
 {% endif %}
 
 $wgVirtualRestConfig['modules']['parsoid'] = array(
-	'url' => "http://$parsoidDomain:8000",
+	'url' => $parsoidURL,
 
 	// domain here is not really the domain. It needs to be unique to each wiki
 	// and both domain and prefix must match settings in Parsoid's settings in

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -734,23 +734,31 @@ $wgHiddenPrefs[] = 'visualeditor-enable';
 #$wgDefaultUserOptions['visualeditor-enable-experimental'] = 1;
 
 
+
+$wgVirtualRestConfig['modules']['parsoid'] = array(
+
 {% if groups['app-servers']|length|int == 1 and groups['parsoid-servers']|length|int == 1 and groups['app-servers'][0] == groups['parsoid-servers'][0] %}
 
 	// One and only Parsoid server is localhost
-	$parsoidURL = 'http://127.0.0.1:8000';
+	'url' => 'http://127.0.0.1:8000',
+	'HTTPProxy' => 'http://192.168.56.80:8001',
+
 
 {% elif 'load-balancers' not in groups or groups['load-balancers']|length|int == 0 %}
 
-        $parsoidURL = '{{ groups["load-balancers-unmanaged"][0] }}:8001';
+	'url' => 'http://{{ groups["load-balancers-unmanaged"][0] }}:8001',
+	'HTTPProxy' => 'http://192.168.56.80:8001',
 
 {% else %}
 
-	$parsoidURL = '{{ groups["load-balancers"][0] }}:8001';
+	'url' => 'http://{{ groups["load-balancers"][0] }}:8001',
+	'HTTPProxy' => 'http://192.168.56.80:8001',
 
 {% endif %}
 
-$wgVirtualRestConfig['modules']['parsoid'] = array(
-	'url' => $parsoidURL,
+
+
+
 
 	// domain here is not really the domain. It needs to be unique to each wiki
 	// and both domain and prefix must match settings in Parsoid's settings in

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -741,18 +741,17 @@ $wgVirtualRestConfig['modules']['parsoid'] = array(
 
 	// One and only Parsoid server is localhost
 	'url' => 'http://127.0.0.1:8000',
-	'HTTPProxy' => 'http://192.168.56.80:8001',
 
 
 {% elif 'load-balancers' not in groups or groups['load-balancers']|length|int == 0 %}
 
 	'url' => 'http://{{ groups["load-balancers-unmanaged"][0] }}:8001',
-	'HTTPProxy' => 'http://192.168.56.80:8001',
+	//'HTTPProxy' => 'http://{{ groups["load-balancers-unmanaged"][0] }}:8001',
 
 {% else %}
 
 	'url' => 'http://{{ groups["load-balancers"][0] }}:8001',
-	'HTTPProxy' => 'http://192.168.56.80:8001',
+	//'HTTPProxy' => 'http://{{ groups["load-balancers"][0] }}:8001',
 
 {% endif %}
 

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -185,6 +185,15 @@ else {
 
 }
 
+{% if m_setup_php_profiling %}
+// See https://www.mediawiki.org/wiki/Manual:Profiling for more info.
+// Output options are udp, text (onto page, probably doesn't work for JS/CSS),
+// db (requires addtional DB setup), and dump (to files)
+$wgProfiler['class'] = 'ProfilerXhprof';
+$wgProfiler['output'] = array( 'ProfilerOutputDump' );
+$wgProfiler['outputDir'] = '{{ m_profiling_directory }}';
+$wgProfiler['visible'] = true;
+{% endif %}
 
 
 

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -388,6 +388,7 @@ $wgSharedTables = array(
  *
  **/
 // proxy setup
+$wgUseSquid = true;
 $wgUsePrivateIPs = true;
 $wgSquidServersNoPurge = array(
 	{% for server in groups['load-balancers'] -%}

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -703,19 +703,9 @@ $wgCirrusSearchClusters['default'][] = '{{ host }}';
  * Extension:VisualEditor
  *
  * Parsoid servers are defined based upon Ansible hosts file and thus
- * cannot be easily added to base-extensions.yml. As such, VisualEditor config
+ * cannot be easily added to MezaCoreExtensions.yml. As such, VisualEditor config
  * is included directly in LocalSettings.php.j2
  */
-// Allow read and edit permission for requests from the server (e.g. Parsoid)
-// Ref: https://www.mediawiki.org/wiki/Talk:Parsoid/Archive#Running_Parsoid_on_a_.22private.22_wiki_-_AccessDeniedError
-// Ref: https://www.mediawiki.org/wiki/Extension:VisualEditor#Linking_with_Parsoid_in_private_wikis
-$mezaValidParsoidServers = [];
-{% for host in groups['parsoid-servers'] %}
-{% if host == inventory_hostname %}
-$mezaValidParsoidServers[] = '127.0.0.1';
-{% endif %}
-$mezaValidParsoidServers[] = '{{ host }}';
-{% endfor %}
 
 /**
  * HTTP_X_FORWARDED_FOR is set by HAProxy when users request pages via
@@ -723,7 +713,11 @@ $mezaValidParsoidServers[] = '{{ host }}';
  * other services (e.g. Parsoid) should directly access webservers. In
  * order to allow services to access MediaWiki with full permissions,
  * if HTTP_X_FORWARDED_FOR does NOT exist then assume it's not a regular
- * user and grant permissions
+ * user and grant permissions.
+ *
+ * Refs:
+ * https://www.mediawiki.org/wiki/Talk:Parsoid/Archive#Running_Parsoid_on_a_.22private.22_wiki_-_AccessDeniedError
+ * https://www.mediawiki.org/wiki/Extension:VisualEditor#Linking_with_Parsoid_in_private_wikis
  **/
 if ( ! isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
 	$wgGroupPermissions['*']['read'] = true;
@@ -739,13 +733,33 @@ $wgHiddenPrefs[] = 'visualeditor-enable';
 // OPTIONAL: Enable VisualEditor's experimental code features
 #$wgDefaultUserOptions['visualeditor-enable-experimental'] = 1;
 
-// URL to the Parsoid instance MUST NOT end in a slash due to Parsoid bug
-if ( in_array( '127.0.0.1', $mezaValidParsoidServers ) ) {
+
+{% if groups['app-servers']|length|int == 1 and groups['parsoid-servers']|length|int == 1 and groups['app-servers'][0] == groups['parsoid-servers'][0] %}
+
+	// One and only Parsoid server is localhost
 	$parsoidDomain = '127.0.0.1';
-}
-else {
+
+{% elif groups['parsoid-servers']|length|int == 1 %}
+
+	// Since there is only one Parsoid server, always use that one
+	$parsoidDomain = '{{ groups["parsoid-servers"][0] }}';
+
+{% elif inventory_hostname in groups['parsoid-servers'] %}
+
+	// Since this app-server is also a Parsoid server, always use this
+	$parsoidDomain = '{{ inventory_hostname }}';
+
+{% else %}
+
+	// Randomly choose which parsoid server to use
+	$mezaValidParsoidServers = [];
+	{% for host in groups['parsoid-servers'] %}
+	$mezaValidParsoidServers[] = '{{ host }}';
+	{% endfor %}
 	$parsoidDomain = $mezaValidParsoidServers[ array_rand( $mezaValidParsoidServers ) ];
-}
+
+{% endif %}
+
 $wgVirtualRestConfig['modules']['parsoid'] = array(
 	'url' => "http://$parsoidDomain:8000",
 

--- a/src/roles/memcached/tasks/main.yml
+++ b/src/roles/memcached/tasks/main.yml
@@ -3,6 +3,8 @@
   yum:
     name: "{{ item }}"
     state: latest
+  tags:
+  - latest
   with_items:
   - memcached
   - nmap-ncat

--- a/src/roles/nodejs/tasks/main.yml
+++ b/src/roles/nodejs/tasks/main.yml
@@ -71,3 +71,5 @@
     NODE_PATH: "{{ npm_config_prefix }}/lib/node_modules"
     NPM_CONFIG_UNSAFE_PERM: "{{ npm_config_unsafe_perm }}"
   with_items: "{{ nodejs_npm_global_packages }}"
+  tags:
+  - latest

--- a/src/roles/parsoid-settings/templates/localsettings.js.j2
+++ b/src/roles/parsoid-settings/templates/localsettings.js.j2
@@ -5,26 +5,39 @@ exports.setup = function(parsoidConfig) {
 	// Otherwise, defaults to "Parsoid/<current-version-defined-in-package.json>"
 	//parsoidConfig.userAgent = "My-User-Agent-String";
 
-	// The URL of your MediaWiki API endpoint.
+	// The URL  f your MediaWiki API endpoint.
 	// uri like:
 	//     http://192.168.56.56/wiki/api.php
 	//     http://enterprisemediawiki.org/wiki/api.php
 
-	// for all wiki ID and app-server combinations and do setMwApi
-	{% for appserver in groups['app-servers'] %}
+
+
+	// for all wiki IDs do setMwApi
 	{% for wiki in list_of_wikis %}
 
-	// {{ wiki }} on {{ appserver }}
-	parsoidConfig.setMwApi( {
-		prefix: '{{ wiki }}',
-		uri: 'http://{{ appserver }}:8080/{{ wiki }}/api.php',
+	parsoidConfig.setMwApi({
+
+		{% if groups['app-servers']|length|int == 1 and groups['parsoid-servers']|length|int == 1 and groups['app-servers'][0] == groups['parsoid-servers'][0] -%}
+
+			uri: 'http://127.0.0.1:8080/{{ wiki }}/api.php',
+
+		{%- elif 'load-balancers' not in groups or groups['load-balancers']|length|int == 0 -%}
+
+			uri: 'http://{{ groups["load-balancers-unmanaged"][0] }}:8081/{{ wiki }}/api.php',
+
+		{%- else -%}
+
+			uri: 'http://{{ groups["load-balancers"][0] }}:8081/{{ wiki }}/api.php',
+
+		{%- endif %}
 
 		// not really the domain, needs to be specific to each wiki
-		domain: '{{ wiki }}'
+		domain: '{{ wiki }}',
+		prefix: '{{ wiki }}'
 	} );
 
 	{% endfor %}
-	{% endfor %}
+
 
 	// To specify a proxy (or proxy headers) specific to this prefix (which
 	// overrides defaultAPIProxyURI) use:
@@ -50,7 +63,11 @@ exports.setup = function(parsoidConfig) {
 	//parsoidConfig.defaultAPIProxyURI = 'http://proxy.example.org:8080';
 
 	// Enable debug mode (prints extra debugging messages)
-	//parsoidConfig.debug = true;
+	{% if m_force_debug %}
+	parsoidConfig.debug = true;
+	{% else %}
+	parsoidConfig.debug = false;
+	{% endif %}
 
 	// Use the PHP preprocessor to expand templates via the MW API (default true)
 	//parsoidConfig.usePHPPreProcessor = false;

--- a/src/roles/parsoid-settings/templates/localsettings.js.j2
+++ b/src/roles/parsoid-settings/templates/localsettings.js.j2
@@ -10,30 +10,21 @@ exports.setup = function(parsoidConfig) {
 	//     http://192.168.56.56/wiki/api.php
 	//     http://enterprisemediawiki.org/wiki/api.php
 
-	// file system
-	var fs = require( 'fs' );
+	// for all wiki ID and app-server combinations and do setMwApi
+	{% for appserver in groups['app-servers'] %}
+	{% for wiki in list_of_wikis %}
 
-	// get all the directories in the /wikis directory. These are the wiki
-	// identifiers for each wiki
-	var wikis = [
-		{%- for wiki in list_of_wikis -%}
-		"{{ wiki }}"{% if not loop.last %},{% endif %}
-		{%- endfor -%}
-	];
+	// {{ wiki }} on {{ appserver }}
+	parsoidConfig.setMwApi( {
+		prefix: '{{ wiki }}',
+		uri: 'http://{{ appserver }}:8080/{{ wiki }}/api.php',
 
-	// Domain, which will be setup by the meza installer
-	var domain = "http://{{ groups['app-servers'][0] }}:8080/";  // was mw_api_domain
+		// not really the domain, needs to be specific to each wiki
+		domain: '{{ wiki }}'
+	} );
 
-	// loop through all wiki IDs and do setMwApi
-	for ( var i = 0; i < wikis.length; i++ ) {
-		parsoidConfig.setMwApi( {
-			prefix: wikis[i],
-			uri: domain + wikis[i] + '/api.php',
-
-			// not really the domain, needs to be specific to each wiki
-			domain: wikis[i]
-		} );
-	}
+	{% endfor %}
+	{% endfor %}
 
 	// To specify a proxy (or proxy headers) specific to this prefix (which
 	// overrides defaultAPIProxyURI) use:

--- a/src/roles/parsoid-settings/templates/localsettings.js.j2
+++ b/src/roles/parsoid-settings/templates/localsettings.js.j2
@@ -24,10 +24,12 @@ exports.setup = function(parsoidConfig) {
 		{%- elif 'load-balancers' not in groups or groups['load-balancers']|length|int == 0 -%}
 
 			uri: 'http://{{ groups["load-balancers-unmanaged"][0] }}:8081/{{ wiki }}/api.php',
+			proxy: { uri: 'http://{{ groups["load-balancers-unmanaged"][0] }}:8081/' },
 
 		{%- else -%}
 
 			uri: 'http://{{ groups["load-balancers"][0] }}:8081/{{ wiki }}/api.php',
+			proxy: { uri: 'http://{{ groups["load-balancers"][0] }}:8081/' },
 
 		{%- endif %}
 
@@ -107,6 +109,7 @@ exports.setup = function(parsoidConfig) {
 	// Allow override of port:
 	//parsoidConfig.serverPort = 8000;
 
+
 	{% if groups['app-servers']|length|int == 1 and groups['parsoid-servers']|length|int == 1 and groups['app-servers'][0] == groups['parsoid-servers'][0] %}
 
 	// One and only Parsoid server is one and only app-server
@@ -117,6 +120,7 @@ exports.setup = function(parsoidConfig) {
 	parsoidConfig.serverInterface = '{{ inventory_hostname }}';
 
 	{% endif %}
+
 
 	// The URL of your LintBridge API endpoint
 	//parsoidConfig.linterAPI = 'http://lintbridge.wmflabs.org/add';

--- a/src/roles/parsoid-settings/templates/localsettings.js.j2
+++ b/src/roles/parsoid-settings/templates/localsettings.js.j2
@@ -96,9 +96,19 @@ exports.setup = function(parsoidConfig) {
 	// OR by defining your own performanceTimer properties
 	//parsoidConfig.heapUsageSampleInterval = 5 * 60 * 1000;
 
-	// Allow override of port/interface:
+	// Allow override of port:
 	//parsoidConfig.serverPort = 8000;
+
+	{% if groups['app-servers']|length|int == 1 and groups['parsoid-servers']|length|int == 1 and groups['app-servers'][0] == groups['parsoid-servers'][0] %}
+
+	// One and only Parsoid server is one and only app-server
 	parsoidConfig.serverInterface = '127.0.0.1';
+
+	{% else %}
+
+	parsoidConfig.serverInterface = '{{ inventory_hostname }}';
+
+	{% endif %}
 
 	// The URL of your LintBridge API endpoint
 	//parsoidConfig.linterAPI = 'http://lintbridge.wmflabs.org/add';

--- a/src/roles/parsoid-settings/templates/localsettings.js.j2
+++ b/src/roles/parsoid-settings/templates/localsettings.js.j2
@@ -24,12 +24,12 @@ exports.setup = function(parsoidConfig) {
 		{%- elif 'load-balancers' not in groups or groups['load-balancers']|length|int == 0 -%}
 
 			uri: 'http://{{ groups["load-balancers-unmanaged"][0] }}:8081/{{ wiki }}/api.php',
-			proxy: { uri: 'http://{{ groups["load-balancers-unmanaged"][0] }}:8081/' },
+			// proxy: { uri: 'http://{{ groups["load-balancers-unmanaged"][0] }}:8081/' },
 
 		{%- else -%}
 
 			uri: 'http://{{ groups["load-balancers"][0] }}:8081/{{ wiki }}/api.php',
-			proxy: { uri: 'http://{{ groups["load-balancers"][0] }}:8081/' },
+			// proxy: { uri: 'http://{{ groups["load-balancers"][0] }}:8081/' },
 
 		{%- endif %}
 

--- a/src/scripts/ssh-users/transfer-master-key.sh
+++ b/src/scripts/ssh-users/transfer-master-key.sh
@@ -17,6 +17,10 @@ source "$m_scripts/shell-functions/linux-user.sh"
 echo "Type space-separated list of minions to copy SSH"
 read -e minions
 
+if [ -z "$ansible_user" ]; then 
+	ansible_user="meza-ansible"
+fi
+
 for minion in $minions; do
 
 	# Copy id_rsa.pub to each minion


### PR DESCRIPTION
Parsoid was always using `parsoidConfig.serverInterface = '127.0.0.1'` even when allowing connection from other servers. This appears to the the cause of parsoid issues in multi-server environments. 

Closes #740