### PR TITLE
Fix improperly assigned variable; noticed when Ansible 2.3.0-->2.3.1

### DIFF
--- a/src/roles/revoke-keys/tasks/main.yml
+++ b/src/roles/revoke-keys/tasks/main.yml
@@ -4,7 +4,6 @@
     path: "/home/{{ alt_remote_user }}/.ssh/{{ item }}"
     state: absent
   delegate_to: "{{ revoke_keys_from_server }}"
-  remote_user: "{{ alt_remote_user }}"
   with_items:
   - id_rsa
   - id_rsa.pub

--- a/src/roles/verify-wiki/tasks/main.yml
+++ b/src/roles/verify-wiki/tasks/main.yml
@@ -464,9 +464,9 @@
 - name: "{{ wiki_id }} - If no uploads dir, but backup dir exists, revoke keys"
   include_role:
     name: revoke-keys
-    alt_remote_user: "{{ uploads_backup_server_remote_user }}"
   vars:
     revoke_keys_from_server: "{{ uploads_backup_server }}"
+    alt_remote_user: "{{ uploads_backup_server_remote_user }}"
   when:
     images_backup_dir.stat.exists
     and (not uploads_dir.stat.exists or do_overwrite_uploads_from_backup)


### PR DESCRIPTION
Variable not put within `vars` when attempting to include role. This "worked" in Ansible 2.3.0 but should not have. 2.3.1 "broke" it. Fixing.

Closes #754