### PR TITLE
Properly set server interface for parsoid; load balance

### DIFF
--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -77,4 +77,6 @@ m_language: en
 
 allow_backup_downloads: false
 
+m_force_debug: false
+
 enable_wiki_emails: true

--- a/src/playbooks/site.yml
+++ b/src/playbooks/site.yml
@@ -86,6 +86,17 @@
   tags: load-balancer
   roles:
     - set-vars
+    - role: firewalld
+      firewalld_port: 8001
+      firewalld_protocol: tcp
+      firewalld_servers: "{{ groups['app-servers'] }}"
+      firewalld_zone: "{{m_private_networking_zone|default('public')}}"
+    - role: firewalld
+      firewalld_port: 8081
+      firewalld_protocol: tcp
+      firewalld_servers: "{{ groups['parsoid-servers'] }}"
+      firewalld_zone: "{{m_private_networking_zone|default('public')}}"
+    # NOTE: firewalld ports 80 and 443 opened to ALL within haproxy role
     - haproxy
 
 - hosts: app-servers
@@ -307,6 +318,17 @@
       firewalld_protocol: tcp
       firewalld_servers: "{{ groups['app-servers'] }}"
       firewalld_zone: "{{m_private_networking_zone|default('public')}}"
+    - role: firewalld
+      firewalld_port: 8000
+      firewalld_protocol: tcp
+      firewalld_servers: "{{ groups['load-balancers'] }}"
+      firewalld_zone: "{{m_private_networking_zone|default('public')}}"
+    - role: firewalld
+      firewalld_port: 8000
+      firewalld_protocol: tcp
+      firewalld_servers: "{{ groups['load-balancers-unmanaged'] }}"
+      firewalld_zone: "{{m_private_networking_zone|default('public')}}"
+      when: "'load-balancers-unmanaged' in groups"
     - nodejs
     - role: parsoid
       nodejs_install_npm_user: "nodejs"

--- a/src/roles/haproxy/templates/haproxy.cfg.j2
+++ b/src/roles/haproxy/templates/haproxy.cfg.j2
@@ -70,13 +70,34 @@ frontend www-https
 
 backend www-backend
 	redirect scheme https if !{ ssl_fc }
-	{% for host in groups['app-servers'] %}
-	{% if host == inventory_hostname %}
-	server apache{{ loop.index }} 127.0.0.1:8080 check
-	{% else %}
-	server apache{{ loop.index }} {{ host }}:8080 check
-	{% endif %}
+	{% for host in groups['app-servers'] -%}
+		{%- if host == inventory_hostname -%}
+			server apache{{ loop.index }} 127.0.0.1:8080 check
+		{%- else -%}
+			server apache{{ loop.index }} {{ host }}:8080 check
+		{%- endif %}
+
 	{% endfor %}
+
+
+listen parsoid-internal
+	bind *:8001
+	{% for host in groups['parsoid-servers'] -%}
+		server parsoid{{ loop.index }} {{ host }}:8000 check
+	{% endfor %}
+
+
+listen mediawiki-internal
+	bind *:8081
+	{% for host in groups['app-servers'] -%}
+		{%- if host == inventory_hostname -%}
+			server mediawiki{{ loop.index }} 127.0.0.1:8080 check
+		{%- else -%}
+			server mediawiki{{ loop.index }} {{ host }}:8080 check
+		{%- endif %}
+
+	{% endfor %}
+
 
 # backend letsencrypt-backend
 # 	server letsencrypt 127.0.0.1:54321

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -703,19 +703,9 @@ $wgCirrusSearchClusters['default'][] = '{{ host }}';
  * Extension:VisualEditor
  *
  * Parsoid servers are defined based upon Ansible hosts file and thus
- * cannot be easily added to base-extensions.yml. As such, VisualEditor config
+ * cannot be easily added to MezaCoreExtensions.yml. As such, VisualEditor config
  * is included directly in LocalSettings.php.j2
  */
-// Allow read and edit permission for requests from the server (e.g. Parsoid)
-// Ref: https://www.mediawiki.org/wiki/Talk:Parsoid/Archive#Running_Parsoid_on_a_.22private.22_wiki_-_AccessDeniedError
-// Ref: https://www.mediawiki.org/wiki/Extension:VisualEditor#Linking_with_Parsoid_in_private_wikis
-$mezaValidParsoidServers = [];
-{% for host in groups['parsoid-servers'] %}
-{% if host == inventory_hostname %}
-$mezaValidParsoidServers[] = '127.0.0.1';
-{% endif %}
-$mezaValidParsoidServers[] = '{{ host }}';
-{% endfor %}
 
 /**
  * HTTP_X_FORWARDED_FOR is set by HAProxy when users request pages via
@@ -723,7 +713,11 @@ $mezaValidParsoidServers[] = '{{ host }}';
  * other services (e.g. Parsoid) should directly access webservers. In
  * order to allow services to access MediaWiki with full permissions,
  * if HTTP_X_FORWARDED_FOR does NOT exist then assume it's not a regular
- * user and grant permissions
+ * user and grant permissions.
+ *
+ * Refs:
+ * https://www.mediawiki.org/wiki/Talk:Parsoid/Archive#Running_Parsoid_on_a_.22private.22_wiki_-_AccessDeniedError
+ * https://www.mediawiki.org/wiki/Extension:VisualEditor#Linking_with_Parsoid_in_private_wikis
  **/
 if ( ! isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
 	$wgGroupPermissions['*']['read'] = true;
@@ -739,15 +733,31 @@ $wgHiddenPrefs[] = 'visualeditor-enable';
 // OPTIONAL: Enable VisualEditor's experimental code features
 #$wgDefaultUserOptions['visualeditor-enable-experimental'] = 1;
 
-// URL to the Parsoid instance MUST NOT end in a slash due to Parsoid bug
-if ( in_array( '127.0.0.1', $mezaValidParsoidServers ) ) {
-	$parsoidDomain = '127.0.0.1';
-}
-else {
-	$parsoidDomain = $mezaValidParsoidServers[ array_rand( $mezaValidParsoidServers ) ];
-}
+
+
 $wgVirtualRestConfig['modules']['parsoid'] = array(
-	'url' => "http://$parsoidDomain:8000",
+
+{% if groups['app-servers']|length|int == 1 and groups['parsoid-servers']|length|int == 1 and groups['app-servers'][0] == groups['parsoid-servers'][0] %}
+
+	// One and only Parsoid server is localhost
+	'url' => 'http://127.0.0.1:8000',
+
+
+{% elif 'load-balancers' not in groups or groups['load-balancers']|length|int == 0 %}
+
+	'url' => 'http://{{ groups["load-balancers-unmanaged"][0] }}:8001',
+	//'HTTPProxy' => 'http://{{ groups["load-balancers-unmanaged"][0] }}:8001',
+
+{% else %}
+
+	'url' => 'http://{{ groups["load-balancers"][0] }}:8001',
+	//'HTTPProxy' => 'http://{{ groups["load-balancers"][0] }}:8001',
+
+{% endif %}
+
+
+
+
 
 	// domain here is not really the domain. It needs to be unique to each wiki
 	// and both domain and prefix must match settings in Parsoid's settings in

--- a/src/roles/parsoid-settings/templates/localsettings.js.j2
+++ b/src/roles/parsoid-settings/templates/localsettings.js.j2
@@ -10,30 +10,36 @@ exports.setup = function(parsoidConfig) {
 	//     http://192.168.56.56/wiki/api.php
 	//     http://enterprisemediawiki.org/wiki/api.php
 
-	// file system
-	var fs = require( 'fs' );
 
-	// get all the directories in the /wikis directory. These are the wiki
-	// identifiers for each wiki
-	var wikis = [
-		{%- for wiki in list_of_wikis -%}
-		"{{ wiki }}"{% if not loop.last %},{% endif %}
-		{%- endfor -%}
-	];
 
-	// Domain, which will be setup by the meza installer
-	var domain = "http://{{ groups['app-servers'][0] }}:8080/";  // was mw_api_domain
+	// for all wiki IDs do setMwApi
+	{% for wiki in list_of_wikis %}
 
-	// loop through all wiki IDs and do setMwApi
-	for ( var i = 0; i < wikis.length; i++ ) {
-		parsoidConfig.setMwApi( {
-			prefix: wikis[i],
-			uri: domain + wikis[i] + '/api.php',
+	parsoidConfig.setMwApi({
 
-			// not really the domain, needs to be specific to each wiki
-			domain: wikis[i]
-		} );
-	}
+		{% if groups['app-servers']|length|int == 1 and groups['parsoid-servers']|length|int == 1 and groups['app-servers'][0] == groups['parsoid-servers'][0] -%}
+
+			uri: 'http://127.0.0.1:8080/{{ wiki }}/api.php',
+
+		{%- elif 'load-balancers' not in groups or groups['load-balancers']|length|int == 0 -%}
+
+			uri: 'http://{{ groups["load-balancers-unmanaged"][0] }}:8081/{{ wiki }}/api.php',
+			// proxy: { uri: 'http://{{ groups["load-balancers-unmanaged"][0] }}:8081/' },
+
+		{%- else -%}
+
+			uri: 'http://{{ groups["load-balancers"][0] }}:8081/{{ wiki }}/api.php',
+			// proxy: { uri: 'http://{{ groups["load-balancers"][0] }}:8081/' },
+
+		{%- endif %}
+
+		// not really the domain, needs to be specific to each wiki
+		domain: '{{ wiki }}',
+		prefix: '{{ wiki }}'
+	} );
+
+	{% endfor %}
+
 
 	// To specify a proxy (or proxy headers) specific to this prefix (which
 	// overrides defaultAPIProxyURI) use:
@@ -59,7 +65,11 @@ exports.setup = function(parsoidConfig) {
 	//parsoidConfig.defaultAPIProxyURI = 'http://proxy.example.org:8080';
 
 	// Enable debug mode (prints extra debugging messages)
-	//parsoidConfig.debug = true;
+	{% if m_force_debug %}
+	parsoidConfig.debug = true;
+	{% else %}
+	parsoidConfig.debug = false;
+	{% endif %}
 
 	// Use the PHP preprocessor to expand templates via the MW API (default true)
 	//parsoidConfig.usePHPPreProcessor = false;
@@ -96,9 +106,21 @@ exports.setup = function(parsoidConfig) {
 	// OR by defining your own performanceTimer properties
 	//parsoidConfig.heapUsageSampleInterval = 5 * 60 * 1000;
 
-	// Allow override of port/interface:
+	// Allow override of port:
 	//parsoidConfig.serverPort = 8000;
+
+
+	{% if groups['app-servers']|length|int == 1 and groups['parsoid-servers']|length|int == 1 and groups['app-servers'][0] == groups['parsoid-servers'][0] %}
+
+	// One and only Parsoid server is one and only app-server
 	parsoidConfig.serverInterface = '127.0.0.1';
+
+	{% else %}
+
+	parsoidConfig.serverInterface = '{{ inventory_hostname }}';
+
+	{% endif %}
+
 
 	// The URL of your LintBridge API endpoint
 	//parsoidConfig.linterAPI = 'http://lintbridge.wmflabs.org/add';

--- a/src/scripts/ssh-users/transfer-master-key.sh
+++ b/src/scripts/ssh-users/transfer-master-key.sh
@@ -17,6 +17,10 @@ source "$m_scripts/shell-functions/linux-user.sh"
 echo "Type space-separated list of minions to copy SSH"
 read -e minions
 
+if [ -z "$ansible_user" ]; then 
+	ansible_user="meza-ansible"
+fi
+
 for minion in $minions; do
 
 	# Copy id_rsa.pub to each minion


### PR DESCRIPTION
Parsoid on a separate server from MediaWiki was having issues due to `parsoidConfig.serverInterface = '127.0.0.1';` always being set in `localsettings.js`. This is not correct when Parsoid is separate from MediaWiki.

Also, it is required to load-balance Parsoid so that MediaWiki can have one Parsoid endpoint. The same is true for MediaWiki, so Parsoid can have one endpoint for it. Two internal-only load balancing schemes were created.