### PR TITLE
Several changes in the process of figuring out slow app server issue

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,26 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# When using Vagrant on Windows, whatever git has checked out gets transferred
+# to the guest OS. If, for example, a shell script is transferred with Windows
+# CRLF line endings then errors like the following will occur:
+#
+# /opt/meza/src/scripts/getmeza.sh: line 6: $'\r': command not found
+#
+# To avoid this, always checkout many files out with LF line endings. The
+# downside to this (I think) is that Windows users editing code and submitting
+# changes will have to make sure their text editors respect line endings.
+*.sh text eol=lf
+*.py text eol=lf
+*.js text eol=lf
+*.php text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.cfg text eol=lf
+*.j2 text eol=lf
+*.sh text eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary
+*.gif binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 
 .vagrant/*
+vagrantconf.yml

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,18 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+require 'yaml'
+
+if not File.file?("#{File.dirname(__FILE__)}/.vagrant/id_rsa")
+  system("
+    ssh-keygen -f './.vagrant/id_rsa' -t rsa -N '' -C 'vagrant@vagrant'
+  ")
+end
+
+if File.file?("#{File.dirname(__FILE__)}/vagrantconf.yml")
+  configuration = YAML::load(File.read("#{File.dirname(__FILE__)}/vagrantconf.yml"))
+else
+  configuration = YAML::load(File.read("#{File.dirname(__FILE__)}/vagrantconf.default.yml"))
+end
 
 # All Vagrant configuration is done below. The "2" in Vagrant.configure
 # configures the configuration version (we support older styles for
@@ -7,56 +20,196 @@
 # you're doing.
 Vagrant.configure("2") do |config|
 
-  # config.vm.define "monolith" do |web|
-  #   web.vm.box = "precise64"
-  #   web.vm.hostname = 'web'
-  #   web.vm.box_url = "ubuntu/precise64"
+  #
+  # CONFIGURE SECOND SERVER IF envtype == 2app
+  # envtype=2app vagrant up
+  #
+  if configuration.key?("app2")
 
-  config.vm.box = "centos/7"
+    config.vm.define "app2" do |app2|
 
-  config.vm.network :private_network, ip: "192.168.56.56"
+      # app2.vm.box = "centos/7"
+      app2.vm.box = "bento/centos-7.3"
+      # app2.vm.box = "geerlingguy/centos7"
+      app2.vm.hostname = 'app2'
+      # app2.vm.box_url = "ubuntu/precise64"
 
-  config.vm.provider "virtualbox" do |vb|
-    vb.memory = 2048
-    vb.cpus = 1
+      app2.vm.network :private_network, ip: "192.168.56.57"
+
+      app2.vm.provider :virtualbox do |v|
+        v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+        v.customize ['modifyvm', :id, '--cableconnected1', 'on']
+        v.customize ["modifyvm", :id, "--memory", configuration["app2"]["memory"] ]
+        v.customize ["modifyvm", :id, "--cpus", configuration["app2"]["cpus"] ]
+        v.customize ["modifyvm", :id, "--name", "app2"]
+      end
+
+      # Non-controlling server should not have meza
+      app2.vm.synced_folder ".", "/vagrant", disabled: true
+   	  # app2.vm.synced_folder ".", "/opt/meza", type: "rsync",
+      #   rsync__args: ["--verbose", "--archive", "--delete", "-z"]
+
+      # Transfer setup-minion-user.sh script to app2
+      app2.vm.provision "file", source: "./src/scripts/ssh-users/setup-minion-user.sh", destination: "/tmp/minion.sh"
+      app2.vm.provision "file", source: "./.vagrant/id_rsa.pub", destination: "/tmp/meza-ansible.id_rsa.pub"
+
+      #
+      # Setup SSH user and unsafe testing config
+      #
+      app2.vm.provision "minion-ssh", type: "shell", preserve_order: true, binary: true, inline: <<-SHELL
+        if [ ! -f /opt/conf-meza/public/vars.yml ]; then
+
+          bash /tmp/minion.sh
+
+          # Turn off host key checking for user meza-ansible, to avoid prompts
+          echo "setup .ssh/config"
+          bash -c 'echo -e "Host *\n   StrictHostKeyChecking no\n   UserKnownHostsFile=/dev/null" > /opt/conf-meza/users/meza-ansible/.ssh/config'
+          sudo chown meza-ansible:meza-ansible /opt/conf-meza/users/meza-ansible/.ssh/config
+          sudo chmod 600 /opt/conf-meza/users/meza-ansible/.ssh/config
+
+          # Allow password auth
+          echo "setup sshd_config password auth"
+          sed -r -i 's/PasswordAuthentication no/PasswordAuthentication yes/g;' /etc/ssh/sshd_config
+          systemctl restart sshd
+        fi
+      SHELL
+    end
+
   end
 
-  # Disable default synced folder at /vagrant, instead put at /opt/meza
-  config.vm.synced_folder ".", "/vagrant", disabled: true
-  config.vm.synced_folder ".", "/opt/meza", type: "rsync",
-    rsync__args: ["--verbose", "--archive", "--delete", "-z"]
+  config.vm.define "app1", primary: true do |app1|
+
+    # app1.vm.box = "centos/7"
+    app1.vm.box = "bento/centos-7.3"
+    # app1.vm.box = "geerlingguy/centos7"
+    app1.vm.hostname = 'app1'
+    # app1.vm.box_url = "ubuntu/precise64"
+
+    app1.vm.network :private_network, ip: "192.168.56.56"
+
+    app1.vm.provider :virtualbox do |v|
+      v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+      v.customize ['modifyvm', :id, '--cableconnected1', 'on']
+      v.customize ["modifyvm", :id, "--memory", configuration["app1"]["memory"] ]
+      v.customize ["modifyvm", :id, "--cpus", configuration["app1"]["cpus"] ]
+      v.customize ["modifyvm", :id, "--name", "app1"]
+    end
+
+    # Disable default synced folder at /vagrant, instead put at /opt/meza
+    app1.vm.synced_folder ".", "/vagrant", disabled: true
+    app1.vm.synced_folder ".", "/opt/meza", type: "virtualbox"
+    # app1.vm.synced_folder ".", "/opt/meza", type: "smb"
+    # app1.vm.synced_folder ".", "/opt/meza", type: "rsync",
+    #   rsync__args: ["--verbose", "--archive", "--delete", "-z"]
 
 
-  # Create a public network, which generally matched to bridged network.
-  # Bridged networks make the machine appear as another physical device on
-  # your network.
-  # config.vm.network "public_network"
+    # Transfer keys to app1
+    app1.vm.provision "file", source: "./.vagrant/id_rsa", destination: "/tmp/meza-ansible.id_rsa"
+    app1.vm.provision "file", source: "./.vagrant/id_rsa.pub", destination: "/tmp/meza-ansible.id_rsa.pub"
 
-  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
-  # such as FTP and Heroku are also available. See the documentation at
-  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
-  # config.push.define "atlas" do |push|
-  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
-  # end
 
-  config.vm.provision "setup", type: "shell", inline: <<-SHELL
-    bash /opt/meza/src/scripts/getmeza.sh
-  SHELL
+    #
+    # Bootstrap meza on the controlling VM
+    #
+    app1.vm.provision "getmeza", type: "shell", preserve_order: true, inline: <<-SHELL
+      bash /opt/meza/src/scripts/getmeza.sh
+      rm -rf /opt/conf-meza/users/meza-ansible/.ssh/id_rsa
+      rm -rf /opt/conf-meza/users/meza-ansible/.ssh/id_rsa.pub
+      mv /tmp/meza-ansible.id_rsa /opt/conf-meza/users/meza-ansible/.ssh/id_rsa
+      mv /tmp/meza-ansible.id_rsa.pub /opt/conf-meza/users/meza-ansible/.ssh/id_rsa.pub
 
-  # Default is to run `meza deploy` command. Add environment variable to override
-  if not ENV["deploy"] || ENV["deploy"] == "basic"
+      chmod 600 /opt/conf-meza/users/meza-ansible/.ssh/id_rsa
+      chown meza-ansible:meza-ansible /opt/conf-meza/users/meza-ansible/.ssh/id_rsa
+      chmod 644 /opt/conf-meza/users/meza-ansible/.ssh/id_rsa.pub
+      chown meza-ansible:meza-ansible /opt/conf-meza/users/meza-ansible/.ssh/id_rsa.pub
 
-    config.vm.provision "deploy", type: "shell", inline: <<-SHELL
-      meza setup env monolith --fqdn=192.168.56.56 --db_pass=1234
-      meza deploy monolith
+      cat /opt/conf-meza/users/meza-ansible/.ssh/id_rsa.pub >> /opt/conf-meza/users/meza-ansible/.ssh/authorized_keys
     SHELL
 
-  # Could have option to get test configs enterprisemediawiki/meza-test-config
-  # and enterprisemediawiki/meza-test-config-secret, and backups from
-  # jamesmontalvo3/meza-test-backups, to bootstrap a test config. Also could
-  # have more involved installations with many well-developed wikis showcasing
-  # what is possible.
-  # elsif ENV["deploy"] == "test"
+    #
+    # Setup meza environment, either monolithic or 2app
+    #
+    if not configuration.key?("app2")
+
+      app1.vm.provision "setupenv", type: "shell", preserve_order: true, inline: <<-SHELL
+        meza setup env vagrant --fqdn=192.168.56.56 --db_pass=1234 --private_net_zone=public
+      SHELL
+
+    else
+
+      # FIXME: should have a less fragile method to check if env exists
+      app1.vm.provision "setupenv", type: "shell", preserve_order: true, inline: <<-SHELL
+        if [ ! -d /opt/conf-meza/secret/vagrant ]; then
+          default_servers=192.168.56.56 app_servers=192.168.56.56,192.168.56.57 meza setup env vagrant --fqdn=192.168.56.56 --db_pass=1234 --private_net_zone=public
+        fi
+      SHELL
+    end
+
+    #
+    # Setup meza public config
+    #
+    app1.vm.provision "publicconfig", type: "shell", preserve_order: true, inline: <<-SHELL
+      # Create public config dir if not exists
+      [ -d /opt/conf-meza/public ] || mkdir /opt/conf-meza/public
+
+      # If public config YAML file not present, create with defaults
+      if [ ! -f /opt/conf-meza/public/vars.yml ]; then
+cat >/opt/conf-meza/public/vars.yml <<EOL
+---
+blender_landing_page_title: Meza Wikis
+m_setup_php_profiling: true
+m_force_debug: true
+EOL
+      fi
+
+      cat /opt/conf-meza/public/vars.yml
+    SHELL
+
+    #
+    # If multi-app: transfer key to second app server
+    #
+    if configuration.key?("app2")
+
+
+
+      app1.vm.provision "keytransfer", type: "shell", preserve_order: true, inline: <<-SHELL
+
+        # Turn off host key checking for user meza-ansible, to avoid prompts
+        bash -c 'echo -e "Host *\n   StrictHostKeyChecking no\n   UserKnownHostsFile=/dev/null" > /opt/conf-meza/users/meza-ansible/.ssh/config'
+        sudo chown meza-ansible:meza-ansible /opt/conf-meza/users/meza-ansible/.ssh/config
+        sudo chmod 600 /opt/conf-meza/users/meza-ansible/.ssh/config
+
+        # Allow SSH login
+        # WARNING: This is INSECURE and for test environment only
+        sed -r -i 's/UsePAM yes/UsePAM no/g;' /etc/ssh/sshd_config
+        systemctl restart sshd
+
+        echo "switch user"
+        sudo su meza-ansible
+
+        # Copy id_rsa.pub to each minion
+        # sshpass -p 1234 ssh meza-ansible@192.168.56.57 "echo \"$pubkey\" >> /opt/conf-meza/users/meza-ansible/.ssh/authorized_keys"
+
+
+        # Remove password-based authentication for $ansible_user
+        #echo "delete password"
+        #ssh 192.168.56.57 "sudo passwd --delete meza-ansible"
+
+        # Allow SSH login
+        # WARNING: This is INSECURE and for test environment only
+        # echo "setup sshd_config"
+        # ssh 192.168.56.57 "sudo sed -r -i 's/UsePAM yes/UsePAM no/g;' /etc/ssh/sshd_config && sudo systemctl restart sshd"
+      SHELL
+
+    else
+
+      #
+      # Finally: Deploy if not multi-server
+      #
+      app1.vm.provision "deploy", type: "shell", preserve_order: true, inline: <<-SHELL
+        meza deploy vagrant
+      SHELL
+    end
 
   end
 

--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -26,6 +26,9 @@ m_meza_data: /opt/data-meza
 m_tmp: /opt/data-meza/tmp
 m_logs: /opt/data-meza/logs
 
+# Only if m_setup_php_profiling: true
+m_profiling_directory: /opt/data-meza/logs/profiling
+
 # uploads dir. This WILL BE OVERIDDEN if multiple app servers are used, and
 # instead will use /opt/data-meza/uploads-gluster to use GlusterFS distributed
 # file system.
@@ -55,6 +58,7 @@ m_php_ini: /etc/php.ini
 m_memcached_conf: /etc/sysconfig/memcached
 m_parsoid_path: /etc/parsoid
 m_simplesamlphp_path: /opt/simplesamlphp
+m_profiling_ui_directory: /usr/share/pear/xhprof_html
 
 # files
 m_i18n: /opt/meza/config/core/i18n
@@ -84,3 +88,6 @@ enable_wiki_emails: true
 enable_haproxy_stats: false
 haproxy_stats_user: admin
 haproxy_stats_password: password
+
+# Only useful for developers and testing performance issues
+m_setup_php_profiling: false

--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -80,3 +80,7 @@ allow_backup_downloads: false
 m_force_debug: false
 
 enable_wiki_emails: true
+
+enable_haproxy_stats: false
+haproxy_stats_user: admin
+haproxy_stats_password: password

--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -59,6 +59,7 @@ m_memcached_conf: /etc/sysconfig/memcached
 m_parsoid_path: /etc/parsoid
 m_simplesamlphp_path: /opt/simplesamlphp
 m_profiling_ui_directory: /usr/share/pear/xhprof_html
+m_profiling_xhgui_directory: /opt/xhgui
 
 # files
 m_i18n: /opt/meza/config/core/i18n

--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -77,4 +77,6 @@ m_language: en
 
 allow_backup_downloads: false
 
+m_force_debug: false
+
 enable_wiki_emails: true

--- a/src/playbooks/getdocker.yml
+++ b/src/playbooks/getdocker.yml
@@ -50,6 +50,8 @@
         name: "docker-ce"
         state: latest
       notify: Restart Docker
+      tags:
+      - latest
 
     - name: Ensure Docker is running (and enable it at boot)
       service:

--- a/src/playbooks/site.yml
+++ b/src/playbooks/site.yml
@@ -124,7 +124,6 @@
     - base-extras
     - imagemagick
     - apache-php
-    - composer
 
 # Keeping this as a separate play, since at some point it will make sense to
 # configure app-servers as gluster clients and have separate gluster servers

--- a/src/playbooks/site.yml
+++ b/src/playbooks/site.yml
@@ -86,6 +86,17 @@
   tags: load-balancer
   roles:
     - set-vars
+    - role: firewalld
+      firewalld_port: 8001
+      firewalld_protocol: tcp
+      firewalld_servers: "{{ groups['app-servers'] }}"
+      firewalld_zone: "{{m_private_networking_zone|default('public')}}"
+    - role: firewalld
+      firewalld_port: 8081
+      firewalld_protocol: tcp
+      firewalld_servers: "{{ groups['parsoid-servers'] }}"
+      firewalld_zone: "{{m_private_networking_zone|default('public')}}"
+    # NOTE: firewalld ports 80 and 443 opened to ALL within haproxy role
     - haproxy
 
 - hosts: app-servers
@@ -307,6 +318,17 @@
       firewalld_protocol: tcp
       firewalld_servers: "{{ groups['app-servers'] }}"
       firewalld_zone: "{{m_private_networking_zone|default('public')}}"
+    - role: firewalld
+      firewalld_port: 8000
+      firewalld_protocol: tcp
+      firewalld_servers: "{{ groups['load-balancers'] }}"
+      firewalld_zone: "{{m_private_networking_zone|default('public')}}"
+    - role: firewalld
+      firewalld_port: 8000
+      firewalld_protocol: tcp
+      firewalld_servers: "{{ groups['load-balancers-unmanaged'] }}"
+      firewalld_zone: "{{m_private_networking_zone|default('public')}}"
+      when: "'load-balancers-unmanaged' in groups"
     - nodejs
     - role: parsoid
       nodejs_install_npm_user: "nodejs"

--- a/src/roles/apache-php/tasks/main.yml
+++ b/src/roles/apache-php/tasks/main.yml
@@ -38,11 +38,41 @@
 
 - name: Install PHP
   include: php.yml
+  # http://docs.ansible.com/ansible/playbooks_roles.html#dynamic-versus-static-includes
   static: yes
+
+
+
+# Only required for developers and performance testing
+- name: Install XHProf PECL package for profiling
+  pear:
+    name: pecl/xhprof-beta
+    state: present
+  when: m_setup_php_profiling
+
+- name: "Ensure {{ m_profiling_directory }} exists"
+  file:
+    path: "{{ m_profiling_directory }}"
+    owner: apache
+    group: apache
+    mode: 0755
+    state: directory
+  when: m_setup_php_profiling
+
+- name: Install graphviz packages
+  yum:
+    name: graphviz
+    state: installed
+  when: m_setup_php_profiling
+
+
 
 # Now that PHP is installed, start apache
 - name: ensure apache is running (and enable it at boot)
-  service: name=httpd state=started enabled=yes
+  service:
+    name: httpd
+    state: started
+    enabled: yes
   when: docker_skip_tasks is not defined or not docker_skip_tasks
 
 

--- a/src/roles/apache-php/tasks/main.yml
+++ b/src/roles/apache-php/tasks/main.yml
@@ -41,30 +41,19 @@
   # http://docs.ansible.com/ansible/playbooks_roles.html#dynamic-versus-static-includes
   static: yes
 
+- name: Ensure Composer configured
+  include_role:
+    name: composer
 
-
-# Only required for developers and performance testing
-- name: Install XHProf PECL package for profiling
-  pear:
-    name: pecl/xhprof-beta
-    state: present
+- name: Ensure PHP profiling configured
+  include: profiling.yml
+  # http://docs.ansible.com/ansible/playbooks_roles.html#dynamic-versus-static-includes
+  static: yes
   when: m_setup_php_profiling
 
-- name: "Ensure {{ m_profiling_directory }} exists"
-  file:
-    path: "{{ m_profiling_directory }}"
-    owner: apache
-    group: apache
-    mode: 0755
-    state: directory
-  when: m_setup_php_profiling
-
-- name: Install graphviz packages
-  yum:
-    name: graphviz
-    state: installed
-  when: m_setup_php_profiling
-
+# FIXME: add "close off profiling" included file when not m_setup_php_profiling
+#        to automatically close ports and turn off services in case this is
+#        ever enabled on a production server.
 
 
 # Now that PHP is installed, start apache

--- a/src/roles/apache-php/tasks/php.yml
+++ b/src/roles/apache-php/tasks/php.yml
@@ -73,6 +73,8 @@
   pear:
     name: "{{ item }}"
     state: latest
+  tags:
+  - latest
   with_items:
   - Mail
   - Net_SMTP

--- a/src/roles/apache-php/tasks/profiling.yml
+++ b/src/roles/apache-php/tasks/profiling.yml
@@ -1,0 +1,117 @@
+---
+
+
+
+# Only required for developers and performance testing
+- name: add mongo repo file
+  template:
+    src: mongo.repo.j2
+    dest: /etc/yum.repos.d/mongo.repo
+  run_once: yes
+
+- name: Install mongodb-org package
+  yum:
+    name: mongodb-org
+    state: installed
+  run_once: yes
+
+# Not used for xhgui, just built in xhprof-ui
+- name: Install graphviz package
+  yum:
+    name: graphviz
+    state: installed
+
+- name: Ensure MongoDB conf file in place
+  template:
+    src: mongod.conf.j2
+    dest: /etc/mongod.conf
+
+- name: run mongodb
+  service:
+    name: mongod
+    state: started
+    enabled: yes
+  run_once: yes
+
+# run command `mongo` then type these...FIXME: how to Ansible-ize?
+# use xhprof
+# db.results.ensureIndex( { 'meta.SERVER.REQUEST_TIME' : -1 } )
+# db.results.ensureIndex( { 'profile.main().wt' : -1 } )
+# db.results.ensureIndex( { 'profile.main().mu' : -1 } )
+# db.results.ensureIndex( { 'profile.main().cpu' : -1 } )
+# db.results.ensureIndex( { 'meta.url' : 1 } )
+
+- name: Install XHProf and mongo PECL packages for profiling
+  pear:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - pecl/xhprof-beta
+    - pecl/mongo
+
+- name: Ensure XHGui present
+  git:
+    repo: https://github.com/perftools/xhgui.git
+    dest: "{{ m_profiling_xhgui_directory }}"
+    version: master
+    force: yes
+
+- name: Ensure XHGui directory owned by Apache
+  file:
+    path: "{{ m_profiling_xhgui_directory }}"
+    owner: apache
+    group: apache
+    mode: 0755
+    recurse: yes
+    state: directory
+
+- name: Ensure XHGui packages present
+  composer:
+    command: install
+    prefer_dist: True
+    working_dir: "{{ m_profiling_xhgui_directory }}"
+
+- name: Ensure XHGui using correct Mongo DB instance (on first app server)
+  template:
+    src: xhgui.config.php.j2
+    dest: "{{ m_profiling_xhgui_directory }}/config/config.php"
+
+- name: "Ensure XHGui cache directory configured"
+  file:
+    path: "{{ m_profiling_xhgui_directory }}/cache"
+    # owner: who?
+    # group: who?
+
+    # FIXME: suggested per docs, but c'mon
+    mode: 0777
+    recurse: yes
+    state: directory
+
+- name: Open port 27017 for MongoDB on all but first app server
+  include_role:
+    name: firewalld
+  vars:
+    # firewalld_service: http
+    firewalld_port: 27017
+    firewalld_protocol: tcp
+    firewalld_servers: "{{ groups['app-servers'] }}"
+    firewalld_zone: "{{m_private_networking_zone|default('public')}}"
+
+- name: Open port 8089 to load balancer
+  include_role:
+    name: firewalld
+  vars:
+    # firewalld_service: http
+    firewalld_port: 8089
+    firewalld_protocol: tcp
+    firewalld_servers: "{{ groups['load-balancers'] }}"
+    firewalld_zone: "{{m_private_networking_zone|default('public')}}"
+
+- name: "Ensure {{ m_profiling_directory }} exists"
+  file:
+    path: "{{ m_profiling_directory }}"
+    owner: apache
+    group: apache
+    mode: 0755
+    state: directory
+

--- a/src/roles/apache-php/templates/httpd.conf.j2
+++ b/src/roles/apache-php/templates/httpd.conf.j2
@@ -423,15 +423,38 @@ Listen 8080
 	{%- endif %}
 
 	{% if m_setup_php_profiling -%}
-	# Use SimpleSamlPhp to handle authentication
-	Alias /xhprof-ui {{ m_profiling_ui_directory }}
-	<Directory {{ m_profiling_ui_directory }}>
-		Require all granted
-		Options All -Indexes
-	</Directory>
-	{%- endif %}
+
+	# Prepends file all files to initiate profiling
+	php_admin_value auto_prepend_file "{{ m_profiling_xhgui_directory }}/external/header.php"
+
+	# Access the built in XHProf UI. Keeping this because the call graphs in
+	# image form may be better for portability
+	#Alias /xhprof-ui {{ m_profiling_ui_directory }}
+	#<Directory {{ m_profiling_ui_directory }}>
+	#	Require all granted
+	#	Options All -Indexes
+	#</Directory>
+
+	{% endif %}
 
 </VirtualHost>
+
+{% if m_setup_php_profiling -%}
+# Enable profiling for PHP
+Listen 8089
+<VirtualHost *:8089>
+
+	<Directory {{ m_profiling_xhgui_directory }}/webroot>
+		Options Indexes MultiViews FollowSymLinks
+		AllowOverride All
+		Require all granted
+	</Directory>
+
+	DocumentRoot {{ m_profiling_xhgui_directory }}/webroot
+	ServerName MezaProfiling
+
+</VirtualHost>
+{% endif %}
 
 # Use port 8090 to access mod_status. Not accessible outside firewall.
 ExtendedStatus on

--- a/src/roles/apache-php/templates/httpd.conf.j2
+++ b/src/roles/apache-php/templates/httpd.conf.j2
@@ -422,6 +422,15 @@ Listen 8080
 	</Directory>
 	{%- endif %}
 
+	{% if m_setup_php_profiling -%}
+	# Use SimpleSamlPhp to handle authentication
+	Alias /xhprof-ui {{ m_profiling_ui_directory }}
+	<Directory {{ m_profiling_ui_directory }}>
+		Require all granted
+		Options All -Indexes
+	</Directory>
+	{%- endif %}
+
 </VirtualHost>
 
 # Use port 8090 to access mod_status. Not accessible outside firewall.

--- a/src/roles/apache-php/templates/mongo.repo.j2
+++ b/src/roles/apache-php/templates/mongo.repo.j2
@@ -1,0 +1,6 @@
+[mongodb-org-3.4]
+name=MongoDB Repository
+baseurl=https://repo.mongodb.org/yum/redhat/7/mongodb-org/3.4/x86_64/
+gpgcheck=1
+enabled=1
+gpgkey=https://www.mongodb.org/static/pgp/server-3.4.asc

--- a/src/roles/apache-php/templates/mongod.conf.j2
+++ b/src/roles/apache-php/templates/mongod.conf.j2
@@ -1,0 +1,44 @@
+# mongod.conf
+
+# for documentation of all options, see:
+#   http://docs.mongodb.org/manual/reference/configuration-options/
+
+# where to write logging data.
+systemLog:
+  destination: file
+  logAppend: true
+  path: /var/log/mongodb/mongod.log
+
+# Where and how to store data.
+storage:
+  dbPath: /var/lib/mongo
+  journal:
+    enabled: true
+#  engine:
+#  mmapv1:
+#  wiredTiger:
+
+# how the process runs
+processManagement:
+  fork: true  # fork and run in background
+  pidFilePath: /var/run/mongodb/mongod.pid  # location of pidfile
+
+# network interfaces
+net:
+  port: 27017
+  #bindIp: 127.0.0.1  # Listen to local interface only, comment to listen on all interfaces.
+
+
+#security:
+
+#operationProfiling:
+
+#replication:
+
+#sharding:
+
+## Enterprise-Only Options
+
+#auditLog:
+
+#snmp:

--- a/src/roles/apache-php/templates/php.ini.j2
+++ b/src/roles/apache-php/templates/php.ini.j2
@@ -572,7 +572,7 @@ html_errors = On
 ; empty.
 ; http://php.net/error-log
 ; Example:
-;error_log = php_errors.log
+error_log = {{ m_logs }}/php_errors.log
 ; Log errors to syslog (Event Log on Windows).
 ;error_log = syslog
 
@@ -899,6 +899,9 @@ default_socket_timeout = 60
 ; Enable profiling capabilities for PHP
 extension=xhprof.so
 xhprof.output_dir={{ m_profiling_directory }}
+
+; Enable MongoDB to use XHGUI for XHProf
+extension=mongo.so
 {% endif %}
 
 ;;;;;;;;;;;;;;;;;;;
@@ -1925,13 +1928,13 @@ opcache.revalidate_freq=30
 opcache.force_restart_timeout=3600
 
 ; OPcache error_log file name. Empty string assumes "stderr".
-; opcache.error_log=/opt/data-meza/logs/opcache_error.log
+opcache.error_log=/opt/data-meza/logs/opcache_error.log
 
 ; All OPcache errors go to the Web server log.
 ; By default, only fatal errors (level 0) or errors (level 1) are logged.
 ; You can also enable warnings (level 2), info messages (level 3) or
 ; debug messages (level 4).
-;opcache.log_verbosity_level=1
+opcache.log_verbosity_level=2
 
 ; Preferred Shared Memory back-end. Leave empty and let the system decide.
 ;opcache.preferred_memory_model=

--- a/src/roles/apache-php/templates/php.ini.j2
+++ b/src/roles/apache-php/templates/php.ini.j2
@@ -895,6 +895,12 @@ default_socket_timeout = 60
 ;extension=php_xmlrpc.dll
 ;extension=php_xsl.dll
 
+{% if m_setup_php_profiling %}
+; Enable profiling capabilities for PHP
+extension=xhprof.so
+xhprof.output_dir={{ m_profiling_directory }}
+{% endif %}
+
 ;;;;;;;;;;;;;;;;;;;
 ; Module Settings ;
 ;;;;;;;;;;;;;;;;;;;

--- a/src/roles/apache-php/templates/xhgui.config.php.j2
+++ b/src/roles/apache-php/templates/xhgui.config.php.j2
@@ -1,0 +1,42 @@
+<?php
+
+// does this override xhgui's config/config.default.php entirely, or just
+// individual items?
+return array(
+    // 'debug' => false,
+    // 'mode' => 'development',
+    // Can be either mongodb or file.
+    /*
+    'save.handler' => 'file',
+    'save.handler.filename' => dirname(__DIR__) . '/cache/' . 'xhgui.data.' . microtime(true) . '_' . substr(md5($url), 0, 6),
+    */
+    //'save.handler' => 'mongodb',
+    // Needed for file save handler. Beware of file locking. You can adujst this file path
+    // to reduce locking problems (eg uniqid, time ...)
+    //'save.handler.filename' => __DIR__.'/../data/xhgui_'.date('Ymd').'.dat',
+
+    {% if inventory_hostname == groups['app-servers'][0] %}
+    'db.host' => 'mongodb://127.0.0.1:27017',
+    {% else %}
+    // mongodb server is on first app server
+    'db.host' => 'mongodb://{{ groups["app-servers"][0] }}:27017',
+    {% endif %}
+
+    //'db.db' => 'xhprof',
+    // Allows you to pass additional options like replicaSet to MongoClient.
+    // 'username', 'password' and 'db' (where the user is added)
+    //'db.options' => array(),
+    //'templates.path' => dirname(__DIR__) . '/src/templates',
+    //'date.format' => 'M jS H:i:s',
+    //'detail.count' => 6,
+    //'page.limit' => 25,
+    // Profile 1 in 100 requests.
+    // You can return true to profile every request.
+    'profiler.enable' => function() {
+        //return rand(1, 100) === 42;
+    	return true;
+    },
+    // 'profiler.simple_url' => function($url) {
+    //     return preg_replace('/\=\d+/', '', $url);
+    // }
+);

--- a/src/roles/base/tasks/main.yml
+++ b/src/roles/base/tasks/main.yml
@@ -48,9 +48,14 @@
     validate: 'visudo -cf %s'
 
 - name: ensure deltarpm is installed and latest
-  yum: name=deltarpm state=installed
+  yum: name=deltarpm state=latest
+  tags:
+  - latest
+
 - name: upgrade all packages
   yum: name=* state=latest
+  tags:
+  - latest
 
 # FIXME: for RedHat may need to enable "Optional RPMs"
 - name: ensure EPEL installed

--- a/src/roles/haproxy/tasks/main.yml
+++ b/src/roles/haproxy/tasks/main.yml
@@ -208,7 +208,18 @@
   with_items:
     - 80
     - 443
+    - 1936
   when: docker_skip_tasks is not defined or not docker_skip_tasks
+
+
+- name: Configure firewalld for haproxy stats via port 1936
+  firewalld:
+    port: "1936/tcp"
+    permanent: true
+    immediate: true
+    state: enabled
+    zone: "{{m_public_networking_zone|default('public')}}"
+  when: (docker_skip_tasks is not defined or not docker_skip_tasks) and enable_haproxy_stats
 
 
 # FIXME: haproxy will need to handle reverse proxy for Elasticsearch plugins

--- a/src/roles/haproxy/tasks/main.yml
+++ b/src/roles/haproxy/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-# FIXME: Eventually add the ability to get SSL cert from letsencrypt
+# FIXME #748: Eventually add the ability to get SSL cert from letsencrypt
 #     ref: https://www.digitalocean.com/community/tutorials/how-to-secure-haproxy-with-let-s-encrypt-on-centos-7
 # Other refs:
 #     https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Load_Balancer_Administration/install_haproxy_example1.html
@@ -152,7 +152,7 @@
   file:
     path: /etc/haproxy/errors
     state: directory
-    # FIXME: permissions?
+    # FIXME #530: permissions?
 
 
 - name: Ensure error pages in place
@@ -160,7 +160,7 @@
     src: "errors/{{ item }}.http.j2"
     dest: "/etc/haproxy/errors/{{ item }}.http"
   with_items:
-    # FIXME: add the others, make the 500 error one good
+    # FIXME #663: add the others, make the 500 error one good
     # - 400
     # - 403
     # - 408
@@ -169,6 +169,8 @@
     # - 503
     # - 504
 
+# FIXME #746: Why does HAProxy specify this different method for firewall? Is
+# it an SELinux thing (which at present we don't have in enforcing)?
 - name: Ensure firewalld haproxy service files in place
   template:
     src: "haproxy-{{ item }}.firewalld.xml.j2"
@@ -211,7 +213,6 @@
     - 1936
   when: docker_skip_tasks is not defined or not docker_skip_tasks
 
-
 - name: Configure firewalld for haproxy stats via port 1936
   firewalld:
     port: "1936/tcp"
@@ -222,7 +223,7 @@
   when: (docker_skip_tasks is not defined or not docker_skip_tasks) and enable_haproxy_stats
 
 
-# FIXME: haproxy will need to handle reverse proxy for Elasticsearch plugins
+# FIXME #747: haproxy will need to handle reverse proxy for Elasticsearch plugins
 # - name: Configure firewalld for Elasticsearch reverse proxy
 #   firewalld:
 #     port: 8008/tcp

--- a/src/roles/haproxy/tasks/main.yml
+++ b/src/roles/haproxy/tasks/main.yml
@@ -223,6 +223,18 @@
   when: (docker_skip_tasks is not defined or not docker_skip_tasks) and enable_haproxy_stats
 
 
+- name: Open port 8088 when profiling enabled
+  firewalld:
+    port: "8088/tcp"
+    permanent: true
+    immediate: true
+    state: enabled
+    zone: "{{m_public_networking_zone|default('public')}}"
+  when: m_setup_php_profiling and (docker_skip_tasks is not defined or not docker_skip_tasks)
+
+# FIXME: disable port 8088 when profiling not enabled
+
+
 # FIXME #747: haproxy will need to handle reverse proxy for Elasticsearch plugins
 # - name: Configure firewalld for Elasticsearch reverse proxy
 #   firewalld:

--- a/src/roles/haproxy/templates/haproxy.cfg.j2
+++ b/src/roles/haproxy/templates/haproxy.cfg.j2
@@ -79,6 +79,13 @@ backend www-backend
 
 	{% endfor %}
 
+{% if m_setup_php_profiling %}
+listen php-profiling
+	bind *:8088
+	{% for host in groups['app-servers'] -%}
+		server profiling{{ loop.index }} {{ host }}:8089 check
+	{% endfor %}
+{% endif %}
 
 listen parsoid-internal
 	bind *:8001

--- a/src/roles/haproxy/templates/haproxy.cfg.j2
+++ b/src/roles/haproxy/templates/haproxy.cfg.j2
@@ -98,6 +98,16 @@ listen mediawiki-internal
 
 	{% endfor %}
 
+{% if enable_haproxy_stats %}
+listen stats
+	bind *:1936 ssl crt /etc/haproxy/certs/meza.pem
+	stats enable
+	stats hide-version
+	stats realm Haproxy\ Statistics
+	stats uri /haproxy
+	stats auth {{ haproxy_stats_user }}:{{ haproxy_stats_password }}
+	stats refresh 30s
+{% endif %}
 
 # backend letsencrypt-backend
 # 	server letsencrypt 127.0.0.1:54321

--- a/src/roles/haproxy/templates/haproxy.cfg.j2
+++ b/src/roles/haproxy/templates/haproxy.cfg.j2
@@ -70,13 +70,34 @@ frontend www-https
 
 backend www-backend
 	redirect scheme https if !{ ssl_fc }
-	{% for host in groups['app-servers'] %}
-	{% if host == inventory_hostname %}
-	server apache{{ loop.index }} 127.0.0.1:8080 check
-	{% else %}
-	server apache{{ loop.index }} {{ host }}:8080 check
-	{% endif %}
+	{% for host in groups['app-servers'] -%}
+		{%- if host == inventory_hostname -%}
+			server apache{{ loop.index }} 127.0.0.1:8080 check
+		{%- else -%}
+			server apache{{ loop.index }} {{ host }}:8080 check
+		{%- endif %}
+
 	{% endfor %}
+
+
+listen parsoid-internal
+	bind *:8001
+	{% for host in groups['parsoid-servers'] -%}
+		server parsoid{{ loop.index }} {{ host }}:8000 check
+	{% endfor %}
+
+
+listen mediawiki-internal
+	bind *:8081
+	{% for host in groups['app-servers'] -%}
+		{%- if host == inventory_hostname -%}
+			server mediawiki{{ loop.index }} 127.0.0.1:8080 check
+		{%- else -%}
+			server mediawiki{{ loop.index }} {{ host }}:8080 check
+		{%- endif %}
+
+	{% endfor %}
+
 
 # backend letsencrypt-backend
 # 	server letsencrypt 127.0.0.1:54321

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -703,19 +703,9 @@ $wgCirrusSearchClusters['default'][] = '{{ host }}';
  * Extension:VisualEditor
  *
  * Parsoid servers are defined based upon Ansible hosts file and thus
- * cannot be easily added to base-extensions.yml. As such, VisualEditor config
+ * cannot be easily added to MezaCoreExtensions.yml. As such, VisualEditor config
  * is included directly in LocalSettings.php.j2
  */
-// Allow read and edit permission for requests from the server (e.g. Parsoid)
-// Ref: https://www.mediawiki.org/wiki/Talk:Parsoid/Archive#Running_Parsoid_on_a_.22private.22_wiki_-_AccessDeniedError
-// Ref: https://www.mediawiki.org/wiki/Extension:VisualEditor#Linking_with_Parsoid_in_private_wikis
-$mezaValidParsoidServers = [];
-{% for host in groups['parsoid-servers'] %}
-{% if host == inventory_hostname %}
-$mezaValidParsoidServers[] = '127.0.0.1';
-{% endif %}
-$mezaValidParsoidServers[] = '{{ host }}';
-{% endfor %}
 
 /**
  * HTTP_X_FORWARDED_FOR is set by HAProxy when users request pages via
@@ -723,7 +713,11 @@ $mezaValidParsoidServers[] = '{{ host }}';
  * other services (e.g. Parsoid) should directly access webservers. In
  * order to allow services to access MediaWiki with full permissions,
  * if HTTP_X_FORWARDED_FOR does NOT exist then assume it's not a regular
- * user and grant permissions
+ * user and grant permissions.
+ *
+ * Refs:
+ * https://www.mediawiki.org/wiki/Talk:Parsoid/Archive#Running_Parsoid_on_a_.22private.22_wiki_-_AccessDeniedError
+ * https://www.mediawiki.org/wiki/Extension:VisualEditor#Linking_with_Parsoid_in_private_wikis
  **/
 if ( ! isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
 	$wgGroupPermissions['*']['read'] = true;
@@ -739,15 +733,31 @@ $wgHiddenPrefs[] = 'visualeditor-enable';
 // OPTIONAL: Enable VisualEditor's experimental code features
 #$wgDefaultUserOptions['visualeditor-enable-experimental'] = 1;
 
-// URL to the Parsoid instance MUST NOT end in a slash due to Parsoid bug
-if ( in_array( '127.0.0.1', $mezaValidParsoidServers ) ) {
-	$parsoidDomain = '127.0.0.1';
-}
-else {
-	$parsoidDomain = $mezaValidParsoidServers[ array_rand( $mezaValidParsoidServers ) ];
-}
+
+
 $wgVirtualRestConfig['modules']['parsoid'] = array(
-	'url' => "http://$parsoidDomain:8000",
+
+{% if groups['app-servers']|length|int == 1 and groups['parsoid-servers']|length|int == 1 and groups['app-servers'][0] == groups['parsoid-servers'][0] %}
+
+	// One and only Parsoid server is localhost
+	'url' => 'http://127.0.0.1:8000',
+
+
+{% elif 'load-balancers' not in groups or groups['load-balancers']|length|int == 0 %}
+
+	'url' => 'http://{{ groups["load-balancers-unmanaged"][0] }}:8001',
+	//'HTTPProxy' => 'http://{{ groups["load-balancers-unmanaged"][0] }}:8001',
+
+{% else %}
+
+	'url' => 'http://{{ groups["load-balancers"][0] }}:8001',
+	//'HTTPProxy' => 'http://{{ groups["load-balancers"][0] }}:8001',
+
+{% endif %}
+
+
+
+
 
 	// domain here is not really the domain. It needs to be unique to each wiki
 	// and both domain and prefix must match settings in Parsoid's settings in

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -185,6 +185,15 @@ else {
 
 }
 
+{% if m_setup_php_profiling %}
+// See https://www.mediawiki.org/wiki/Manual:Profiling for more info.
+// Output options are udp, text (onto page, probably doesn't work for JS/CSS),
+// db (requires addtional DB setup), and dump (to files)
+$wgProfiler['class'] = 'ProfilerXhprof';
+$wgProfiler['output'] = array( 'ProfilerOutputDump' );
+$wgProfiler['outputDir'] = '{{ m_profiling_directory }}';
+$wgProfiler['visible'] = true;
+{% endif %}
 
 
 

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -388,6 +388,7 @@ $wgSharedTables = array(
  *
  **/
 // proxy setup
+$wgUseSquid = true;
 $wgUsePrivateIPs = true;
 $wgSquidServersNoPurge = array(
 	{% for server in groups['load-balancers'] -%}

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -189,10 +189,11 @@ else {
 // See https://www.mediawiki.org/wiki/Manual:Profiling for more info.
 // Output options are udp, text (onto page, probably doesn't work for JS/CSS),
 // db (requires addtional DB setup), and dump (to files)
-$wgProfiler['class'] = 'ProfilerXhprof';
-$wgProfiler['output'] = array( 'ProfilerOutputDump' );
-$wgProfiler['outputDir'] = '{{ m_profiling_directory }}';
-$wgProfiler['visible'] = true;
+//
+// $wgProfiler['class'] = 'ProfilerXhprof';
+// $wgProfiler['output'] = array( 'ProfilerOutputDump' );
+// $wgProfiler['outputDir'] = '{{ m_profiling_directory }}';
+// $wgProfiler['visible'] = true;
 {% endif %}
 
 

--- a/src/roles/memcached/tasks/main.yml
+++ b/src/roles/memcached/tasks/main.yml
@@ -3,6 +3,8 @@
   yum:
     name: "{{ item }}"
     state: latest
+  tags:
+  - latest
   with_items:
   - memcached
   - nmap-ncat

--- a/src/roles/nodejs/tasks/main.yml
+++ b/src/roles/nodejs/tasks/main.yml
@@ -71,3 +71,5 @@
     NODE_PATH: "{{ npm_config_prefix }}/lib/node_modules"
     NPM_CONFIG_UNSAFE_PERM: "{{ npm_config_unsafe_perm }}"
   with_items: "{{ nodejs_npm_global_packages }}"
+  tags:
+  - latest

--- a/src/roles/parsoid-settings/templates/localsettings.js.j2
+++ b/src/roles/parsoid-settings/templates/localsettings.js.j2
@@ -10,30 +10,36 @@ exports.setup = function(parsoidConfig) {
 	//     http://192.168.56.56/wiki/api.php
 	//     http://enterprisemediawiki.org/wiki/api.php
 
-	// file system
-	var fs = require( 'fs' );
 
-	// get all the directories in the /wikis directory. These are the wiki
-	// identifiers for each wiki
-	var wikis = [
-		{%- for wiki in list_of_wikis -%}
-		"{{ wiki }}"{% if not loop.last %},{% endif %}
-		{%- endfor -%}
-	];
 
-	// Domain, which will be setup by the meza installer
-	var domain = "http://{{ groups['app-servers'][0] }}:8080/";  // was mw_api_domain
+	// for all wiki IDs do setMwApi
+	{% for wiki in list_of_wikis %}
 
-	// loop through all wiki IDs and do setMwApi
-	for ( var i = 0; i < wikis.length; i++ ) {
-		parsoidConfig.setMwApi( {
-			prefix: wikis[i],
-			uri: domain + wikis[i] + '/api.php',
+	parsoidConfig.setMwApi({
 
-			// not really the domain, needs to be specific to each wiki
-			domain: wikis[i]
-		} );
-	}
+		{% if groups['app-servers']|length|int == 1 and groups['parsoid-servers']|length|int == 1 and groups['app-servers'][0] == groups['parsoid-servers'][0] -%}
+
+			uri: 'http://127.0.0.1:8080/{{ wiki }}/api.php',
+
+		{%- elif 'load-balancers' not in groups or groups['load-balancers']|length|int == 0 -%}
+
+			uri: 'http://{{ groups["load-balancers-unmanaged"][0] }}:8081/{{ wiki }}/api.php',
+			// proxy: { uri: 'http://{{ groups["load-balancers-unmanaged"][0] }}:8081/' },
+
+		{%- else -%}
+
+			uri: 'http://{{ groups["load-balancers"][0] }}:8081/{{ wiki }}/api.php',
+			// proxy: { uri: 'http://{{ groups["load-balancers"][0] }}:8081/' },
+
+		{%- endif %}
+
+		// not really the domain, needs to be specific to each wiki
+		domain: '{{ wiki }}',
+		prefix: '{{ wiki }}'
+	} );
+
+	{% endfor %}
+
 
 	// To specify a proxy (or proxy headers) specific to this prefix (which
 	// overrides defaultAPIProxyURI) use:
@@ -59,7 +65,11 @@ exports.setup = function(parsoidConfig) {
 	//parsoidConfig.defaultAPIProxyURI = 'http://proxy.example.org:8080';
 
 	// Enable debug mode (prints extra debugging messages)
-	//parsoidConfig.debug = true;
+	{% if m_force_debug %}
+	parsoidConfig.debug = true;
+	{% else %}
+	parsoidConfig.debug = false;
+	{% endif %}
 
 	// Use the PHP preprocessor to expand templates via the MW API (default true)
 	//parsoidConfig.usePHPPreProcessor = false;
@@ -96,9 +106,21 @@ exports.setup = function(parsoidConfig) {
 	// OR by defining your own performanceTimer properties
 	//parsoidConfig.heapUsageSampleInterval = 5 * 60 * 1000;
 
-	// Allow override of port/interface:
+	// Allow override of port:
 	//parsoidConfig.serverPort = 8000;
+
+
+	{% if groups['app-servers']|length|int == 1 and groups['parsoid-servers']|length|int == 1 and groups['app-servers'][0] == groups['parsoid-servers'][0] %}
+
+	// One and only Parsoid server is one and only app-server
 	parsoidConfig.serverInterface = '127.0.0.1';
+
+	{% else %}
+
+	parsoidConfig.serverInterface = '{{ inventory_hostname }}';
+
+	{% endif %}
+
 
 	// The URL of your LintBridge API endpoint
 	//parsoidConfig.linterAPI = 'http://lintbridge.wmflabs.org/add';

--- a/src/scripts/ssh-users/setup-minion-user.sh
+++ b/src/scripts/ssh-users/setup-minion-user.sh
@@ -71,7 +71,9 @@ mf_add_ssh_user "meza-ansible"
 
 
 if [ -f /tmp/meza-ansible.id_rsa.pub ]; then
-	cat /tmp/meza-ansible.id_rsa.pub >> /opt/conf-meza/users/meza-ansible/.ssh/authorized_keys
+	cat /tmp/meza-ansible.id_rsa.pub >> "$meza_user_dir/meza-ansible/.ssh/authorized_keys"
+	chown meza-ansible:meza-ansible "$meza_user_dir/meza-ansible/.ssh/authorized_keys"
+	chmod 644 "$meza_user_dir/meza-ansible/.ssh/authorized_keys"
 	passwd --delete meza-ansible
 else
 	echo

--- a/src/scripts/ssh-users/transfer-master-key.sh
+++ b/src/scripts/ssh-users/transfer-master-key.sh
@@ -17,6 +17,10 @@ source "$m_scripts/shell-functions/linux-user.sh"
 echo "Type space-separated list of minions to copy SSH"
 read -e minions
 
+if [ -z "$ansible_user" ]; then 
+	ansible_user="meza-ansible"
+fi
+
 for minion in $minions; do
 
 	# Copy id_rsa.pub to each minion

--- a/vagrantconf.default.yml
+++ b/vagrantconf.default.yml
@@ -1,0 +1,9 @@
+---
+app1:
+  memory: 2048
+  cpus: 1
+
+# To add a second app server, uncomment the lines below
+# app2:
+#   memory: 512
+#   cpus: 1


### PR DESCRIPTION
This pull request includes several concepts which have each been repackaged into individual commits to keep them separate. They were broken out because they were initially added in order to determine how to fix MediaWiki's extreme slowness when having multiple app servers. That issue is solved in the next pull request.

### Commits

#### Properly set server interface for parsoid; load balance

Previously localsettings.js had `parsoidConfig.serverInterface = '127.0.0.1';` in all cases. This breaks in a multi-server setup, since Parsoid needs to bind to it's servers IP address. Also, in multi-parsoid setups we need a way to load balance between the parsoids, so that is added to HAProxy. Finally, MediaWiki also needs to be available load-balanced to Parsoid but Parsoid can't go through HTTPS (at this time) so that entry is in HAProxy now, too.

####  Allow enabling HAProxy stats page

By adding the following to your config (secret config!) you can see the HAProxy stats page at `https://example.com:1936/haproxy`

```yaml
enable_haproxy_stats: true
haproxy_stats_user: admin
haproxy_stats_password: password
```

####  Update FIXMEs with issue numbers

Added several issue numbers to inline FIXMEs.

####  Add profiling capability and XHProf built-in UI

Added profiling capability with XHProf using MediaWiki's built-in support and XHProf's built-in user interface. This was good initially, but isn't as clean as XHGui's interface. See commit below for replacement.

####  add 'latest' tag where appropriate

In order to filter out more things that don't need to be repeatedly run by doing `--skip-tags latest`, add more `latest` tags!

####  Specify explicitly to use squid; has no noticable effect

Was missing a Squid variable that evidently had little or no change but should be there.

####  Add XHGui+MongoDB when profiling; Move composer into apache-php

Replace the built-in XHProf UI with XHGui. In order to use XHGui, can't use the built-in MediaWiki hooks into XHProf. Instead, need to use XHGui's `header.php` using the Apache configuration `php_admin_value auto_prepend_file "{{ m_profiling_xhgui_directory }}/external/header.php"`. This makes it so `header.php` is prepended to all requests, and thus profiles them.

####  Make Vagrant capable of creating two servers; Allow Windows

Update Vagrantfile to use the config in either `vagrantconf.default.yml` or `vagrantconf.yml` (if it's present) to determine what type of VMs to build. By default builds one with modest RAM and 1 CPU. Optionally add a second VM to be another app server. This was created to support testing of the app server issues.

The `.gitattributes` file was added to this commit to try to make it so Windows always used LF line endings just like *nix. This was required because when you do `vagrant up` on Windows you need the code to be copied over to the CentOS client in a compatible method. None of the code is supposed to execute on Windows, so that should be fine. In practice, it doesn't seem like Git handles checkout of these files properly. This may just be because the `.gitattributes` file is not on `master` yet, so things get screwy on initial `git clone`.

On major enhancement, aside from easier/better `vagrant up` usage, is that shared directories are now setup. However, on Windows these directories only appear to work on the initial `vagrant up`. If `vagrant halt` is used and then the server is brought `up` again the mount does not (always) work.