### PR TITLE
Clean up PHP profiling to only use XHGui

### DIFF
--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -27,9 +27,6 @@ m_cache_directory: /opt/data-meza/cache
 m_tmp: /opt/data-meza/tmp
 m_logs: /opt/data-meza/logs
 
-# Only if m_setup_php_profiling: true
-m_profiling_directory: /opt/data-meza/logs/profiling
-
 # uploads dir. This WILL BE OVERIDDEN if multiple app servers are used, and
 # instead will use /opt/data-meza/uploads-gluster to use GlusterFS distributed
 # file system.
@@ -59,7 +56,6 @@ m_php_ini: /etc/php.ini
 m_memcached_conf: /etc/sysconfig/memcached
 m_parsoid_path: /etc/parsoid
 m_simplesamlphp_path: /opt/simplesamlphp
-m_profiling_ui_directory: /usr/share/pear/xhprof_html
 m_profiling_xhgui_directory: /opt/xhgui
 
 # files

--- a/src/roles/apache-php/tasks/main.yml
+++ b/src/roles/apache-php/tasks/main.yml
@@ -51,9 +51,16 @@
   static: yes
   when: m_setup_php_profiling
 
-# FIXME: add "close off profiling" included file when not m_setup_php_profiling
-#        to automatically close ports and turn off services in case this is
-#        ever enabled on a production server.
+# If profiling not enabled, disable MongoDB if it exists (e.g. profiling had
+# previously been enabled)
+- name: Check if MongoDB service exists
+  stat: path=/etc/init.d/mongod
+  register: mongo_service_status
+- name: Stop MongoDB service if profiling is disabled
+  service:
+    name: mongod
+    state: stopped
+  when: mongo_service_status.stat.exists and not m_setup_php_profiling
 
 
 # Now that PHP is installed, start apache

--- a/src/roles/apache-php/tasks/profiling.yml
+++ b/src/roles/apache-php/tasks/profiling.yml
@@ -15,12 +15,6 @@
     state: installed
   run_once: yes
 
-# Not used for xhgui, just built in xhprof-ui
-- name: Install graphviz package
-  yum:
-    name: graphviz
-    state: installed
-
 - name: Ensure MongoDB conf file in place
   template:
     src: mongod.conf.j2
@@ -106,12 +100,3 @@
     firewalld_protocol: tcp
     firewalld_servers: "{{ groups['load-balancers'] }}"
     firewalld_zone: "{{m_private_networking_zone|default('public')}}"
-
-- name: "Ensure {{ m_profiling_directory }} exists"
-  file:
-    path: "{{ m_profiling_directory }}"
-    owner: apache
-    group: apache
-    mode: 0755
-    state: directory
-

--- a/src/roles/apache-php/tasks/profiling.yml
+++ b/src/roles/apache-php/tasks/profiling.yml
@@ -27,13 +27,7 @@
     enabled: yes
   run_once: yes
 
-# run command `mongo` then type these...FIXME: how to Ansible-ize?
-# use xhprof
-# db.results.ensureIndex( { 'meta.SERVER.REQUEST_TIME' : -1 } )
-# db.results.ensureIndex( { 'profile.main().wt' : -1 } )
-# db.results.ensureIndex( { 'profile.main().mu' : -1 } )
-# db.results.ensureIndex( { 'profile.main().cpu' : -1 } )
-# db.results.ensureIndex( { 'meta.url' : 1 } )
+# FIXME #753: Setup indexes for MongoDB used for profiling
 
 - name: Install XHProf and mongo PECL packages for profiling
   pear:

--- a/src/roles/apache-php/templates/httpd.conf.j2
+++ b/src/roles/apache-php/templates/httpd.conf.j2
@@ -423,18 +423,8 @@ Listen 8080
 	{%- endif %}
 
 	{% if m_setup_php_profiling -%}
-
 	# Prepends file all files to initiate profiling
 	php_admin_value auto_prepend_file "{{ m_profiling_xhgui_directory }}/external/header.php"
-
-	# Access the built in XHProf UI. Keeping this because the call graphs in
-	# image form may be better for portability
-	#Alias /xhprof-ui {{ m_profiling_ui_directory }}
-	#<Directory {{ m_profiling_ui_directory }}>
-	#	Require all granted
-	#	Options All -Indexes
-	#</Directory>
-
 	{% endif %}
 
 </VirtualHost>

--- a/src/roles/apache-php/templates/php.ini.j2
+++ b/src/roles/apache-php/templates/php.ini.j2
@@ -898,7 +898,6 @@ default_socket_timeout = 60
 {% if m_setup_php_profiling %}
 ; Enable profiling capabilities for PHP
 extension=xhprof.so
-xhprof.output_dir={{ m_profiling_directory }}
 
 ; Enable MongoDB to use XHGUI for XHProf
 extension=mongo.so

--- a/src/roles/haproxy/tasks/main.yml
+++ b/src/roles/haproxy/tasks/main.yml
@@ -233,6 +233,14 @@
   when: m_setup_php_profiling and (docker_skip_tasks is not defined or not docker_skip_tasks)
 
 # FIXME: disable port 8088 when profiling not enabled
+- name: CLOSE port 8088 when profiling DISABLED
+  firewalld:
+    port: "8088/tcp"
+    permanent: true
+    immediate: true
+    state: disabled
+    zone: "{{m_public_networking_zone|default('public')}}"
+  when: not m_setup_php_profiling and (docker_skip_tasks is not defined or not docker_skip_tasks)
 
 
 # FIXME #747: haproxy will need to handle reverse proxy for Elasticsearch plugins

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -185,17 +185,6 @@ else {
 
 }
 
-{% if m_setup_php_profiling %}
-// See https://www.mediawiki.org/wiki/Manual:Profiling for more info.
-// Output options are udp, text (onto page, probably doesn't work for JS/CSS),
-// db (requires addtional DB setup), and dump (to files)
-//
-// $wgProfiler['class'] = 'ProfilerXhprof';
-// $wgProfiler['output'] = array( 'ProfilerOutputDump' );
-// $wgProfiler['outputDir'] = '{{ m_profiling_directory }}';
-// $wgProfiler['visible'] = true;
-{% endif %}
-
 
 
 


### PR DESCRIPTION
Prior to this pull request we have:

1. XHProf: PHP extension that does the profiling heavy-lifting
2. MediaWiki `$wgProfiler['class'] = 'ProfilerXhprof';` to perform the profiling
3. XHProf UI to display the output of (2)
4. XHGui to be a better UI
5. XHGui `header.php` prepended to all page loads via Apache to perform the profiling

We only want to keep 1, 4, and 5. Removing 2 and 3 also means removing Graphviz which was used to create callgraphs. 