### PR TITLE
Use file cache for localization, else serious lag when multi-app

### DIFF
--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -23,6 +23,7 @@ m_test: /opt/meza/test
 
 # data dir
 m_meza_data: /opt/data-meza
+m_cache_directory: /opt/data-meza/cache
 m_tmp: /opt/data-meza/tmp
 m_logs: /opt/data-meza/logs
 

--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -163,6 +163,21 @@
   when: saml_public is defined
 
 
+#
+# Cache (at this time) for localization caching. Also can be used for caching
+# page contents, but this isn't as necessary for enterprise cases where
+# generally users are always logged in.
+#
+- name: Ensure localization cache root directory exists (each wiki with sub-directory)
+  file:
+    state: directory
+    path: "{{ m_cache_directory }}"
+    owner: apache
+    group: apache
+    mode: 0700
+
+
+
 
 #
 # DEMO WIKI (if needed)

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -491,6 +491,22 @@ wfLoadSkin( 'Vector' );
 $wgRestrictDisplayTitle = false;
 
 
+/**
+ * Directory for caching data in the local filesystem. Should not be accessible
+ * from the web. Meza's usage of this is for localization cache
+ *
+ * Note: if multiple wikis share the same localisation cache directory, they
+ * must all have the same set of extensions.
+ *
+ * Refs:
+ *  - mediawiki/includes/DefaultSettings.php
+ *  - https://www.mediawiki.org/wiki/Localisation#Caching
+ *  - https://www.mediawiki.org/wiki/Manual:$wgCacheDirectory
+ *  - https://www.mediawiki.org/wiki/Manual:$wgLocalisationCacheConf
+ */
+$wgCacheDirectory = "{{ m_cache_directory }}/$wikiId";
+
+
 
 
 

--- a/src/roles/verify-wiki/tasks/main.yml
+++ b/src/roles/verify-wiki/tasks/main.yml
@@ -14,6 +14,15 @@
 #      - eventually need method to force-rsync from backup
 
 
+- name: Ensure localization cache directory exists for this wiki
+  file:
+    state: directory
+    path: "{{ m_cache_directory }}/{{ wiki_id }}"
+    owner: apache
+    group: apache
+    mode: 0700
+
+
 
 # Check if databases starting with "wiki_" exist
 #   if database exists: wiki_database.rc == 0


### PR DESCRIPTION
Having multiple application servers (mediawiki servers) was showing serious lag if localization cache was in database. Slow query log showed LCStoreDB::finishWrite as the major culprit method. Also MediaWiki::restInPeace, but to a lesser extent. 

Essentially this fix just adds the following to `LocalSettings.php`:

```php
$wgCacheDirectory = '/some/directory';
```

I believe the issue is due to the app servers applying locks in the database when trying to update the cache. By instead using a directory the app servers are all using their own cache, rather than sharing one across all app servers. This duplication is okay because the localization cache is not updated frequently...really only when MediaWiki or extensions are upgraded.