### PR TITLE
Fix permissions to allow Parsoid to work in _closed_ multi-server setups

### DIFF
--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -744,7 +744,10 @@ $parsoidServers = array(
 	{% endfor %}
 );
 $xffPresent = isset( $_SERVER['HTTP_X_FORWARDED_FOR'] );
-$remoteAddrIsValidParsoid = in_array( $_SERVER['REMOTE_ADDR'], array('127.0.0.1','localhost');
+$remoteAddrIsValidParsoid = in_array(
+	$_SERVER['REMOTE_ADDR'],
+	array('127.0.0.1','localhost')
+);
 
 if ( (! $xffPresent && $remoteAddrIsValidParsoid)
 	|| ( $xffPresent && in_array($_SERVER['HTTP_X_FORWARDED_FOR'],$parsoidServers) )

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -724,20 +724,38 @@ $wgCirrusSearchClusters['default'][] = '{{ host }}';
  */
 
 /**
- * HTTP_X_FORWARDED_FOR is set by HAProxy when users request pages via
- * the load balancer. No users should directly access webservers. Only
- * other services (e.g. Parsoid) should directly access webservers. In
- * order to allow services to access MediaWiki with full permissions,
- * if HTTP_X_FORWARDED_FOR does NOT exist then assume it's not a regular
- * user and grant permissions.
+ * HTTP_X_FORWARDED_FOR (XFF) is set by HAProxy when users request pages via
+ * the load balancer. Users always access via the load balancer. Parsoid may or
+ * may not access via the load balancer (it will if Parsoid is not on the same
+ * server as the one and only load balancer). In order to allow Parsoid to
+ * access MediaWiki with full permissions, grant access to server if:
+ *
+ *   No XFF (e.g. is a request internal to the server) and REMOTE_ADDR is local
+ *   - or -
+ *   Yes XFF and XFF is a parsoid server
  *
  * Refs:
  * https://www.mediawiki.org/wiki/Talk:Parsoid/Archive#Running_Parsoid_on_a_.22private.22_wiki_-_AccessDeniedError
  * https://www.mediawiki.org/wiki/Extension:VisualEditor#Linking_with_Parsoid_in_private_wikis
  **/
-if ( ! isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
+$parsoidServers = array(
+	{% for parsoid in groups['parsoid-servers'] %}
+	'{{ parsoid }}',
+	{% endfor %}
+);
+$xffPresent = isset( $_SERVER['HTTP_X_FORWARDED_FOR'] );
+$remoteAddrIsValidParsoid = in_array( $_SERVER['REMOTE_ADDR'], array('127.0.0.1','localhost');
+
+if ( (! $xffPresent && $remoteAddrIsValidParsoid)
+	|| ( $xffPresent && in_array($_SERVER['HTTP_X_FORWARDED_FOR'],$parsoidServers) )
+) {
+
+	// xff = X-Forwarded-For HTTP header (see above)
+	// If no xff and remote address is "localhost" or "127.0.0.1"
+	// If yes xff and xff in [list,of,parsoid,servers]
 	$wgGroupPermissions['*']['read'] = true;
 	$wgGroupPermissions['*']['edit'] = true;
+
 }
 
 // Enable by default for everybody

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -738,27 +738,39 @@ $wgCirrusSearchClusters['default'][] = '{{ host }}';
  * https://www.mediawiki.org/wiki/Talk:Parsoid/Archive#Running_Parsoid_on_a_.22private.22_wiki_-_AccessDeniedError
  * https://www.mediawiki.org/wiki/Extension:VisualEditor#Linking_with_Parsoid_in_private_wikis
  **/
-$parsoidServers = array(
-	{% for parsoid in groups['parsoid-servers'] %}
-	'{{ parsoid }}',
-	{% endfor %}
-);
-$xffPresent = isset( $_SERVER['HTTP_X_FORWARDED_FOR'] );
-$remoteAddrIsValidParsoid = in_array(
-	$_SERVER['REMOTE_ADDR'],
-	array('127.0.0.1','localhost')
-);
+// initially assume we're not granting special rights
+$grantParsoidReadWrite = false;
 
-if ( (! $xffPresent && $remoteAddrIsValidParsoid)
-	|| ( $xffPresent && in_array($_SERVER['HTTP_X_FORWARDED_FOR'],$parsoidServers) )
-) {
+// if X-Forwarded-For HTTP header exists
+if ( isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
 
-	// xff = X-Forwarded-For HTTP header (see above)
-	// If no xff and remote address is "localhost" or "127.0.0.1"
-	// If yes xff and xff in [list,of,parsoid,servers]
+	$parsoidServers = array(
+		{% for parsoid in groups['parsoid-servers'] %}
+		'{{ parsoid }}',
+		{% endfor %}
+	);
+
+	// if request originated at a Parsoid server
+	if ( in_array( $_SERVER['HTTP_X_FORWARDED_FOR'], $parsoidServers ) ) {
+		$grantParsoidReadWrite = true;
+	}
+
+}
+
+// no X-Forwarded-For HTTP Header
+else if ( isset( $_SERVER['REMOTE_ADDR'] ) ) {
+
+	// if remote address is this server
+	if ( $_SERVER['REMOTE_ADDR'] === 'localhost' || $_SERVER['REMOTE_ADDR'] === '127.0.0.1' ) {
+		$grantParsoidReadWrite = true;
+	}
+
+}
+
+// if the logic above resulted in granting access
+if ( $grantParsoidReadWrite ) {
 	$wgGroupPermissions['*']['read'] = true;
 	$wgGroupPermissions['*']['edit'] = true;
-
 }
 
 // Enable by default for everybody


### PR DESCRIPTION
Parsoid permissions (MW granting read/write to Parsoid) were not configured to work if Parsoid wasn't on the same server as MW _and_ MW wasn't wide open permissions (e.g. allow anon read). Fixed it.