### PR TITLE
Remove 'meza deploy' from 'vagrant up' command; do it after 'vagrant up'

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -254,14 +254,14 @@ EOL
         # ssh 192.168.56.57 "sudo sed -r -i 's/UsePAM yes/UsePAM no/g;' /etc/ssh/sshd_config && sudo systemctl restart sshd"
       SHELL
 
-    else
+      # else
 
       #
       # Finally: Deploy if not multi-server
       #
-      app1.vm.provision "deploy", type: "shell", preserve_order: true, inline: <<-SHELL
-        meza deploy vagrant
-      SHELL
+      # app1.vm.provision "deploy", type: "shell", preserve_order: true, inline: <<-SHELL
+      #   meza deploy vagrant
+      # SHELL
     end
 
   end


### PR DESCRIPTION
This change will make it so `vagrant up` does a little bit _less_: It will no longer actually run the `deploy` command for you. You'll need to SSH into the VM (`vagrant ssh`) then run `sudo meza deploy vagrant` manually. The reason for this is (1) you have to do it this way anyway for multi-VM situations due to limitations of Vagrant and (2) auto-deploying prevents you from doing anything pre-deploy. This limits dev capabilities. Additionally, (3) if anything goes wrong with `deploy`, then it's harder to explain to new users how to run `deploy` again (versus just "up arrow, hit enter, to run again").

So, the full install process is now:

1. install git, vagrant, virtualbox
2. `git clone https://github.com/enterprisemediawiki/meza`
3. `cd meza`
4. Optional: `cp vagrantconf.default.yml vagrantconf.yml` and edit as desired
5. `vagrant up` and wait a few minutes
6. `vagrant ssh`
7. `sudo meza deploy vagrant`