### PR TITLE
Change of httpd ServerName specification broke SAML; fixit

### DIFF
--- a/src/roles/apache-php/templates/httpd.conf.j2
+++ b/src/roles/apache-php/templates/httpd.conf.j2
@@ -411,7 +411,9 @@ Listen 8080
 	</Directory>
 
 	DocumentRoot {{ m_htdocs }}
-	ServerName https://{{ wiki_app_fqdn }}
+	# WAS: ServerName https://{{ wiki_app_fqdn }}
+	#      This server name causes issues with SAML setups, ref #794
+	ServerName MezaMainEntrypoint
 
 	{% if saml_secret is defined -%}
 	# Use SimpleSamlPhp to handle authentication


### PR DESCRIPTION
Breaking change in 14154d26908739bb3eda03525d091c56a5cad139 (merged in #785). Set `ServerName` to non-problematic value.