### PR TITLE
Better handling of SQL backup files

### DIFF
--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -125,3 +125,8 @@ m_cache_directory_group: apache
 m_logs_mode: "0755"
 m_logs_owner: meza-ansible
 m_logs_group: wheel
+
+
+m_backups_mode: "0755"
+m_backups_owner: root
+m_backups_group: root

--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -100,6 +100,8 @@ mysql_slow_query_log_file: /var/log/mariadb/slow-queries.log
 load_balancer_unmanaged_parsoid_port: 8000
 load_balancer_unmanaged_mediawiki_port: 8080
 
+# If false, keep all SQL files on backup servers. If true, only keep the latest
+do_cleanup_sql_backup: False
 
 #
 # FILE MODES, OWNERS, GROUPS

--- a/src/roles/backup-db-wikis/tasks/main.yml
+++ b/src/roles/backup-db-wikis/tasks/main.yml
@@ -12,17 +12,17 @@
   file:
     path: "{{ m_backups }}/{{ env }}"
     state: directory
-    mode: 0755
-    owner: root
-    group: root
+    mode: "{{ m_backups_mode }}"
+    owner: "{{ m_backups_owner }}"
+    group: "{{ m_backups_group }}"
 
 - name: Ensure backups directory exists for each wiki
   file:
     path: "{{ m_backups }}/{{ env }}/{{ item }}"
     state: directory
-    mode: 0755
-    owner: root
-    group: root
+    mode: "{{ m_backups_mode }}"
+    owner: "{{ m_backups_owner }}"
+    group: "{{ m_backups_group }}"
   with_items: "{{ wiki_dirs.files | map(attribute='path') | map('basename') | list }}"
 
 # copy from server A (db-master) to server B (backups)

--- a/src/roles/backup-db-wikis/tasks/main.yml
+++ b/src/roles/backup-db-wikis/tasks/main.yml
@@ -44,3 +44,14 @@
   delegate_to: "{{ groups['db-master'][0] }}"
   with_items: "{{ wiki_dirs.files | map(attribute='path') | map('basename') | list }}"
   run_once: true
+
+- name: "Clean out all but the latest SQL backup file for {{ item }} IF DESIRED"
+  include_role:
+    name: sql-backup-cleanup
+  vars:
+    cleanup_wiki: "{{ item }}"
+  run_once: true
+  tags:
+    - sql-backup-cleanup
+  with_items: "{{ wiki_dirs.files | map(attribute='path') | map('basename') | list }}"
+  when: do_cleanup_sql_backup

--- a/src/roles/database/tasks/secure-installation.yml
+++ b/src/roles/database/tasks/secure-installation.yml
@@ -57,18 +57,23 @@
 - name: Copy .my.cnf file with root password credentials
   template:
     src: "root-my.cnf.j2"
-    dest: "{{ item.home }}/.my.cnf"
-    owner: "{{ item.owner }}"
-    group: "{{ item.group }}"
-    mode: 0600
-  when: mysql_install_packages | bool or mysql_root_password_update
-  with_items:
-  - home: "{{ mysql_root_home }}"
+    dest: "{{ mysql_root_home }}/.my.cnf"
     owner: root
     group: root
-  - home: "{{ m_home }}/meza-ansible"
+    mode: 0600
+  when: mysql_install_packages | bool or mysql_root_password_update
+
+# Also make sure meza-ansible has mysql root's .my.cnf. This allows `mysql` and
+# `mysqldump` to be called using Ansible's `shell` command rather than the
+# Ansible mysql commands. Doing `shell: mysqldump my_db > /some/path/.sql` as
+# user meza-ansible needs a .my.cnf in place
+- name: Copy .my.cnf file with root password credentials
+  template:
+    src: "root-my.cnf.j2"
+    dest: "{{ m_home }}/meza-ansible/.my.cnf"
     owner: meza-ansible
     group: wheel
+    mode: 0600
 
 - name: Get list of hosts for the anonymous user.
   command: mysql -NBe 'SELECT Host FROM mysql.user WHERE User = ""'

--- a/src/roles/database/tasks/secure-installation.yml
+++ b/src/roles/database/tasks/secure-installation.yml
@@ -54,14 +54,21 @@
   when: ((mysql_install_packages | bool) or mysql_root_password_update) and ('5.7.' not in mysql_cli_version.stdout)
 
 # Has to be after the root password assignment, for idempotency.
-- name: Copy .my.cnf file with root password credentials.
+- name: Copy .my.cnf file with root password credentials
   template:
     src: "root-my.cnf.j2"
-    dest: "{{ mysql_root_home }}/.my.cnf"
-    owner: root
-    group: root
+    dest: "{{ item.home }}/.my.cnf"
+    owner: "{{ item.owner }}"
+    group: "{{ item.group }}"
     mode: 0600
   when: mysql_install_packages | bool or mysql_root_password_update
+  with_items:
+  - home: "{{ mysql_root_home }}"
+    owner: root
+    group: root
+  - home: "{{ m_home }}/meza-ansible"
+    owner: meza-ansible
+    group: wheel
 
 - name: Get list of hosts for the anonymous user.
   command: mysql -NBe 'SELECT Host FROM mysql.user WHERE User = ""'

--- a/src/roles/remote-mysqldump/tasks/main.yml
+++ b/src/roles/remote-mysqldump/tasks/main.yml
@@ -48,22 +48,51 @@
   when: remote_server_mysql_pass is not defined
 
 #
-# DO mysqldump
+# SET remote_server_ssh_user to 'meza-ansible' if not defined
+#
+- name: Set remote_server_ssh_user to 'meza-ansible' if not defined
+  set_fact:
+    remote_server_ssh_user: "meza-ansible"
+  when: remote_server_ssh_user is not defined
+
+
+#
+# If remote_server != target_server, use SSH to run mysqldump. Else, doit locally
 #
 # FIXME: Remove StrictHostKeyChecking=no when tests properly add host keys (users should do so, too, of course)
+- name: remote_server ({{ remote_server }}) != target_server ({{ target_server }}); run mysqldump over SSH
+  set_fact:
+    mysqldump_command: >
+      ssh
+      -o StrictHostKeyChecking=no
+      -i /root/meza-ansible-id_rsa
+      -o UserKnownHostsFile=/root/meza-ansible-known_hosts
+      {{ remote_server_ssh_user }}@{{ remote_server }}
+      "mysqldump
+      {{ user_option }}
+      {{ password_option }}
+      {{ dump_database }}
+      | gzip -c"
+      | gunzip > {{ target_server_path }}
+  when: remote_server != target_server
+- name: remote_server == target_server ({{ target_server }}); run mysqldump locally
+  set_fact:
+    mysqldump_command: >
+      mysqldump
+      {{ user_option }}
+      {{ password_option }}
+      {{ dump_database }}
+      > {{ target_server_path }}
+  when: remote_server == target_server
+
+- debug: { msg: "{{ mysqldump_command }}" }
+
+#
+# DO mysqldump
+#
 - name: "Perform MySQL dump from {{ remote_server }} to {{ target_server }}"
-  shell: >
-    ssh
-    -o StrictHostKeyChecking=no
-    -i /root/meza-ansible-id_rsa
-    -o UserKnownHostsFile=/root/meza-ansible-known_hosts
-    {{ remote_server_ssh_user }}@{{ remote_server }}
-    "mysqldump
-    {{ user_option }}
-    {{ password_option }}
-    {{ dump_database }}
-    | gzip -c"
-    | gunzip > {{ target_server_path }}
+  shell: "{{ mysqldump_command }}"
+  delegate_to: "{{ target_server }}"
 
 - name: "Revoke keys from {{ target_server }}"
   include_role:

--- a/src/roles/sql-backup-cleanup/tasks/main.yml
+++ b/src/roles/sql-backup-cleanup/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+# vars:
+#   cleanup_wiki: "<some wiki id>"
+
+- name: "SQL backup files for {{ cleanup_wiki }} _PRIOR TO_ cleanup"
+  shell: "ls {{ m_backups }}/{{ env }}/{{ cleanup_wiki }} -al"
+  register: ls_sql_backup
+  delegate_to: "{{ groups['backup-servers'][0] }}"
+
+- debug: { var: ls_sql_backup }
+
+- name: "Clean out all but the latest SQL backup file for {{ cleanup_wiki }} IF DESIRED"
+  shell: |
+    path_to_files="{{ m_backups }}/{{ env }}/{{ cleanup_wiki }}"
+    latest_file_path=$(find $path_to_files -maxdepth 1 -type f -iname "*.sql" | sort -r | head -n +1)
+    latest_file=$(basename $latest_file_path)
+    find $path_to_files -type f ! -name "$latest_file" -delete
+  delegate_to: "{{ groups['backup-servers'][0] }}"
+
+- name: "SQL backup files for {{ cleanup_wiki }} _AFTER_ cleanup"
+  shell: "ls {{ m_backups }}/{{ env }}/{{ cleanup_wiki }} -al"
+  register: ls_sql_backup
+  delegate_to: "{{ groups['backup-servers'][0] }}"
+
+- debug: { var: ls_sql_backup }

--- a/src/roles/update.php/tasks/main.yml
+++ b/src/roles/update.php/tasks/main.yml
@@ -6,13 +6,14 @@
   set_fact:
     backup_timestamp: "{{lookup('pipe','date +%Y%m%d%H%M%S')}}"
 
-- name: Ensure backups directory exists for each wiki
+- name: Ensure backups directory exists for wiki
   file:
     path: "{{ m_backups }}/{{ env }}/{{ wiki_id }}"
     state: directory
     mode: "{{ m_backups_mode }}"
     owner: "{{ m_backups_owner }}"
     group: "{{ m_backups_group }}"
+  delegate_to: "{{ groups['backup-servers'][0] }}"
 
 #
 # DUMP SQL from DB Master to backup-servers[0]

--- a/src/roles/update.php/tasks/main.yml
+++ b/src/roles/update.php/tasks/main.yml
@@ -2,21 +2,40 @@
 
 - debug: { msg: "Running role:update.php for {{ wiki_id }}" }
 
-# FIXME: This shouldn't go to {{ m_tmp }}. Also it should be pushed to a backup server
-#        and maybe we should use incremental backups (patches) to limit size.
-- name: Backup wiki database prior to running update.php
-  mysql_db:
-    state: dump
-    name: "wiki_{{ wiki_id }}"
-    target: "{{ m_tmp }}/backup_{{ wiki_id }}_{{ ansible_date_time.iso8601 }}.sql"
-  delegate_to: "{{ groups['db-master'][0] }}"
+- name: Set backup timestamp fact
+  set_fact:
+    backup_timestamp: "{{lookup('pipe','date +%Y%m%d%H%M%S')}}"
 
-  # [1] This role should be included in such a way that it is run just once,
-  #     but just in case we'll add it here, too. Apply to all tasks
+
+#
+# DUMP SQL from DB Master to backup-servers[0]
+#
+- name: "Backup wiki database prior to running update.php"
+  include_role:
+    name: remote-mysqldump
+  vars:
+    remote_server:            "{{ groups['db-master'][0] }}"
+
+    # FIXME: these shouldn't be required
+    # remote_server_ssh_user:   "{{ db_backup_server_remote_user }}"
+    # remote_server_mysql_user: "{{  }}"
+    # remote_server_mysql_pass: "{{  }}"
+    dump_database:            "wiki_{{ wiki_id }}"
+    target_server:            "{{ groups['backup-servers'][0] }}"
+
+    # FIXME: this string below is copied from role:backup-db-wikis. It should
+    #        be standardized somehow to avoid mistakes.
+    target_server_path:       "{{ m_backups }}/{{ env }}/{{ item }}/{{ backup_timestamp }}_wiki.sql"
   run_once: true
+  tags:
+    - update.php
+    - update.php-backup
+
 
 - name: Run update.php on this wiki
   shell: >
     WIKI="{{ wiki_id }}" php "{{ m_mediawiki }}/maintenance/update.php" --quick
   # run_once see [1]
   run_once: true
+  tags:
+    - update.php

--- a/src/roles/update.php/tasks/main.yml
+++ b/src/roles/update.php/tasks/main.yml
@@ -39,6 +39,16 @@
     - update.php
     - update.php-backup
 
+- name: "Clean out all but the latest SQL backup file for {{ wiki_id }} IF DESIRED"
+  include_role:
+    name: sql-backup-cleanup
+  vars:
+    cleanup_wiki: "{{ wiki_id }}"
+  run_once: true
+  tags:
+    - update.php
+    - sql-backup-cleanup
+  when: do_cleanup_sql_backup
 
 - name: Run update.php on this wiki
   shell: >

--- a/src/roles/update.php/tasks/main.yml
+++ b/src/roles/update.php/tasks/main.yml
@@ -6,6 +6,13 @@
   set_fact:
     backup_timestamp: "{{lookup('pipe','date +%Y%m%d%H%M%S')}}"
 
+- name: Ensure backups directory exists for each wiki
+  file:
+    path: "{{ m_backups }}/{{ env }}/{{ wiki_id }}"
+    state: directory
+    mode: "{{ m_backups_mode }}"
+    owner: "{{ m_backups_owner }}"
+    group: "{{ m_backups_group }}"
 
 #
 # DUMP SQL from DB Master to backup-servers[0]
@@ -25,7 +32,7 @@
 
     # FIXME: this string below is copied from role:backup-db-wikis. It should
     #        be standardized somehow to avoid mistakes.
-    target_server_path:       "{{ m_backups }}/{{ env }}/{{ item }}/{{ backup_timestamp }}_wiki.sql"
+    target_server_path:       "{{ m_backups }}/{{ env }}/{{ wiki_id }}/{{ backup_timestamp }}_wiki.sql"
   run_once: true
   tags:
     - update.php

--- a/tests/docker/backup-to-remote.setup.sh
+++ b/tests/docker/backup-to-remote.setup.sh
@@ -38,6 +38,16 @@ ${docker_exec_1[@]} default_servers="$docker_ip_1" backup_servers="$docker_ip_2"
 	--fqdn="$docker_ip_1" --db_pass=1234 --private_net_zone=public
 
 
+# secret.yml is encrypted. decrypt first, make edits, re-encrypt.
+secret_yml="/opt/conf-meza/secret/$env_name/secret.yml"
+vault_pass="/opt/conf-meza/users/meza-ansible/.vault-pass-$env_name.txt"
+${docker_exec_1[@]} bash -c "ansible-vault decrypt $secret_yml --vault-password-file $vault_pass"
+${docker_exec_1[@]} bash -c "echo -e '\n' >> $secret_yml"
+${docker_exec_1[@]} bash -c "echo 'mysql_root_password_update: yes' >> $secret_yml"
+${docker_exec_1[@]} bash -c "echo -e '\n' >> $secret_yml"
+${docker_exec_1[@]} bash -c "ansible-vault encrypt $secret_yml --vault-password-file $vault_pass"
+
+
 # Run script on controller to `meza deploy`, `meza create wiki` and
 # `meza backup`
 ${docker_exec_1[@]} bash /opt/meza/tests/deploys/backup-to-remote.controller.sh "$env_name"

--- a/tests/docker/backup-to-remote.setup.sh
+++ b/tests/docker/backup-to-remote.setup.sh
@@ -39,13 +39,13 @@ ${docker_exec_1[@]} default_servers="$docker_ip_1" backup_servers="$docker_ip_2"
 
 
 # secret.yml is encrypted. decrypt first, make edits, re-encrypt.
-secret_yml="/opt/conf-meza/secret/$env_name/secret.yml"
-vault_pass="/opt/conf-meza/users/meza-ansible/.vault-pass-$env_name.txt"
-${docker_exec_1[@]} bash -c "ansible-vault decrypt $secret_yml --vault-password-file $vault_pass"
-${docker_exec_1[@]} bash -c "echo -e '\n' >> $secret_yml"
-${docker_exec_1[@]} bash -c "echo 'mysql_root_password_update: yes' >> $secret_yml"
-${docker_exec_1[@]} bash -c "echo -e '\n' >> $secret_yml"
-${docker_exec_1[@]} bash -c "ansible-vault encrypt $secret_yml --vault-password-file $vault_pass"
+# secret_yml="/opt/conf-meza/secret/$env_name/secret.yml"
+# vault_pass="/opt/conf-meza/users/meza-ansible/.vault-pass-$env_name.txt"
+# ${docker_exec_1[@]} bash -c "ansible-vault decrypt $secret_yml --vault-password-file $vault_pass"
+# ${docker_exec_1[@]} bash -c "echo -e '\n' >> $secret_yml"
+# ${docker_exec_1[@]} bash -c "echo 'mysql_root_password_update: yes' >> $secret_yml"
+# ${docker_exec_1[@]} bash -c "echo -e '\n' >> $secret_yml"
+# ${docker_exec_1[@]} bash -c "ansible-vault encrypt $secret_yml --vault-password-file $vault_pass"
 
 
 # Run script on controller to `meza deploy`, `meza create wiki` and

--- a/tests/docker/backup-to-remote.setup.sh
+++ b/tests/docker/backup-to-remote.setup.sh
@@ -33,7 +33,7 @@ docker_exec_2=( "${docker_exec[@]}" )
 
 # Create a new environment called "travis" with everything on CONTAINER 1, but
 # backups on CONTAINER 2
-${docker_exec_1[@]} default_servers="localhost" backup_servers="$docker_ip_2" \
+${docker_exec_1[@]} default_servers="$docker_ip_1" backup_servers="$docker_ip_2" \
 	meza setup env "$env_name" \
 	--fqdn="$docker_ip_1" --db_pass=1234 --private_net_zone=public
 


### PR DESCRIPTION
Closes #772

* Better tagging. Tags `update.php` and `update.php-backup`
* Don't put `update.php` backups in `m_tmp`. Send them directly from DB-master to backups server using role `remote-mysqldump`
* Provide option `do_cleanup_sql_backup` that will always keep only the latest SQL backup file. All older files will be deleted.