### PR TITLE
Configuration for SSH to limit to safe ciphers and algorithms

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -213,6 +213,9 @@ cat >/opt/conf-meza/public/public.yml <<EOL
 blender_landing_page_title: Meza Wikis
 m_setup_php_profiling: true
 m_force_debug: true
+
+sshd_config_UsePAM: "no"
+sshd_config_PasswordAuthentication: "yes"
 EOL
       fi
 

--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -103,6 +103,10 @@ load_balancer_unmanaged_mediawiki_port: 8080
 # If false, keep all SQL files on backup servers. If true, only keep the latest
 do_cleanup_sql_backup: False
 
+# sshd_config defaults
+sshd_config_UsePAM: "yes"
+sshd_config_PasswordAuthentication: "no"
+
 #
 # FILE MODES, OWNERS, GROUPS
 #

--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -105,7 +105,7 @@ do_cleanup_sql_backup: False
 
 # sshd_config defaults
 sshd_config_UsePAM: "yes"
-sshd_config_PasswordAuthentication: "no"
+sshd_config_PasswordAuthentication: "yes"
 
 #
 # FILE MODES, OWNERS, GROUPS

--- a/src/playbooks/site.yml
+++ b/src/playbooks/site.yml
@@ -70,6 +70,12 @@
       group: wheel
       mode: "0600"
 
+# FIXME: why is controller init on all app servers?
+- hosts: app-servers
+  become: yes
+  roles:
+    - set-vars
+    - init-controller-config
 
 # Ensure proper base setup on all servers in inventory, with the exception of
 # servers in "exclude-all" group. At present, the intent of this group is to
@@ -82,13 +88,6 @@
     - base
     # FIXME: add "security" module here
   tags: base
-
-# FIXME: why is controller init on all app servers?
-- hosts: app-servers
-  become: yes
-  roles:
-    - set-vars
-    - init-controller-config
 
 - hosts: load-balancers
   become: yes

--- a/src/roles/base/handlers/main.yml
+++ b/src/roles/base/handlers/main.yml
@@ -2,3 +2,7 @@
 - name: restart ntpd
   service: name=ntpd state=restarted
   when: docker_skip_tasks is not defined or not docker_skip_tasks
+
+- name: restart sshd
+  service: name=sshd state=restarted
+  when: docker_skip_tasks is not defined or not docker_skip_tasks

--- a/src/roles/base/tasks/main.yml
+++ b/src/roles/base/tasks/main.yml
@@ -131,6 +131,36 @@
 #   with_dict: "{{firewalld_zone_interface|default({})}}"
 #   notify: restart firewalld
 
+
+#
+# SSH config
+#
+- name: Ensure sshd is running and enabled
+  service:
+    name: sshd
+    state: started
+    enabled: yes
+  when: docker_skip_tasks is not defined or not docker_skip_tasks
+
+- name: Ensure SSH client and SSH Daemon configs in place
+  template:
+    src: "ssh_config.j2"
+    dest: "/etc/ssh/ssh_config"
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Ensure SSH client and SSH Daemon configs in place
+  template:
+    src: "sshd_config.j2"
+    dest: "/etc/ssh/sshd_config"
+    owner: root
+    group: root
+    mode: "0600"
+  notify:
+    - restart sshd
+
+
 # Replace the following shell commands:
 # chkconfig ntpd on # Activate service
 # ntpdate pool.ntp.org # Synchronize the system clock with 0.pool.ntp.org server

--- a/src/roles/base/templates/ssh_config.j2
+++ b/src/roles/base/templates/ssh_config.j2
@@ -1,0 +1,18 @@
+# From default CentOS 7 ssh(d)_config
+Host *
+        GSSAPIAuthentication yes
+# If this option is set to yes then remote X11 clients will have full access
+# to the original X11 display. As virtually no X11 client supports the untrusted
+# mode correctly we set this to yes.
+        ForwardX11Trusted yes
+# Send locale-related environment variables
+        SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
+        SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
+        SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE
+        SendEnv XMODIFIERS
+
+# Ciphers allowed in order of preference
+Ciphers aes256-ctr,aes192-ctr,aes128-ctr,aes256-cbc,aes192-cbc,aes128-cbc
+
+# MAC algorithms in order of preference
+MACs hmac-sha2-256,hmac-sha2-512,hmac-sha1

--- a/src/roles/base/templates/sshd_config.j2
+++ b/src/roles/base/templates/sshd_config.j2
@@ -1,0 +1,161 @@
+#       $OpenBSD: sshd_config,v 1.93 2014/01/10 05:59:19 djm Exp $
+
+# This is the sshd server system-wide configuration file.  See
+# sshd_config(5) for more information.
+
+# This sshd was compiled with PATH=/usr/local/bin:/usr/bin
+
+# The strategy used for options in the default sshd_config shipped with
+# OpenSSH is to specify options with their default value where
+# possible, but leave them commented.  Uncommented options override the
+# default value.
+
+# If you want to change the port on a SELinux system, you have to tell
+# SELinux about this change.
+# semanage port -a -t ssh_port_t -p tcp #PORTNUMBER
+#
+#Port 22
+#AddressFamily any
+#ListenAddress 0.0.0.0
+#ListenAddress ::
+
+# The default requires explicit activation of protocol 1
+#Protocol 2
+
+# HostKey for protocol version 1
+#HostKey /etc/ssh/ssh_host_key
+# HostKeys for protocol version 2
+HostKey /etc/ssh/ssh_host_rsa_key
+#HostKey /etc/ssh/ssh_host_dsa_key
+HostKey /etc/ssh/ssh_host_ecdsa_key
+HostKey /etc/ssh/ssh_host_ed25519_key
+
+# Lifetime and size of ephemeral version 1 server key
+#KeyRegenerationInterval 1h
+#ServerKeyBits 1024
+
+# Ciphers and keying
+#RekeyLimit default none
+
+# Logging
+# obsoletes QuietMode and FascistLogging
+#SyslogFacility AUTH
+SyslogFacility AUTHPRIV
+#LogLevel INFO
+
+# Authentication:
+
+#LoginGraceTime 2m
+#PermitRootLogin yes
+#StrictModes yes
+#MaxAuthTries 6
+#MaxSessions 10
+
+#RSAAuthentication yes
+#PubkeyAuthentication yes
+
+# The default is to check both .ssh/authorized_keys and .ssh/authorized_keys2
+# but this is overridden so installations will only check .ssh/authorized_keys
+AuthorizedKeysFile      .ssh/authorized_keys
+
+#AuthorizedPrincipalsFile none
+
+#AuthorizedKeysCommand none
+#AuthorizedKeysCommandUser nobody
+
+# For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
+#RhostsRSAAuthentication no
+# similar for protocol version 2
+#HostbasedAuthentication no
+# Change to yes if you don't trust ~/.ssh/known_hosts for
+# RhostsRSAAuthentication and HostbasedAuthentication
+#IgnoreUserKnownHosts no
+# Don't read the user's ~/.rhosts and ~/.shosts files
+#IgnoreRhosts yes
+
+# To disable tunneled clear text passwords, change to no here!
+#PasswordAuthentication yes
+#PermitEmptyPasswords no
+PasswordAuthentication {{ sshd_config_PasswordAuthentication }}
+
+# Change to no to disable s/key passwords
+#ChallengeResponseAuthentication yes
+ChallengeResponseAuthentication no
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+#KerberosGetAFSToken no
+#KerberosUseKuserok yes
+
+# GSSAPI options
+GSSAPIAuthentication no
+GSSAPICleanupCredentials no
+#GSSAPIStrictAcceptorCheck yes
+#GSSAPIKeyExchange no
+#GSSAPIEnablek5users no
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the ChallengeResponseAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via ChallengeResponseAuthentication may bypass
+# the setting of "PermitRootLogin without-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and ChallengeResponseAuthentication to 'no'.
+# WARNING: 'UsePAM no' is not supported in Red Hat Enterprise Linux and may cause several
+# problems.
+UsePAM {{ sshd_config_UsePAM }}
+
+#AllowAgentForwarding yes
+#AllowTcpForwarding yes
+#GatewayPorts no
+X11Forwarding yes
+#X11DisplayOffset 10
+#X11UseLocalhost yes
+#PermitTTY yes
+#PrintMotd yes
+#PrintLastLog yes
+#TCPKeepAlive yes
+#UseLogin no
+UsePrivilegeSeparation sandbox          # Default for new installations.
+#PermitUserEnvironment no
+#Compression delayed
+#ClientAliveInterval 0
+#ClientAliveCountMax 3
+#ShowPatchLevel no
+#UseDNS yes
+#PidFile /var/run/sshd.pid
+#MaxStartups 10:30:100
+#PermitTunnel no
+#ChrootDirectory none
+#VersionAddendum none
+
+# no default banner path
+#Banner none
+
+# Accept locale-related environment variables
+AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
+AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
+AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE
+AcceptEnv XMODIFIERS
+
+# override default of no subsystems
+Subsystem       sftp    /usr/libexec/openssh/sftp-server
+
+# Example of overriding settings on a per-user basis
+#Match User anoncvs
+#       X11Forwarding no
+#       AllowTcpForwarding no
+#       PermitTTY no
+#       ForceCommand cvs server
+UseDNS no
+
+
+# Ciphers allowed in order of preference
+Ciphers aes256-ctr,aes192-ctr,aes128-ctr,aes256-cbc,aes192-cbc,aes128-cbc
+
+# MAC algorithms in order of preference
+MACs hmac-sha2-256,hmac-sha2-512,hmac-sha1

--- a/tests/docker/backup-to-remote.setup.sh
+++ b/tests/docker/backup-to-remote.setup.sh
@@ -39,6 +39,7 @@ ${docker_exec_1[@]} default_servers="$docker_ip_1" backup_servers="$docker_ip_2"
 
 
 public_yml="/opt/conf-meza/public/public.yml"
+${docker_exec_1[@]} bash -c "mkdir -p /opt/conf-meza/public"
 ${docker_exec_1[@]} bash -c "echo -e '---\n' > $public_yml"
 ${docker_exec_1[@]} bash -c "echo -e 'sshd_config_UsePAM: \"no\"\n' >> $public_yml"
 ${docker_exec_1[@]} bash -c "echo -e 'sshd_config_PasswordAuthentication: \"yes\"\n' >> $public_yml"

--- a/tests/docker/backup-to-remote.setup.sh
+++ b/tests/docker/backup-to-remote.setup.sh
@@ -38,6 +38,12 @@ ${docker_exec_1[@]} default_servers="$docker_ip_1" backup_servers="$docker_ip_2"
 	--fqdn="$docker_ip_1" --db_pass=1234 --private_net_zone=public
 
 
+public_yml="/opt/conf-meza/public/public.yml"
+${docker_exec_1[@]} bash -c "echo -e '---\n' > $public_yml"
+${docker_exec_1[@]} bash -c "echo -e 'sshd_config_UsePAM: \"no\"\n' >> $public_yml"
+${docker_exec_1[@]} bash -c "echo -e 'sshd_config_PasswordAuthentication: \"yes\"\n' >> $public_yml"
+
+
 # secret.yml is encrypted. decrypt first, make edits, re-encrypt.
 # secret_yml="/opt/conf-meza/secret/$env_name/secret.yml"
 # vault_pass="/opt/conf-meza/users/meza-ansible/.vault-pass-$env_name.txt"


### PR DESCRIPTION
Reapply SSH safe ciphers and algorithms as were originally applied in #392 but were lost when switching to Ansible.

* Add `ssh_config.j2` and `sshd_config.j2` templates
* Add defaults for `sshd_config_UsePAM: "yes"` and `sshd_config_PasswordAuthentication: "yes"` for good secure config, but allow override for testing. Several tests and Vagrantfile require updating these defaults for now.
* Changed order of when `role:init-controller-config` is run so it happens before `role:base`, such that config vars are picked up if `init-controller-config` causes any changes. In particular, if secret config has a public config repo set, need to run `init-controller-config` to pull that public config repo.


Closes #703