### PR TITLE
Add setting to disable MariaDB performance_schema 

### DIFF
--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -95,6 +95,13 @@ mysql_slow_query_log_enabled: yes
 mysql_slow_query_time: "5"
 mysql_slow_query_log_file: /var/log/mariadb/slow-queries.log
 
+# Default to using the performance schema
+# But allow it to be turned OFF easily in low mem environments
+# or for high performance environments like prod
+# http://dev.mysql.com/doc/refman/5.5/en/performance-schema.html
+# https://mariadb.com/kb/en/mariadb/performance-schema-overview/
+mysql_performance_schema: "on"
+
 # If using a load balancer not managed by meza, on what port should you
 # access Parsoid and MediaWiki internal services?
 load_balancer_unmanaged_parsoid_port: 8000

--- a/src/roles/database/templates/my.cnf.j2
+++ b/src/roles/database/templates/my.cnf.j2
@@ -68,6 +68,8 @@ symbolic-links = 0
 user = mysql
 
 # http://dev.mysql.com/doc/refman/5.5/en/performance-schema.html
+# Turn off the performance schema on low mem (1GB) VPS in monolith env. so mem available for parsoid
+# performance_schema = off
 ;performance_schema
 
 # Memory settings.

--- a/src/roles/database/templates/my.cnf.j2
+++ b/src/roles/database/templates/my.cnf.j2
@@ -67,10 +67,7 @@ symbolic-links = 0
 # User is ignored when systemd is used (fedora >= 15).
 user = mysql
 
-# http://dev.mysql.com/doc/refman/5.5/en/performance-schema.html
-# Turn off the performance schema on low mem (1GB) VPS in monolith env. so mem available for parsoid
-# performance_schema = off
-;performance_schema
+performance_schema = {{ mysql_performance_schema }}
 
 # Memory settings.
 key_buffer_size = {{ mysql_key_buffer_size }}


### PR DESCRIPTION
I don't know if it's worth coding this 'feature', so I thought to add a line of comment into the template. Monolith environments with only 1 GB of memory can fail because MySQL takes up a lot of it before Parsoid gets installed.  If the performance schema is disabled, it shouldn't affect an intentionally low power "demo" or "development" environment, but will allow Meza deploy to complete.  Feel free to decline and tell me that this should be an 'issue' instead.

