### PR TITLE
Add option to process shared database tables. Fixes issue #845

### DIFF
--- a/src/roles/update.php/tasks/main.yml
+++ b/src/roles/update.php/tasks/main.yml
@@ -44,7 +44,7 @@
 
 - name: Run update.php on this wiki
   shell: >
-    WIKI="{{ wiki_id }}" php "{{ m_mediawiki }}/maintenance/update.php" --quick
+    WIKI="{{ wiki_id }}" php "{{ m_mediawiki }}/maintenance/update.php" --quick --doshared
   # run_once see [1]
   run_once: true
   tags:


### PR DESCRIPTION
Fixes issue #845

Since meza already sets up $wgSharedTables in LocalSettings.php, this option should be added.  Without it, meza will not perform schema changes on shared database tables.

For documentation purposes, there could perhaps be some added commentary about the compatibility of migrating a complex wikifarm into meza, where there would likely not be a 100% match of what's shared by default in meza and what's shared in the custom environment.  But in those cases a migration will be complex in the first place, and they would necessarily have to understand the workings of the meza shared database configuration anyway.
