### PR TITLE
Need to always run set-vars when rebuilding data

### DIFF
--- a/src/playbooks/rebuild-smw-and-index.yml
+++ b/src/playbooks/rebuild-smw-and-index.yml
@@ -2,10 +2,13 @@
 
 - hosts: app-servers
   become: yes
-  roles:
-    - set-vars
-
   tasks:
+
+  - name: Set vars
+    include_role:
+      name: set-vars
+    tags:
+    - always
 
   - name: (Re-)build search index for each wiki
     shell: "bash {{ m_deploy }}/elastic-rebuild-all.sh"
@@ -18,3 +21,4 @@
     run_once: true
     tags:
     - smw-data
+


### PR DESCRIPTION
Without this, if specifying a particular tag it would skip `set-vars`.