### PR TITLE
RHEL/CentOS 7.4 EPEL change, Node.js fix

### DIFF
--- a/src/roles/nodejs/tasks/main.yml
+++ b/src/roles/nodejs/tasks/main.yml
@@ -9,8 +9,7 @@
 # repository, which caused it to be removed from the EPEL repository. When
 # CentOS 7.4 comes out it will have http-parser in its base repo. To maintain
 # functionality for all machines running RHEL/CentOS 7.0-7.3 we need to
-# manually install http-parser. If using 7.4+, make sure this manually-added
-# RPM isn't installed
+# manually install http-parser.
 #
 # Refs:
 #   https://bugs.centos.org/view.php?id=13669&nbn=8
@@ -21,11 +20,6 @@
     name: https://kojipkgs.fedoraproject.org//packages/http-parser/2.7.1/3.el7/x86_64/http-parser-2.7.1-3.el7.x86_64.rpm
     state: present
   when: ansible_distribution_version.split('.')[1] | int <= 3
-- name: Ensure http-parser not installed from RPM for {{ ansible_distribution_version }}
-  yum:
-    name: https://kojipkgs.fedoraproject.org//packages/http-parser/2.7.1/3.el7/x86_64/http-parser-2.7.1-3.el7.x86_64.rpm
-    state: absent
-  when: ansible_distribution_version.split('.')[1] | int > 3
 
 - name: Ensure Node.js and npm are installed.
   yum:

--- a/src/roles/nodejs/tasks/main.yml
+++ b/src/roles/nodejs/tasks/main.yml
@@ -5,6 +5,28 @@
 # - include: setup-Debian.yml
 #   when: ansible_os_family == 'Debian'
 
+# Fix for RHEL upgrade from 7.3 --> 7.4 adding package http-parser to base
+# repository, which caused it to be removed from the EPEL repository. When
+# CentOS 7.4 comes out it will have http-parser in its base repo. To maintain
+# functionality for all machines running RHEL/CentOS 7.0-7.3 we need to
+# manually install http-parser. If using 7.4+, make sure this manually-added
+# RPM isn't installed
+#
+# Refs:
+#   https://bugs.centos.org/view.php?id=13669&nbn=8
+#   https://bugzilla.redhat.com/show_bug.cgi?id=1481008
+#   https://bugzilla.redhat.com/show_bug.cgi?id=1481470
+- name: Ensure http-parser installed from RPM for {{ ansible_distribution_version }}
+  yum:
+    name: https://kojipkgs.fedoraproject.org//packages/http-parser/2.7.1/3.el7/x86_64/http-parser-2.7.1-3.el7.x86_64.rpm
+    state: present
+  when: ansible_distribution_version.split('.')[1] | int <= 3
+- name: Ensure http-parser not installed from RPM for {{ ansible_distribution_version }}
+  yum:
+    name: https://kojipkgs.fedoraproject.org//packages/http-parser/2.7.1/3.el7/x86_64/http-parser-2.7.1-3.el7.x86_64.rpm
+    state: absent
+  when: ansible_distribution_version.split('.')[1] | int > 3
+
 - name: Ensure Node.js and npm are installed.
   yum:
     name: "{{ item }}"

--- a/src/roles/nodejs/tasks/setup-RedHat.yml
+++ b/src/roles/nodejs/tasks/setup-RedHat.yml
@@ -33,5 +33,27 @@
     state: present
   when: ansible_distribution_major_version|int >= 7
 
+# Fix for RHEL upgrade from 7.3 --> 7.4 adding package http-parser to base
+# repository, which caused it to be removed from the EPEL repository. When
+# CentOS 7.4 comes out it will have http-parser in its base repo. To maintain
+# functionality for all machines running RHEL/CentOS 7.0-7.3 we need to
+# manually install http-parser. If using 7.4+, make sure this manually-added
+# RPM isn't installed
+#
+# Refs:
+#   https://bugs.centos.org/view.php?id=13669&nbn=8
+#   https://bugzilla.redhat.com/show_bug.cgi?id=1481008
+#   https://bugzilla.redhat.com/show_bug.cgi?id=1481470
+- name: Ensure http-parser installed
+  yum:
+    name: https://kojipkgs.fedoraproject.org//packages/http-parser/2.7.1/3.el7/x86_64/http-parser-2.7.1-3.el7.x86_64.rpm
+    state: present
+  when: {{ ansible_distribution_version | version_compare('7.3', '<=') }}
+- name: Ensure http-parser not installed from RPM (will use RHEL/CentOS base repo version)
+  yum:
+    name: https://kojipkgs.fedoraproject.org//packages/http-parser/2.7.1/3.el7/x86_64/http-parser-2.7.1-3.el7.x86_64.rpm
+    state: absent
+  when: {{ ansible_distribution_version | version_compare('7.3', '>') }}
+
 - name: Ensure Node.js and npm are installed.
   yum: "name=nodejs-{{ nodejs_version[0] }}.* state=present enablerepo='epel,nodesource'"

--- a/src/roles/nodejs/tasks/setup-RedHat.yml
+++ b/src/roles/nodejs/tasks/setup-RedHat.yml
@@ -37,23 +37,17 @@
 # repository, which caused it to be removed from the EPEL repository. When
 # CentOS 7.4 comes out it will have http-parser in its base repo. To maintain
 # functionality for all machines running RHEL/CentOS 7.0-7.3 we need to
-# manually install http-parser. If using 7.4+, make sure this manually-added
-# RPM isn't installed
+# manually install http-parser.
 #
 # Refs:
 #   https://bugs.centos.org/view.php?id=13669&nbn=8
 #   https://bugzilla.redhat.com/show_bug.cgi?id=1481008
 #   https://bugzilla.redhat.com/show_bug.cgi?id=1481470
-- name: Ensure http-parser installed
+- name: Ensure http-parser installed from RPM for {{ ansible_distribution_version }}
   yum:
     name: https://kojipkgs.fedoraproject.org//packages/http-parser/2.7.1/3.el7/x86_64/http-parser-2.7.1-3.el7.x86_64.rpm
     state: present
-  when: {{ ansible_distribution_version | version_compare('7.3', '<=') }}
-- name: Ensure http-parser not installed from RPM (will use RHEL/CentOS base repo version)
-  yum:
-    name: https://kojipkgs.fedoraproject.org//packages/http-parser/2.7.1/3.el7/x86_64/http-parser-2.7.1-3.el7.x86_64.rpm
-    state: absent
-  when: {{ ansible_distribution_version | version_compare('7.3', '>') }}
+  when: ansible_distribution_version.split('.')[1] | int <= 3
 
 - name: Ensure Node.js and npm are installed.
   yum: "name=nodejs-{{ nodejs_version[0] }}.* state=present enablerepo='epel,nodesource'"


### PR DESCRIPTION
RHEL upgrade from 7.3 to 7.4 added package `http-parser` to the RHEL base repository, which caused it to be removed from the EPEL repository. This means that any pre-7.4 OSes (RHEL or CentOS) using EPEL to get Node.js (and probably other things) will no longer function due to missing the `http-parser` dependency. When CentOS 7.4 comes out it will have http-parser in its base repo. To maintain functionality for all machines running RHEL/CentOS 7.0-7.3 we need to manually install http-parser.

Also note that this is done in two places: directly in the `nodejs` role's `main.yml` as well as in the `setup-RedHat.yml` file. The `setup-RedHat.yml` file is not currently in use since meza was simplified to only care about install the meza-required version of Node.js (6.x) rather than maintaining the ability to install different versions. The `setup-RedHat.yml` file could be removed, but is left for now since plans to make meza support Debian are underway.

Refs:
* https://bugs.centos.org/view.php?id=13669&nbn=8
* https://bugzilla.redhat.com/show_bug.cgi?id=1481008
* https://bugzilla.redhat.com/show_bug.cgi?id=1481470