### PR TITLE
Allow deploy vars in public.yml and new env/<env-name>.yml

### DIFF
--- a/src/roles/base/templates/config.php.j2
+++ b/src/roles/base/templates/config.php.j2
@@ -108,6 +108,15 @@ $all_backup_downloaders = array(
 {% for key, value in public_deploy_vars.iteritems() %}
 {% if value is number %}
 ${{ key }} = {{ value }};
+{% elif value is iterable %}
+	${{ key }} = [];
+	{% for subkey, subvalue in value.iteritems() %}
+		{% if value is number %}
+		${{ key }}[{{ subkey }}] = {{ subvalue }};
+		{% else %}
+		${{ key }}[{{ subkey }}] = '{{ subvalue }}';
+		{% endif %}
+	{% endfor %}
 {% else %}
 ${{ key }} = '{{ value }}';
 {% endif %}
@@ -123,6 +132,15 @@ ${{ key }} = '{{ value }}';
 {% for key, value in env_deploy_vars.iteritems() %}
 {% if value is number %}
 ${{ key }} = {{ value }};
+{% elif value is iterable %}
+	${{ key }} = [];
+	{% for subkey, subvalue in value.iteritems() %}
+		{% if value is number %}
+		${{ key }}[{{ subkey }}] = {{ subvalue }};
+		{% else %}
+		${{ key }}[{{ subkey }}] = '{{ subvalue }}';
+		{% endif %}
+	{% endfor %}
 {% else %}
 ${{ key }} = '{{ value }}';
 {% endif %}
@@ -138,6 +156,15 @@ ${{ key }} = '{{ value }}';
 {% for key, value in secret_deploy_vars.iteritems() %}
 {% if value is number %}
 ${{ key }} = {{ value }};
+{% elif value is iterable %}
+	${{ key }} = [];
+	{% for subkey, subvalue in value.iteritems() %}
+		{% if value is number %}
+		${{ key }}[{{ subkey }}] = {{ subvalue }};
+		{% else %}
+		${{ key }}[{{ subkey }}] = '{{ subvalue }}';
+		{% endif %}
+	{% endfor %}
 {% else %}
 ${{ key }} = '{{ value }}';
 {% endif %}
@@ -155,6 +182,15 @@ ${{ key }} = '{{ value }}';
 {% for key, value in deploy_vars.iteritems() %}
 {% if value is number %}
 ${{ key }} = {{ value }};
+{% elif value is iterable %}
+	${{ key }} = [];
+	{% for subkey, subvalue in value.iteritems() %}
+		{% if value is number %}
+		${{ key }}[{{ subkey }}] = {{ subvalue }};
+		{% else %}
+		${{ key }}[{{ subkey }}] = '{{ subvalue }}';
+		{% endif %}
+	{% endfor %}
 {% else %}
 ${{ key }} = '{{ value }}';
 {% endif %}

--- a/src/roles/base/templates/config.php.j2
+++ b/src/roles/base/templates/config.php.j2
@@ -94,9 +94,64 @@ $all_backup_downloaders = array(
 
 
 #
-# CUSTOM DEPLOY VARIABLES: from secret.yml
+# DEPLOY VARS included in the following order, with each superceding the previous
+#   1. public
+#   2. env-specific
+#   3. secret
+#   4. FIXME: deprecated deploy_vars, use secret_deploy_vars instead
 #
+{% if public_deploy_vars is defined and public_deploy_vars is iterable %}
+#
+# CUSTOM __public__ DEPLOY VARIABLES
+# These should only come from public.yml
+#
+{% for key, value in public_deploy_vars.iteritems() %}
+{% if value is number %}
+${{ key }} = {{ value }};
+{% else %}
+${{ key }} = '{{ value }}';
+{% endif %}
+{% endfor %}
+{% endif %}
+
+
+{% if env_deploy_vars is defined and env_deploy_vars is iterable %}
+#
+# CUSTOM __{{ env }} environment__ DEPLOY VARIABLES
+# These should only come from env/{{ env }}.yml
+#
+{% for key, value in env_deploy_vars.iteritems() %}
+{% if value is number %}
+${{ key }} = {{ value }};
+{% else %}
+${{ key }} = '{{ value }}';
+{% endif %}
+{% endfor %}
+{% endif %}
+
+
+{% if secret_deploy_vars is defined and secret_deploy_vars is iterable %}
+#
+# CUSTOM __secret__ DEPLOY VARIABLES
+# These should only come from secret.yml
+#
+{% for key, value in secret_deploy_vars.iteritems() %}
+{% if value is number %}
+${{ key }} = {{ value }};
+{% else %}
+${{ key }} = '{{ value }}';
+{% endif %}
+{% endfor %}
+{% endif %}
+
+
 {% if deploy_vars is defined and deploy_vars is iterable %}
+#
+# __DEPRECATED__ CUSTOM DEPLOY VARIABLES
+#
+# FIXME: remove deploy_vars in lieu of secret_deploy_vars when production wikis
+#        are updated.
+#
 {% for key, value in deploy_vars.iteritems() %}
 {% if value is number %}
 ${{ key }} = {{ value }};

--- a/src/roles/base/templates/config.php.j2
+++ b/src/roles/base/templates/config.php.j2
@@ -106,22 +106,48 @@ $all_backup_downloaders = array(
 # These should only come from public.yml
 #
 {% for key, value in public_deploy_vars.iteritems() %}
-{% if value is number %}
-${{ key }} = {{ value }};
-{% elif value is iterable %}
+
+{% if value is number -%}
+	${{ key }} = {{ value }};
+
+{%- elif value is string -%}
+	${{ key }} = '{{ value }}';
+
+{%- elif value is iterable -%}
 	${{ key }} = [];
-	{% for subkey, subvalue in value.iteritems() %}
-		{% if value is number %}
-		${{ key }}[{{ subkey }}] = {{ subvalue }};
-		{% else %}
-		${{ key }}[{{ subkey }}] = '{{ subvalue }}';
-		{% endif %}
-	{% endfor %}
-{% else %}
-${{ key }} = '{{ value }}';
-{% endif %}
-{% endfor %}
-{% endif %}
+
+	{%- if value is mapping -%}
+		{%- for subkey, subvalue in value.iteritems() %}
+
+			{% if subvalue is number -%}
+				${{ key }}['{{ subkey }}'] = {{ subvalue }};
+			{%- else -%}
+				${{ key }}['{{ subkey }}'] = '{{ subvalue }}';
+			{%- endif -%}
+
+		{% endfor -%}
+
+	{%- else -%}
+		{%- for subvalue in value %}
+
+			{% if subvalue is number -%}
+				${{ key }}[] = {{ subvalue }};
+			{%- else -%}
+				${{ key }}[] = '{{ subvalue }}';
+			{%- endif -%}
+
+		{% endfor -%}
+
+	{%- endif -%}
+
+{%- else -%}
+	${{ key }} = '{{ value }}';
+
+{%- endif %}
+
+{% endfor -%}
+{%- endif %}
+
 
 
 {% if env_deploy_vars is defined and env_deploy_vars is iterable %}
@@ -130,22 +156,47 @@ ${{ key }} = '{{ value }}';
 # These should only come from env/{{ env }}.yml
 #
 {% for key, value in env_deploy_vars.iteritems() %}
-{% if value is number %}
-${{ key }} = {{ value }};
-{% elif value is iterable %}
+
+{% if value is number -%}
+	${{ key }} = {{ value }};
+
+{%- elif value is string -%}
+	${{ key }} = '{{ value }}';
+
+{%- elif value is iterable -%}
 	${{ key }} = [];
-	{% for subkey, subvalue in value.iteritems() %}
-		{% if value is number %}
-		${{ key }}[{{ subkey }}] = {{ subvalue }};
-		{% else %}
-		${{ key }}[{{ subkey }}] = '{{ subvalue }}';
-		{% endif %}
-	{% endfor %}
-{% else %}
-${{ key }} = '{{ value }}';
-{% endif %}
-{% endfor %}
-{% endif %}
+
+	{%- if value is mapping -%}
+		{%- for subkey, subvalue in value.iteritems() %}
+
+			{% if subvalue is number -%}
+				${{ key }}['{{ subkey }}'] = {{ subvalue }};
+			{%- else -%}
+				${{ key }}['{{ subkey }}'] = '{{ subvalue }}';
+			{%- endif -%}
+
+		{% endfor -%}
+
+	{%- else -%}
+		{%- for subvalue in value %}
+
+			{% if subvalue is number -%}
+				${{ key }}[] = {{ subvalue }};
+			{%- else -%}
+				${{ key }}[] = '{{ subvalue }}';
+			{%- endif -%}
+
+		{% endfor -%}
+
+	{%- endif -%}
+
+{%- else -%}
+	${{ key }} = '{{ value }}';
+
+{%- endif %}
+
+{% endfor -%}
+{%- endif %}
 
 
 {% if secret_deploy_vars is defined and secret_deploy_vars is iterable %}
@@ -154,22 +205,48 @@ ${{ key }} = '{{ value }}';
 # These should only come from secret.yml
 #
 {% for key, value in secret_deploy_vars.iteritems() %}
-{% if value is number %}
-${{ key }} = {{ value }};
-{% elif value is iterable %}
+
+{% if value is number -%}
+	${{ key }} = {{ value }};
+
+{%- elif value is string -%}
+	${{ key }} = '{{ value }}';
+
+{%- elif value is iterable -%}
 	${{ key }} = [];
-	{% for subkey, subvalue in value.iteritems() %}
-		{% if value is number %}
-		${{ key }}[{{ subkey }}] = {{ subvalue }};
-		{% else %}
-		${{ key }}[{{ subkey }}] = '{{ subvalue }}';
-		{% endif %}
-	{% endfor %}
-{% else %}
-${{ key }} = '{{ value }}';
-{% endif %}
-{% endfor %}
-{% endif %}
+
+	{%- if value is mapping -%}
+		{%- for subkey, subvalue in value.iteritems() %}
+
+			{% if subvalue is number -%}
+				${{ key }}['{{ subkey }}'] = {{ subvalue }};
+			{%- else -%}
+				${{ key }}['{{ subkey }}'] = '{{ subvalue }}';
+			{%- endif -%}
+
+		{% endfor -%}
+
+	{%- else -%}
+		{%- for subvalue in value %}
+
+			{% if subvalue is number -%}
+				${{ key }}[] = {{ subvalue }};
+			{%- else -%}
+				${{ key }}[] = '{{ subvalue }}';
+			{%- endif -%}
+
+		{% endfor -%}
+
+	{%- endif -%}
+
+{%- else -%}
+	${{ key }} = '{{ value }}';
+
+{%- endif %}
+
+{% endfor -%}
+{%- endif %}
+
 
 
 {% if deploy_vars is defined and deploy_vars is iterable %}
@@ -180,22 +257,48 @@ ${{ key }} = '{{ value }}';
 #        are updated.
 #
 {% for key, value in deploy_vars.iteritems() %}
-{% if value is number %}
-${{ key }} = {{ value }};
-{% elif value is iterable %}
+
+{% if value is number -%}
+	${{ key }} = {{ value }};
+
+{%- elif value is string -%}
+	${{ key }} = '{{ value }}';
+
+{%- elif value is iterable -%}
 	${{ key }} = [];
-	{% for subkey, subvalue in value.iteritems() %}
-		{% if value is number %}
-		${{ key }}[{{ subkey }}] = {{ subvalue }};
-		{% else %}
-		${{ key }}[{{ subkey }}] = '{{ subvalue }}';
-		{% endif %}
-	{% endfor %}
-{% else %}
-${{ key }} = '{{ value }}';
-{% endif %}
-{% endfor %}
-{% endif %}
+
+	{%- if value is mapping -%}
+		{%- for subkey, subvalue in value.iteritems() %}
+
+			{% if subvalue is number -%}
+				${{ key }}['{{ subkey }}'] = {{ subvalue }};
+			{%- else -%}
+				${{ key }}['{{ subkey }}'] = '{{ subvalue }}';
+			{%- endif -%}
+
+		{% endfor -%}
+
+	{%- else -%}
+		{%- for subvalue in value %}
+
+			{% if subvalue is number -%}
+				${{ key }}[] = {{ subvalue }};
+			{%- else -%}
+				${{ key }}[] = '{{ subvalue }}';
+			{%- endif -%}
+
+		{% endfor -%}
+
+	{%- endif -%}
+
+{%- else -%}
+	${{ key }} = '{{ value }}';
+
+{%- endif %}
+
+{% endfor -%}
+{%- endif %}
+
 
 
 #

--- a/src/roles/base/templates/config.sh.j2
+++ b/src/roles/base/templates/config.sh.j2
@@ -64,7 +64,9 @@ m_i18n="{{ m_i18n }}"
 # These should only come from public.yml
 #
 {% for key, value in public_deploy_vars.iteritems() %}
-{% if value is iterable %}
+{% if value is string %}
+{{ key }}="{{ value }}"
+{% elif value is iterable %}
 # Skipping iterable deploy var {{ key }}. FIXME #856.
 {% else %}
 {{ key }}="{{ value }}"
@@ -79,7 +81,9 @@ m_i18n="{{ m_i18n }}"
 # These should only come from env/{{ env }}.yml
 #
 {% for key, value in env_deploy_vars.iteritems() %}
-{% if value is iterable %}
+{% if value is string %}
+{{ key }}="{{ value }}"
+{% elif value is iterable %}
 # Skipping iterable deploy var {{ key }}. FIXME #856.
 {% else %}
 {{ key }}="{{ value }}"
@@ -94,7 +98,9 @@ m_i18n="{{ m_i18n }}"
 # These should only come from secret.yml
 #
 {% for key, value in secret_deploy_vars.iteritems() %}
-{% if value is iterable %}
+{% if value is string %}
+{{ key }}="{{ value }}"
+{% elif value is iterable %}
 # Skipping iterable deploy var {{ key }}. FIXME #856.
 {% else %}
 {{ key }}="{{ value }}"
@@ -111,7 +117,9 @@ m_i18n="{{ m_i18n }}"
 #        are updated.
 #
 {% for key, value in deploy_vars.iteritems() %}
-{% if value is iterable %}
+{% if value is string %}
+{{ key }}="{{ value }}"
+{% elif value is iterable %}
 # Skipping iterable deploy var {{ key }}. FIXME #856.
 {% else %}
 {{ key }}="{{ value }}"

--- a/src/roles/base/templates/config.sh.j2
+++ b/src/roles/base/templates/config.sh.j2
@@ -49,14 +49,60 @@ m_language="{{ m_language }}"
 m_i18n="{{ m_i18n }}"
 
 
+
 #
-# CUSTOM DEPLOY VARIABLES: from secret.yml
+# DEPLOY VARS included in the following order, with each superceding the previous
+#   1. public
+#   2. env-specific
+#   3. secret
+#   4. FIXME: deprecated deploy_vars, use secret_deploy_vars instead
 #
+
+{% if public_deploy_vars is defined and public_deploy_vars is iterable %}
+#
+# CUSTOM __public__ DEPLOY VARIABLES
+# These should only come from public.yml
+#
+{% for key, value in public_deploy_vars.iteritems() %}
+{{ key }}="{{ value }}"
+{% endfor %}
+{% endif %}
+
+
+{% if env_deploy_vars is defined and env_deploy_vars is iterable %}
+#
+# CUSTOM __{{ env }} environment__ DEPLOY VARIABLES
+# These should only come from env/{{ env }}.yml
+#
+{% for key, value in env_deploy_vars.iteritems() %}
+{{ key }}="{{ value }}"
+{% endfor %}
+{% endif %}
+
+
+{% if secret_deploy_vars is defined and secret_deploy_vars is iterable %}
+#
+# CUSTOM __secret__ DEPLOY VARIABLES
+# These should only come from secret.yml
+#
+{% for key, value in secret_deploy_vars.iteritems() %}
+{{ key }}="{{ value }}"
+{% endfor %}
+{% endif %}
+
+
 {% if deploy_vars is defined and deploy_vars is iterable %}
+#
+# __DEPRECATED__ CUSTOM DEPLOY VARIABLES
+#
+# FIXME: remove deploy_vars in lieu of secret_deploy_vars when production wikis
+#        are updated.
+#
 {% for key, value in deploy_vars.iteritems() %}
 {{ key }}="{{ value }}"
 {% endfor %}
 {% endif %}
+
 
 
 #

--- a/src/roles/base/templates/config.sh.j2
+++ b/src/roles/base/templates/config.sh.j2
@@ -64,7 +64,11 @@ m_i18n="{{ m_i18n }}"
 # These should only come from public.yml
 #
 {% for key, value in public_deploy_vars.iteritems() %}
+{% if value is iterable %}
+# Skipping iterable deploy var {{ key }}. FIXME #856.
+{% else %}
 {{ key }}="{{ value }}"
+{% endif %}
 {% endfor %}
 {% endif %}
 
@@ -75,7 +79,11 @@ m_i18n="{{ m_i18n }}"
 # These should only come from env/{{ env }}.yml
 #
 {% for key, value in env_deploy_vars.iteritems() %}
+{% if value is iterable %}
+# Skipping iterable deploy var {{ key }}. FIXME #856.
+{% else %}
 {{ key }}="{{ value }}"
+{% endif %}
 {% endfor %}
 {% endif %}
 
@@ -86,7 +94,11 @@ m_i18n="{{ m_i18n }}"
 # These should only come from secret.yml
 #
 {% for key, value in secret_deploy_vars.iteritems() %}
+{% if value is iterable %}
+# Skipping iterable deploy var {{ key }}. FIXME #856.
+{% else %}
 {{ key }}="{{ value }}"
+{% endif %}
 {% endfor %}
 {% endif %}
 
@@ -99,7 +111,11 @@ m_i18n="{{ m_i18n }}"
 #        are updated.
 #
 {% for key, value in deploy_vars.iteritems() %}
+{% if value is iterable %}
+# Skipping iterable deploy var {{ key }}. FIXME #856.
+{% else %}
 {{ key }}="{{ value }}"
+{% endif %}
 {% endfor %}
 {% endif %}
 

--- a/src/roles/set-vars/tasks/main.yml
+++ b/src/roles/set-vars/tasks/main.yml
@@ -26,6 +26,12 @@
 - set_fact:
     list_of_wikis: "{{ wikis_dirs.files | map(attribute='path') | map('basename') | list }}"
 
+- name: "Set meza environment-specific public variables for env={{ env }}"
+  include_vars:
+    file: "{{ m_local_public }}/env/{{ env }}.yml"
+  # Ingore errors so this file is not required to be included
+  ignore_errors: yes
+
 - name: Set meza local secret variables
   include_vars:
     file: "{{ m_local_secret }}/{{ env }}/secret.yml"


### PR DESCRIPTION
Previously had `deploy_vars` as a variable that was intended to be in `secret.yml`. This would look like:

```yaml
deploy_vars:
  my_var: "some value"
  another_var: "another value"
```

These values would then get written to `/opt/.deploy-meza/config.sh` like:

```bash
my_var="some value"
another_var="another value"
```

and to `config.php` like:

```php
$my_var = "some value";
$another_var = "another value";
```

However, this did not allow for such values to be written in `public.yml`. Additionally, `secret.yml` functions as both a place for secret information (DB passwords, etc) as well as server-specific info. In order to allow more deploy-vars functionality, the following change was made.

### Setting deploy vars in `secret.yml`

Deploy vars should be set in `secret.yml` with `secret_deploy_vars` variable, like:

```yaml
secret_deploy_vars:
  my_var: "some value"
  another_var: "another value"
```

### Setting deploy vars in `public.yml`

Deploy vars should be set in `public.yml` with `public_deploy_vars` variable, like:

```yaml
public_deploy_vars:
  my_var: "some value"
  another_var: "another value"
```

### Setting environment-specific deploy vars

Environment-specific deploy vars can be set in your public config by creating a file like `/opt/conf-meza/public/env/<your-environment>.yml`. So if your environment is `production` then create the `env` directory in your public config, and create the `production.yml` file within it like:

```yaml
env_deploy_vars:
  my_var: "some value"
  another_var: "another value"
```

### Deprecate plain `deploy_vars`

You can still use `deploy_vars` within `secret.yml` (as opposed to `secret_deploy_vars`), but that will be removed soon.

### Order of overrides

If you set `my_var` within `public.yml` deploy vars and `my_var` also within `secret.yml`, the value in `secret.yml` will win. Order of overrides is:

1. `secret.yml` highest priority
2. environment-specific
3. `public.yml` lowest priority
