### PR TITLE
Fix case A of Issue #861

### DIFF
--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -47,7 +47,7 @@ m_mediawiki: /opt/htdocs/mediawiki
 m_cert_private: /etc/pki/tls/private/meza.key
 m_cert_public: /etc/pki/tls/certs/meza.crt
 m_ca_cert: /etc/pki/tls/certs/meza-ca.crt
-
+m_https_always: True
 
 # app locations
 m_apache: /etc/httpd

--- a/src/roles/apache-php/tasks/main.yml
+++ b/src/roles/apache-php/tasks/main.yml
@@ -29,6 +29,27 @@
   notify:
   - restart apache
 
+- name: HTTPS Always with unmanaged load balancer
+  blockinfile:
+    path: "{{ m_apache_conf }}"
+    block: |
+      # redirect traffic on port 80 to SSL if local HAproxy is unused
+      Listen 80
+      <VirtualHost *:80>
+             <IfModule mod_rewrite.c>
+                 # Enable mod_rewrite engine
+                 RewriteEngine on
+                 # This is needed if NOT using HAproxy, but offloading to an unmanaged load balancer
+                 # and you still want all traffic to go through HTTPS
+                 RewriteCond %{HTTP:X-Forwarded-Proto} ^http$
+                 RewriteRule .* https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
+             </IfModule>
+      </VirtualHost>
+    state: present
+    when: "'load-balancers-unmanaged' in groups and {{ m_https_always }} "
+    notify:
+    - restart apache
+
 - name: Install PHP
   include: php.yml
   # http://docs.ansible.com/ansible/playbooks_roles.html#dynamic-versus-static-includes


### PR DESCRIPTION
Inserts additional block in the Apache configuration to make requests use the HTTPS protocol

### Testing

- [ ] `curl -LO https://raw.githubusercontent.com/enterprisemediawiki/meza/redirect-apache-80/scripts/install.sh`
- [ ] `sudo bash install.sh`
- [ ] `redirect-apache-80` branch
- [ ] Perform standard tests from [CONTRIBUTING.md](https://github.com/enterprisemediawiki/meza/blob/master/CONTRIBUTING.md)
- [ ] If testing during development, modify the apache conf directly, then issue a `sudo apachectl restart` and `curl -l --head http://localhost` and `curl -l --head http://example.com`

** Note: I'm not familiar with the Testing procedures, so I'm not sure if the above applies or not **

### Changes

After the Apache configuration is in place, this new task will insert a block to make Apache listen on port 80 and will redirect all requests on that port to HTTPS.  This block only gets inserted when loadbalancers-unmanaged is in the hosts file and the *m_https_always* configuration option is set to True 
Introduces new config value **m_https_always: True**

**Note: I just realized that the when: condition should also include a count>0 test**

### Issues

* Addresses #861 
