### PR TITLE
Relative link fix in markdown file

### DIFF
--- a/manual/SettingUpVirtualBox.md
+++ b/manual/SettingUpVirtualBox.md
@@ -14,7 +14,7 @@ sudo meza setup dev-networking
 ```
 4. Now SSH into your machine and run `sudo meza deploy monolith`.
 
-This will setup a demo wiki with the user `Admin` with password `adminpass`. Update this password or remove this user for production environments. To add wikis see [these docs](manual/AddingWikis.md).
+This will setup a demo wiki with the user `Admin` with password `adminpass`. Update this password or remove this user for production environments. To add wikis see [these docs](AddingWikis.md).
 
 ## Detailed steps
 
@@ -66,7 +66,7 @@ These steps do the following:
 2. SSH into the VM
 3. Run `sudo meza deploy monolith` to install your wiki server.
 
-This will setup a demo wiki with the user `Admin` with password `adminpass`. Update this password or remove this user for production environments. To add wikis see [these docs](./AddingWikis.md).
+This will setup a demo wiki with the user `Admin` with password `adminpass`. Update this password or remove this user for production environments. To add wikis see [these docs](AddingWikis.md).
 
 ## Red Hat
 

--- a/manual/SettingUpVirtualBox.md
+++ b/manual/SettingUpVirtualBox.md
@@ -66,7 +66,7 @@ These steps do the following:
 2. SSH into the VM
 3. Run `sudo meza deploy monolith` to install your wiki server.
 
-This will setup a demo wiki with the user `Admin` with password `adminpass`. Update this password or remove this user for production environments. To add wikis see [these docs](manual/AddingWikis.md).
+This will setup a demo wiki with the user `Admin` with password `adminpass`. Update this password or remove this user for production environments. To add wikis see [these docs](./AddingWikis.md).
 
 ## Red Hat
 


### PR DESCRIPTION
Fix links for adding wikis in `SettingUpVirtualBox.md`. Link was to `manual/AddingWikis.md` but this does not work (404 error) since a URL with `manual/manual/AddingWikis.md` is created. Either `./AddingWikis.md` or `AddingWikis.md` works since `AddingWikis.md` is in the same directory as `SettingUpVirtualBox.md`. Links in `README.md` need to have the `manual/` prefix.

This PR supersedes #883.