### PR TITLE
Elasticsearch test unnecessary option which is invalid in ES 5.x

### DIFF
--- a/tests/integration/wiki-check.sh
+++ b/tests/integration/wiki-check.sh
@@ -35,8 +35,8 @@ curl -L "$api_url_ve" | jq ".visualeditor.result == \"success\"" -e \
 	&& (echo 'VisualEditor PASS' && exit 0) || (echo 'VisualEditor FAIL' && exit 1)
 
 # Verify an indices exist for this wiki
-curl "http://127.0.0.1:9200/_stats/index,store"
-curl "http://127.0.0.1:9200/_stats/index,store" | jq ".indices | has(\"wiki_${wiki_id}_content_first\")" -e \
+curl "http://127.0.0.1:9200/_stats/store"
+curl "http://127.0.0.1:9200/_stats/store" | jq ".indices | has(\"wiki_${wiki_id}_content_first\")" -e \
 	&& (echo 'Elasticsearch PASS' && exit 0) || (echo 'Elasticsearch FAIL' && exit 1)
-curl "http://127.0.0.1:9200/_stats/index,store" | jq ".indices | has(\"wiki_${wiki_id}_general_first\")" -e \
+curl "http://127.0.0.1:9200/_stats/store" | jq ".indices | has(\"wiki_${wiki_id}_general_first\")" -e \
 	&& (echo 'Elasticsearch PASS' && exit 0) || (echo 'Elasticsearch FAIL' && exit 1)


### PR DESCRIPTION
Elasticsearch testing changed:

```
WAS: http://127.0.0.1:9200/_stats/index,store
IS:  http://127.0.0.1:9200/_stats/store
```

The `index` option is not in any documentation I could find. It wasn't causing any issues until Elasticsearch 5.x. Removing now to keep testing consistent across versions.