### PR TITLE
require_once isn't great for settings; won't get pulled in a second time

### DIFF
--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -29,7 +29,7 @@ if ( !defined( 'MEDIAWIKI' ) ) {
  *  Perform authentication up front.
  *
  **/
-require_once "{{ m_deploy }}/samlLocalSettings.php";
+require "{{ m_deploy }}/samlLocalSettings.php";
 
 
 {% endif %}
@@ -41,7 +41,7 @@ require_once "{{ m_deploy }}/samlLocalSettings.php";
  *  from the WIKI environment variable (for command line scripts)
  **/
 
-require_once '/opt/.deploy-meza/config.php';
+require '/opt/.deploy-meza/config.php';
 
 if( $wgCommandLineMode ) {
 


### PR DESCRIPTION
If file required/included earlier, won't get pulled in again. This could break something the second time `require_once` is used, if the second time isn't in the same context as the first (so variables you think you're including don't get included).