### PR TITLE
Saml syslog fix

### DIFF
--- a/src/roles/saml/files/NonMediaWikiSimpleSamlAuth.php
+++ b/src/roles/saml/files/NonMediaWikiSimpleSamlAuth.php
@@ -64,7 +64,7 @@ class NonMediaWikiSimpleSamlAuth {
 		// Load the simpleSamlPhp service
 		require_once rtrim( $wgSamlSspRoot, DIRECTORY_SEPARATOR ) .
 			DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . '_autoload.php';
-		self::$as = new SimpleSAML_Auth_Simple( $wgSamlAuthSource );
+		self::$as = new SimpleSAML\Auth\Simple( $wgSamlAuthSource );
 		self::$initialised = is_object( self::$as );
 		return self::$initialised;
 	}

--- a/src/roles/saml/tasks/main.yml
+++ b/src/roles/saml/tasks/main.yml
@@ -10,13 +10,12 @@
 
 - name: Ensure SimpleSamlAuth (MediaWiki extension) installed
   git:
-    repo: https://github.com/jornane/mwSimpleSamlAuth.git
+    # Main version of this extension, jornane/mwSimpleSamlAuth, is slow to
+    # update. Use this fork instead, which should stay current with jornane
+    # until meza switches to Cicalese's Extension:SimpleSamlPhp.
+    repo: https://github.com/jamesmontalvo3/mwSimpleSamlAuth.git
     dest: "{{ m_mediawiki }}/extensions/SimpleSamlAuth"
-    
-    # Use hash for now, until version greater than v0.7 is released that fixes
-    # issues with MW 1.27 user creation.
-    # Ref: https://github.com/jornane/mwSimpleSamlAuth/issues/31#issuecomment-302759940
-    version: "2e0e7b7b6d08de2d97741a0561ea4a6b3c58d4f9"
+    version: master
   tags:
     - latest
 


### PR DESCRIPTION
Forked Extension:SimpleSamlAuth and fixed namespace issue that was creating many syslog messages. Also updated `NonMediaWikiSimpleSamlAuth.php` for the same fix.