### PR TITLE
Specify version of SimpleSamlPhp to avoid breaking changes

### DIFF
--- a/src/roles/saml/tasks/main.yml
+++ b/src/roles/saml/tasks/main.yml
@@ -4,7 +4,7 @@
   git:
     repo: https://github.com/simplesamlphp/simplesamlphp.git
     dest: "{{ m_simplesamlphp_path }}"
-    version: "master"
+    version: "tags/v1.15.0"
   tags:
     - latest
 


### PR DESCRIPTION
Currently tracking `master` of SimpleSamlPhp. Pulling new commits could cause breaking changes.