### PR TITLE
Fixes for building docker images

### DIFF
--- a/src/playbooks/site.yml
+++ b/src/playbooks/site.yml
@@ -344,6 +344,7 @@
   roles:
     - set-vars
     - meza-log
+  when: docker_skip_tasks is not defined or not docker_skip_tasks
 
 - hosts: all:!exclude-all:!load-balancers-unmanaged
   become: yes

--- a/src/playbooks/site.yml
+++ b/src/playbooks/site.yml
@@ -351,4 +351,6 @@
   tags: cron
   roles:
     - set-vars
-    - cron
+    - role: cron
+      when: docker_skip_tasks is not defined or not docker_skip_tasks
+ 

--- a/src/playbooks/site.yml
+++ b/src/playbooks/site.yml
@@ -343,8 +343,8 @@
   tags: logging
   roles:
     - set-vars
-    - meza-log
-  when: docker_skip_tasks is not defined or not docker_skip_tasks
+    - role: meza-log
+      when: docker_skip_tasks is not defined or not docker_skip_tasks
 
 - hosts: all:!exclude-all:!load-balancers-unmanaged
   become: yes

--- a/src/roles/meza-log/tasks/main.yml
+++ b/src/roles/meza-log/tasks/main.yml
@@ -22,7 +22,7 @@
     state: import
     target: "/opt/meza/src/roles/meza-log/files/meza_server_log.sql"
   run_once: true
-  when: not server_log_exists
+  when: not server_log_exists AND (docker_skip_tasks is not defined or not docker_skip_tasks)
 
 
 #
@@ -33,16 +33,17 @@
   register: register_disk_space
   ignore_errors: yes
   run_once: true
+  when: docker_skip_tasks is not defined or not docker_skip_tasks
 
 - name: "Set fact if disk_space table DOES exist"
   set_fact:
     disk_space_exists: True
-  when: register_disk_space.rc == 0
+  when: register_disk_space.rc == 0 AND (docker_skip_tasks is not defined or not docker_skip_tasks)
 
 - name: "Set fact if disk_space table DOES NOT exist"
   set_fact:
     disk_space_exists: False
-  when: register_disk_space.rc != 0
+  when: register_disk_space.rc != 0 AND (docker_skip_tasks is not defined or not docker_skip_tasks)
 
 - name: "Create table disk_space if not exists"
   mysql_db:
@@ -50,7 +51,7 @@
     state: import
     target: "/opt/meza/src/roles/meza-log/files/table_disk_space.sql"
   run_once: true
-  when: not disk_space_exists
+  when: not disk_space_exists AND (docker_skip_tasks is not defined or not docker_skip_tasks)
 
 
 #

--- a/src/roles/meza-log/tasks/main.yml
+++ b/src/roles/meza-log/tasks/main.yml
@@ -22,7 +22,7 @@
     state: import
     target: "/opt/meza/src/roles/meza-log/files/meza_server_log.sql"
   run_once: true
-  when: not server_log_exists AND (docker_skip_tasks is not defined or not docker_skip_tasks)
+  when: not server_log_exists and (docker_skip_tasks is not defined or not docker_skip_tasks)
 
 
 #
@@ -38,12 +38,12 @@
 - name: "Set fact if disk_space table DOES exist"
   set_fact:
     disk_space_exists: True
-  when: register_disk_space.rc == 0 AND (docker_skip_tasks is not defined or not docker_skip_tasks)
+  when: register_disk_space.rc == 0 and (docker_skip_tasks is not defined or not docker_skip_tasks)
 
 - name: "Set fact if disk_space table DOES NOT exist"
   set_fact:
     disk_space_exists: False
-  when: register_disk_space.rc != 0 AND (docker_skip_tasks is not defined or not docker_skip_tasks)
+  when: register_disk_space.rc != 0 and (docker_skip_tasks is not defined or not docker_skip_tasks)
 
 - name: "Create table disk_space if not exists"
   mysql_db:
@@ -51,7 +51,7 @@
     state: import
     target: "/opt/meza/src/roles/meza-log/files/table_disk_space.sql"
   run_once: true
-  when: not disk_space_exists AND (docker_skip_tasks is not defined or not docker_skip_tasks)
+  when: not disk_space_exists and (docker_skip_tasks is not defined or not docker_skip_tasks)
 
 
 #

--- a/src/roles/meza-log/tasks/main.yml
+++ b/src/roles/meza-log/tasks/main.yml
@@ -22,7 +22,7 @@
     state: import
     target: "/opt/meza/src/roles/meza-log/files/meza_server_log.sql"
   run_once: true
-  when: not server_log_exists and (docker_skip_tasks is not defined or not docker_skip_tasks)
+  when: not server_log_exists
 
 
 #
@@ -33,17 +33,16 @@
   register: register_disk_space
   ignore_errors: yes
   run_once: true
-  when: docker_skip_tasks is not defined or not docker_skip_tasks
 
 - name: "Set fact if disk_space table DOES exist"
   set_fact:
     disk_space_exists: True
-  when: register_disk_space.rc == 0 and (docker_skip_tasks is not defined or not docker_skip_tasks)
+  when: register_disk_space.rc == 0
 
 - name: "Set fact if disk_space table DOES NOT exist"
   set_fact:
     disk_space_exists: False
-  when: register_disk_space.rc != 0 and (docker_skip_tasks is not defined or not docker_skip_tasks)
+  when: register_disk_space.rc != 0
 
 - name: "Create table disk_space if not exists"
   mysql_db:
@@ -51,7 +50,7 @@
     state: import
     target: "/opt/meza/src/roles/meza-log/files/table_disk_space.sql"
   run_once: true
-  when: not disk_space_exists and (docker_skip_tasks is not defined or not docker_skip_tasks)
+  when: not disk_space_exists
 
 
 #


### PR DESCRIPTION
When building docker images you can't enable or use any services (as far as I understand). As such, two Ansible plays that use MySQL and Cron need to be disabled during image building.