### PR TITLE
Specify xhgui version; else breakage with master

### DIFF
--- a/src/roles/apache-php/tasks/profiling.yml
+++ b/src/roles/apache-php/tasks/profiling.yml
@@ -41,7 +41,7 @@
   git:
     repo: https://github.com/perftools/xhgui.git
     dest: "{{ m_profiling_xhgui_directory }}"
-    version: master
+    version: "0.8.1"
     force: yes
 
 - name: Ensure XHGui directory owned by Apache


### PR DESCRIPTION
Currently specifying `master`. This breaks with never version of xhgui. Specify an actual version.