### PR TITLE
Tell Apache to redirect to HTTPS when HAProxy is not used.

### DIFF
--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -47,7 +47,7 @@ m_mediawiki: /opt/htdocs/mediawiki
 m_cert_private: /etc/pki/tls/private/meza.key
 m_cert_public: /etc/pki/tls/certs/meza.crt
 m_ca_cert: /etc/pki/tls/certs/meza-ca.crt
-
+m_https_always: True
 
 # app locations
 m_apache: /etc/httpd

--- a/src/roles/apache-php/tasks/main.yml
+++ b/src/roles/apache-php/tasks/main.yml
@@ -29,6 +29,27 @@
   notify:
   - restart apache
 
+- name: HTTPS Always with unmanaged load balancer
+  blockinfile:
+    path: "{{ m_apache_conf }}"
+    block: |
+      # redirect traffic on port 80 to SSL if local HAproxy is unused
+      Listen 80
+      <VirtualHost *:80>
+             <IfModule mod_rewrite.c>
+                 # Enable mod_rewrite engine
+                 RewriteEngine on
+                 # This is needed if NOT using HAproxy, but offloading to an unmanaged load balancer
+                 # and you still want all traffic to go through HTTPS
+                 RewriteCond %{HTTP:X-Forwarded-Proto} ^http$
+                 RewriteRule .* https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
+             </IfModule>
+      </VirtualHost>
+    state: present
+    when: "'load-balancers-unmanaged' in groups and {{ m_https_always }} "
+    notify:
+    - restart apache
+
 - name: Install PHP
   include: php.yml
   # http://docs.ansible.com/ansible/playbooks_roles.html#dynamic-versus-static-includes


### PR DESCRIPTION
When HAProxy is used, it is configured to listen on port 80 and redirect to port 443, enabling SSL.  However, if you have an unmanaged load balancer in your Meza hosts file, then that means that HAProxy is unused, and instead all requests get forwarded to Apache. This change adds a listener in the Apache config that listens on port 80, and redirects to port 443, enabling SSL by default for Meza installations with an external proxy.

### Testing

1. Specify an IP in your hosts file for 'load-balancers-unmanaged'
```[load-balancers-unmanaged]                                                                                                                                                                                             
54.87.172.239
```
1. Set the m_https_always configuration variable to true in config/core/defaults.yml (or an override)
1. Run a deploy, then check that any HTTP request gets automatically handed over to HTTPS in your environment.

### Changes
* new variable in config/core/defaults.yml **m_https_always**
* new `listen` and new `VirtualHost` block in Apache configuration

### Issues

