### PR TITLE
switch default to anonymous read from anonymous edit

### DIFF
--- a/src/roles/init-controller-config/templates/public.yml.j2
+++ b/src/roles/init-controller-config/templates/public.yml.j2
@@ -7,6 +7,7 @@
 # Set a default authentication method for all wikis that don't specify one
 # FIXME #763: List types, and descriptions
 # meza_auth_type: "viewer-read"
+meza_auth_type: "anon-read"
 
 blender_landing_page_title: Test of Meza Wikis
 

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -622,8 +622,12 @@ $wgUseRCPatrol = false;
  *
  *
  **/
+# Prevent new user registrations except by sysops
+$wgGroupPermissions['*']['createaccount'] = false;
+
+
 if ( ! isset( $mezaAuthType ) ) {
-	$mezaAuthType = 'anon-edit'; // default: wide open!
+	$mezaAuthType = 'anon-read'; // default: require creation by sysop
 }
 if ( $mezaAuthType === 'anon-edit' ) {
 


### PR DESCRIPTION
**Anonymous edit** is dangerous on the public web as a default. Your wiki will instantly be spammed with ads for Viagra and many more unmentionable things.  This changes the default auth_type in Meza to **Anonymous read**

### Testing

1. Deploy a new monolith
1. Try to edit a page anonymously (no login). You should be denied.
1. Try to create an account without logging in; the "create account" link should not be displayed.
1. Try to create an account by directly accessing the **CreateAccount** Special Page: e.g. https://demo.qualitybox.us/wiki/Special:CreateAccount; You should be denied.
1. Login as an Admin user, and visit the CreateAccount special page. You should be able to create an account for a user.

### Changes

* Sets up meza_auth_type: "anon-read" in `src/roles/init-controller-config/templates/public.yml.j2`
* Turns off account creation for all users `$wgGroupPermissions['*']['createaccount'] = false;` which means that admin users need to create accounts; or that some specific and intentional policy needs to be put into LocalSettings.php or an override.


### Issues

none
