### PR TITLE
Use semantic versioning for SemCompoundQueries

### DIFF
--- a/config/core/MezaCoreExtensions.yml
+++ b/config/core/MezaCoreExtensions.yml
@@ -46,7 +46,7 @@ list:
 
   - name: SemanticCompoundQueries
     composer: "mediawiki/semantic-compound-queries"
-    version: "1.1.0"
+    version: "~1.1"
   - name: SubPageList
     composer: "mediawiki/sub-page-list"
     version: "~1.1"


### PR DESCRIPTION
per the extension page, they use semantic versioning, so we should too
https://www.mediawiki.org/wiki/Extension:Semantic_Compound_Queries

This changes the version for Semantic Compound Queries 
from
    explicit "1.1.0"
to 
    a semantic versioning notation "~1.1"
The latter is described on the project's homepage as the way to specify version for SCQ. This implies that they are aware of and using [semantic versioning](https://getcomposer.org/doc/articles/versions.md#tilde-version-range-).  This change allows us to automatically benefit from bugfixes prior to any (major) version bump.
