### PR TITLE
Allow timezone to be specified in the config file; Default to Chicago…

### DIFF
--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -68,6 +68,8 @@ m_db_replication_log_pos: /opt/data-meza/db_master_log_pos
 
 meza_server_log_db: meza_server_log
 
+m_timezone: America/New_York
+
 ntp_server: [0.pool.ntp.org, 1.pool.ntp.org, 2.pool.ntp.org, 3.pool.ntp.org]
 
 m_language: en

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -557,8 +557,14 @@ $wgEnableMWSuggest = true;
 // fixes login issue for some users (login issue fixed in MW version 1.18.1 supposedly)
 $wgDisableCookieCheck = true;
 
-#Set Default Timezone
+# Read timezone from meza config
+{% if m_timezone is defined %}
+$wgLocaltimezone = "{{ m_timezone }}";
+{% else %}
+# Set Default Timezone for farm
 $wgLocaltimezone = "America/Chicago";
+{% endif %}
+
 $oldtz = getenv("TZ");
 putenv("TZ=$wgLocaltimezone");
 


### PR DESCRIPTION
… (CST) - same as Houston.

Introduces new config variable m_timezone

If m_timezone is not defined in the config, then LocalSettings.php.j2 will default to
$wgLocaltimezone = "America/Chicago";