### PR TITLE
SSL always - without HAProxy

### DIFF
--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -72,6 +72,10 @@ ntp_server: [0.pool.ntp.org, 1.pool.ntp.org, 2.pool.ntp.org, 3.pool.ntp.org]
 
 m_language: en
 
+# This is a fallback setting for Apache when no proxy or an external proxy is used
+# Under a normal meza with HAProxy, it's the load balancer that handles SSL
+m_https_always: true
+
 allow_backup_downloads: false
 
 m_force_debug: false

--- a/src/roles/apache-php/templates/httpd.conf.j2
+++ b/src/roles/apache-php/templates/httpd.conf.j2
@@ -450,6 +450,23 @@ Listen 8089
 </VirtualHost>
 {% endif %}
 
+{% if m_https_always %}
+# redirect traffic on port 80 to SSL if local HAproxy is unused
+Listen 80
+<VirtualHost *:80>
+    <IfModule mod_rewrite.c>
+        # Enable mod_rewrite engine
+        RewriteEngine on
+        # This is needed if NOT using HAproxy,
+		# but offloading to an unmanaged load balancer
+        # and you still want all traffic to go through HTTPS
+        RewriteCond %{HTTP:X-Forwarded-Proto} ^http$
+        RewriteRule .* https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
+    </IfModule>
+</VirtualHost>
+{% endif %}
+
+
 # Use port 8090 to access mod_status. Not accessible outside firewall.
 # Accessible via [[Special:Serverstatus]]
 ExtendedStatus on


### PR DESCRIPTION
If you have an entry in the [load-balancers-unmanaged] group in your hosts file, then HAProxy is not used.

Still, if the external load balancer is configured to handle traffic on port 443, then the internal traffic handled by Meza should be redirected to port 443 also.

Introduces new config variable m_https_always