### PR TITLE
Bump REL1_28 version for security release.

### DIFF
--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -115,7 +115,7 @@ sshd_config_PasswordAuthentication: "yes"
 #
 
 # Version of MediaWiki core
-mediawiki_version: "1.28.2"
+mediawiki_version: "1.28.3"
 
 # Branch to use on many extensions extensions and skins
 mediawiki_default_branch: "REL1_28"


### PR DESCRIPTION
1.28.3 is the most recent release.

The REL1_28 branch is not supported anymore, so we should upgrade/work on the REL1_29 and REL1_30 branches.  However, for anyone using REL1_28, you're going to want the patched 1.28.3 release

* https://releases.wikimedia.org/mediawiki/1.28/
* https://www.mediawiki.org/wiki/Release_notes/1.28#MediaWiki_1.28.3
