### PR TITLE
wgEnableMWSuggest was deprecated in REL1_20

### DIFF
--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -552,8 +552,6 @@ $wgDefaultUserOptions['watchmoves'] = 1;
 $wgDefaultUserOptions['watchdeletion'] = 1;
 $wgDefaultUserOptions['watchcreations'] = 1;
 
-$wgEnableMWSuggest = true;
-
 // fixes login issue for some users (login issue fixed in MW version 1.18.1 supposedly)
 $wgDisableCookieCheck = true;
 


### PR DESCRIPTION
This setting is in core since REL1_20

Removes $wgEnableMWSuggest from LocalSettings.php.j2 because it's not needed. https://www.mediawiki.org/wiki/Manual:$wgEnableMWSuggest

If you want to turn OFF autosuggest, you can use https://www.mediawiki.org/wiki/Manual:$wgEnableOpenSearchSuggest