### PR TITLE
REMOVE talk privilege for anonymous

### DIFF
--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -647,8 +647,6 @@ else if ( $mezaAuthType === 'anon-read' ) {
     $wgGroupPermissions['*']['edit'] = false;
     $wgGroupPermissions['user']['edit'] = true;
 
-	// do allow anonymous to edit talk pages
-	$wgGroupPermissions['*']['talk'] = true;
 }
 
 else if ( $mezaAuthType === 'user-edit' ) {


### PR DESCRIPTION
This "default" **anon-read** setup allows for a public deploy of Meza
without surprisingly allowing anonymous spammers to edit the Talk namespace.

In meza, the 'talk' permission is added to MediaWiki via the [TalkRight extension](https://www.mediawiki.org/wiki/Extension:TalkRight). To properly configure the TalkRight extension, setup a group such as "Commentators" and give them the "talk" privilege.

Other meza auth types (user-read, viewer-read) give the talk right to the groups 'user' and 'Viewer' respectively.