### PR TITLE
Feature optimize opcache

### DIFF
--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -5,6 +5,11 @@
 m_install: /opt
 m_meza: /opt/meza
 
+# meza mode (development or production)
+# production being as performant and secure as possible
+# development being less secure and providing optional features useful for dev
+m_mode: production
+
 # config dir
 m_config_core: /opt/meza/config/core
 m_local_secret: /opt/conf-meza/secret

--- a/src/roles/apache-php/templates/php.ini.j2
+++ b/src/roles/apache-php/templates/php.ini.j2
@@ -1855,12 +1855,10 @@ opcache.enable_cli=1
 opcache.memory_consumption=256
 
 ; The amount of memory for interned strings in Mbytes
-;opcache.interned_strings_buffer=4
 opcache.interned_strings_buffer=16
 
 ; The maximum number of keys (scripts) in the OPcache hash table
 ; Only numbers between 200 and 100000 are allowed
-;opcache.max_accelerated_files=20000
 opcache.max_accelerated_files=7963
 
 ; The maximum percentage of "wasted" memory until a restart is scheduled
@@ -1874,13 +1872,18 @@ opcache.max_accelerated_files=7963
 
 ; When disabled, you must reset the OPcache manually or restart the
 ; webserver for changes to the filesystem to take effect
-;opcache.validate_timestamps=1
+; In other words, 
+; IF YOU EDIT LIVE ON PRODUCTION, APACHE WON'T EVEN SEE YOUR CHANGES
+; unless you restart the webserver. Rogue admins foiled! Do it right!
+{% if m_mode == "production" %}
 opcache.validate_timestamps=0
+{% else %}
+opcache.validate_timestamps=1
+{% endif %}
 
 ; How often (in seconds) to check file timestamps for changes to the shared
 ; memory storage allocation. ("1" means validate once per second, but only
 ; once per request. "0" means always validate)
-;opcache.revalidate_freq=30
 opcache.revalidate_freq=0
 
 ; Enables or disables file search in include_path optimization
@@ -1896,7 +1899,6 @@ opcache.revalidate_freq=0
 ;opcache.load_comments=1
 
 ; If enabled, a fast shutdown sequence is used for the accelerated code
-;opcache.fast_shutdown=0
 opcache.fast_shutdown=1
 
 ; Allow file existence override (file_exists, etc.) performance feature.
@@ -1938,7 +1940,11 @@ opcache.error_log=/opt/data-meza/logs/opcache_error.log
 ; By default, only fatal errors (level 0) or errors (level 1) are logged.
 ; You can also enable warnings (level 2), info messages (level 3) or
 ; debug messages (level 4).
+{% if m_mode == "production" %}
+opcache.log_verbosity_level=1
+{% else %}
 opcache.log_verbosity_level=2
+{% endif %}
 
 ; Preferred Shared Memory back-end. Leave empty and let the system decide.
 ;opcache.preferred_memory_model=

--- a/src/roles/apache-php/templates/php.ini.j2
+++ b/src/roles/apache-php/templates/php.ini.j2
@@ -1855,11 +1855,13 @@ opcache.enable_cli=1
 opcache.memory_consumption=256
 
 ; The amount of memory for interned strings in Mbytes
-opcache.interned_strings_buffer=4
+;opcache.interned_strings_buffer=4
+opcache.interned_strings_buffer=16
 
 ; The maximum number of keys (scripts) in the OPcache hash table
 ; Only numbers between 200 and 100000 are allowed
-opcache.max_accelerated_files=20000
+;opcache.max_accelerated_files=20000
+opcache.max_accelerated_files=7963
 
 ; The maximum percentage of "wasted" memory until a restart is scheduled
 ;opcache.max_wasted_percentage=5
@@ -1872,12 +1874,14 @@ opcache.max_accelerated_files=20000
 
 ; When disabled, you must reset the OPcache manually or restart the
 ; webserver for changes to the filesystem to take effect
-opcache.validate_timestamps=1
+;opcache.validate_timestamps=1
+opcache.validate_timestamps=0
 
 ; How often (in seconds) to check file timestamps for changes to the shared
 ; memory storage allocation. ("1" means validate once per second, but only
 ; once per request. "0" means always validate)
-opcache.revalidate_freq=30
+;opcache.revalidate_freq=30
+opcache.revalidate_freq=0
 
 ; Enables or disables file search in include_path optimization
 ;opcache.revalidate_path=0
@@ -1893,6 +1897,7 @@ opcache.revalidate_freq=30
 
 ; If enabled, a fast shutdown sequence is used for the accelerated code
 ;opcache.fast_shutdown=0
+opcache.fast_shutdown=1
 
 ; Allow file existence override (file_exists, etc.) performance feature.
 ;opcache.enable_file_override=0


### PR DESCRIPTION
Changes to the php.ini to optimize PHP's Opcache

Introduces new config called 'm_mode' (default 'production').
meza mode (development or production)
1. production being as performant and secure as possible
1. development being less secure and providing optional features useful for dev