### PR TITLE
Hotfix last commit: need meza_core_extensions even when not doing latest

### DIFF
--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -80,18 +80,14 @@
     file: "{{ m_config_core }}/MezaCoreExtensions.yml"
     name: meza_core_extensions
   tags:
-    - git-extensions
-    - git-core-extensions
-    - latest
+    - always
 
 - name: Set variable holding list of local extensions
   include_vars:
     file: "{{ m_local_public }}/MezaLocalExtensions.yml"
     name: meza_local_extensions
   tags:
-    - git-extensions
-    - git-core-extensions
-    - latest
+    - always
 
 - name: Ensure core meza extensions installed (non-Composer)
   git:


### PR DESCRIPTION
Fixes issue from #947, which applied tags (e.g. `latest`) to including `meza_core_extensions.yml` and `meza_local_extensions.yml`. However, if `--skip-tags latest` is used, this will cause these files not to be included, which has effects other than just pulling new versions. Instead, this PR switches the tags to `always` for including these files. This is pretty minimal efficiency loss.