### PR TITLE
Set specific version of Extension:ReplaceText (v1.4)

### DIFF
--- a/config/core/MezaCoreExtensions.yml
+++ b/config/core/MezaCoreExtensions.yml
@@ -111,7 +111,7 @@ list:
     version: "{{ mediawiki_default_branch }}"
   - name: ReplaceText
     repo: https://gerrit.wikimedia.org/r/mediawiki/extensions/ReplaceText.git
-    version: "{{ mediawiki_default_branch }}"
+    version: tags/1.4
   - name: Interwiki
     repo: https://gerrit.wikimedia.org/r/mediawiki/extensions/Interwiki.git
     version: "{{ mediawiki_default_branch }}"


### PR DESCRIPTION
Extension:ReplaceText was set to default meza version, tracking branch `REL1_27`. We want features from the new `1.4` tag.