### PR TITLE
NEW option to disable and not use the local firewall

### DIFF
--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -78,6 +78,11 @@ m_force_debug: false
 
 enable_wiki_emails: true
 
+# Do NOT turn this off unless you are behind another firewall
+# Or using a local setup like Vagrant
+# Should this instance enable it's own firewall?
+m_firewall_enabled: true
+
 enable_haproxy_stats: false
 haproxy_stats_user: admin
 haproxy_stats_password: password

--- a/src/playbooks/site.yml
+++ b/src/playbooks/site.yml
@@ -98,11 +98,13 @@
       firewalld_protocol: tcp
       firewalld_servers: "{{ groups['app-servers'] }}"
       firewalld_zone: "{{m_private_networking_zone|default('public')}}"
+      when: m_firewall_enabled
     - role: firewalld
       firewalld_port: 8081
       firewalld_protocol: tcp
       firewalld_servers: "{{ groups['parsoid-servers'] }}"
       firewalld_zone: "{{m_private_networking_zone|default('public')}}"
+      when: m_firewall_enabled
     # NOTE: firewalld ports 80 and 443 opened to ALL within haproxy role
     - haproxy
 
@@ -117,17 +119,19 @@
       firewalld_protocol: tcp
       firewalld_servers: "{{ groups['load-balancers'] }}"
       firewalld_zone: "{{m_private_networking_zone|default('public')}}"
+      when: m_firewall_enabled
     - role: firewalld
       firewalld_port: 8080
       firewalld_protocol: tcp
       firewalld_servers: "{{ groups['load-balancers-unmanaged'] }}"
       firewalld_zone: "{{m_private_networking_zone|default('public')}}"
-      when: "'load-balancers-unmanaged' in groups"
+      when: m_firewall_enabled and "'load-balancers-unmanaged' in groups"
     - role: firewalld
       firewalld_port: 8080
       firewalld_protocol: tcp
       firewalld_servers: "{{ groups['parsoid-servers'] }}"
       firewalld_zone: "{{m_private_networking_zone|default('public')}}"
+      when: m_firewall_enabled
     - base-extras
     - imagemagick
     - apache-php
@@ -156,13 +160,13 @@
       firewalld_protocol: tcp
       firewalld_servers: "{{ groups['app-servers'] }}"
       firewalld_zone: "{{m_private_networking_zone|default('public')}}"
-      when: "groups['app-servers']|length|int > 1"
+      when: m_firewall_enabled and "groups['app-servers']|length|int > 1"
     - role: firewalld
       firewalld_port: 111
       firewalld_protocol: udp
       firewalld_servers: "{{ groups['app-servers'] }}"
       firewalld_zone: "{{m_private_networking_zone|default('public')}}"
-      when: "groups['app-servers']|length|int > 1"
+      when: m_firewall_enabled and "groups['app-servers']|length|int > 1"
 
     # All gluster servers, Gluster Daemon
     # maybe also: 24009, 24010, 24011
@@ -181,13 +185,13 @@
       firewalld_protocol: tcp
       firewalld_servers: "{{ groups['app-servers'] }}"
       firewalld_zone: "{{m_private_networking_zone|default('public')}}"
-      when: "groups['app-servers']|length|int > 1"
+      when: m_firewall_enabled and "groups['app-servers']|length|int > 1"
     - role: firewalld
       firewalld_port: 24008
       firewalld_protocol: tcp
       firewalld_servers: "{{ groups['app-servers'] }}"
       firewalld_zone: "{{m_private_networking_zone|default('public')}}"
-      when: "groups['app-servers']|length|int > 1"
+      when: m_firewall_enabled and "groups['app-servers']|length|int > 1"
 
     # One port required for each brick (in meza, this equals each server (one
     # brick per server))
@@ -196,25 +200,25 @@
       firewalld_protocol: tcp
       firewalld_servers: "{{ groups['app-servers'] }}"
       firewalld_zone: "{{m_private_networking_zone|default('public')}}"
-      when: "groups['app-servers']|length|int > 1"
+      when: m_firewall_enabled and "groups['app-servers']|length|int > 1"
     - role: firewalld
       firewalld_port: 49153
       firewalld_protocol: tcp
       firewalld_servers: "{{ groups['app-servers'] }}"
       firewalld_zone: "{{m_private_networking_zone|default('public')}}"
-      when: "groups['app-servers']|length|int > 1"
+      when: m_firewall_enabled and "groups['app-servers']|length|int > 1"
     - role: firewalld
       firewalld_port: 49154
       firewalld_protocol: tcp
       firewalld_servers: "{{ groups['app-servers'] }}"
       firewalld_zone: "{{m_private_networking_zone|default('public')}}"
-      when: "groups['app-servers']|length|int > 1"
+      when: m_firewall_enabled and "groups['app-servers']|length|int > 1"
     - role: firewalld
       firewalld_port: 49155
       firewalld_protocol: tcp
       firewalld_servers: "{{ groups['app-servers'] }}"
       firewalld_zone: "{{m_private_networking_zone|default('public')}}"
-      when: "groups['app-servers']|length|int > 1"
+      when: m_firewall_enabled and "groups['app-servers']|length|int > 1"
 
     # FIXME #801: Some docs said ports 38465, 38466, 38467 needed for Gluster
 
@@ -232,6 +236,7 @@
       firewalld_protocol: tcp
       firewalld_servers: "{{ groups['app-servers'] }}"
       firewalld_zone: "{{m_private_networking_zone|default('public')}}"
+      when: m_firewall_enabled
     - memcached
 
 - hosts: db-master
@@ -243,10 +248,12 @@
       firewalld_service: mysql
       firewalld_servers: "{{ groups['app-servers'] }}"
       firewalld_zone: "{{m_private_networking_zone|default('public')}}"
+      when: m_firewall_enabled
     - role: firewalld
       firewalld_service: mysql
       firewalld_servers: "{{ groups['db-slaves'] }}"
       firewalld_zone: public
+      when: m_firewall_enabled
     - role: database
       # Get the one and only server that should be in the db-master group and set
       # it's IP address as replication master IP. Note that this can be left blank
@@ -265,6 +272,7 @@
       firewalld_service: mysql
       firewalld_servers: "{{ groups['app-servers'] }}"
       firewalld_zone: "{{m_private_networking_zone|default('public')}}"
+      when: m_firewall_enabled
     - role: database
       # Get the one and only server that should be in the db-master group and set
       # it's IP address as replication master IP. Note that this can be left blank
@@ -283,21 +291,25 @@
       firewalld_protocol: tcp
       firewalld_servers: "{{ groups['app-servers'] }}"
       firewalld_zone: "{{m_private_networking_zone|default('public')}}"
+      when: m_firewall_enabled
     - role: firewalld
       firewalld_port: 9300
       firewalld_protocol: tcp
       firewalld_servers: "{{ groups['app-servers'] }}"
       firewalld_zone: "{{m_private_networking_zone|default('public')}}"
+      when: m_firewall_enabled
     - role: firewalld
       firewalld_port: 9200
       firewalld_protocol: tcp
       firewalld_servers: "{{ groups['elastic-servers'] }}"
       firewalld_zone: "{{m_private_networking_zone|default('public')}}"
+      when: m_firewall_enabled
     - role: firewalld
       firewalld_port: 9300
       firewalld_protocol: tcp
       firewalld_servers: "{{ groups['elastic-servers'] }}"
       firewalld_zone: "{{m_private_networking_zone|default('public')}}"
+      when: m_firewall_enabled
     - elasticsearch
 
 # Note: this is app-servers again, but must be after everything else is setup
@@ -323,17 +335,19 @@
       firewalld_protocol: tcp
       firewalld_servers: "{{ groups['app-servers'] }}"
       firewalld_zone: "{{m_private_networking_zone|default('public')}}"
+      when: m_firewall_enabled
     - role: firewalld
       firewalld_port: 8000
       firewalld_protocol: tcp
       firewalld_servers: "{{ groups['load-balancers'] }}"
       firewalld_zone: "{{m_private_networking_zone|default('public')}}"
+      when: m_firewall_enabled
     - role: firewalld
       firewalld_port: 8000
       firewalld_protocol: tcp
       firewalld_servers: "{{ groups['load-balancers-unmanaged'] }}"
       firewalld_zone: "{{m_private_networking_zone|default('public')}}"
-      when: "'load-balancers-unmanaged' in groups"
+      when: m_firewall_enabled and "'load-balancers-unmanaged' in groups"
     - nodejs
     - parsoid
     - parsoid-settings
@@ -355,4 +369,3 @@
     - set-vars
     - role: cron
       when: docker_skip_tasks is not defined or not docker_skip_tasks
- 

--- a/src/roles/apache-php/tasks/profiling.yml
+++ b/src/roles/apache-php/tasks/profiling.yml
@@ -84,6 +84,7 @@
     firewalld_protocol: tcp
     firewalld_servers: "{{ groups['app-servers'] }}"
     firewalld_zone: "{{m_private_networking_zone|default('public')}}"
+  when: m_firewall_enabled
 
 - name: Open port 8089 to load balancer
   include_role:
@@ -94,3 +95,4 @@
     firewalld_protocol: tcp
     firewalld_servers: "{{ groups['load-balancers'] }}"
     firewalld_zone: "{{m_private_networking_zone|default('public')}}"
+  when: m_firewall_enabled

--- a/src/roles/base/tasks/main.yml
+++ b/src/roles/base/tasks/main.yml
@@ -118,7 +118,6 @@
     - vim
     - git
     - net-tools
-    - firewalld
     - selinux-policy
     - rsyslog
     - jq
@@ -127,6 +126,14 @@
   tags:
   - latest
 
+- name: Install firewall packages
+  yum: name={{item}} state=installed
+  with_items:
+    - firewalld
+  tags:
+  - latest
+  when: m_firewall_enabled
+
 - name: put SELinux in permissive mode
   selinux:
     policy: targeted
@@ -134,7 +141,7 @@
 
 - name: ensure firewalld is running (and enable it at boot)
   service: name=firewalld state=started enabled=yes
-  when: docker_skip_tasks is not defined or not docker_skip_tasks
+  when: m_firewall_enabled and (docker_skip_tasks is not defined or not docker_skip_tasks)
 
 
 #

--- a/src/roles/firewalld/tasks/main.yml
+++ b/src/roles/firewalld/tasks/main.yml
@@ -62,7 +62,7 @@
     zone: "{{firewalld_zone|default('public')}}"
   # strip "localhost" or inventory_hostname from list of servers to configure
   with_items: "{{ firewalld_servers | difference([ 'localhost', inventory_hostname ]) }}"
-  when: firewalld_service is defined and (docker_skip_tasks is not defined or not docker_skip_tasks)
+  when: m_firewall_enabled and firewalld_service is defined and (docker_skip_tasks is not defined or not docker_skip_tasks)
 
 - name: set firewalld allow port {{ firewalld_port }} for list of servers
   firewalld:
@@ -73,4 +73,4 @@
     zone: "{{firewalld_zone|default('public')}}"
   # strip "localhost" or inventory_hostname from list of servers to configure
   with_items: "{{ firewalld_servers | difference([ 'localhost', inventory_hostname ]) }}"
-  when: firewalld_port is defined and firewalld_protocol is defined and (docker_skip_tasks is not defined or not docker_skip_tasks)
+  when: m_firewall_enabled and firewalld_port is defined and firewalld_protocol is defined and (docker_skip_tasks is not defined or not docker_skip_tasks)

--- a/src/roles/haproxy/tasks/main.yml
+++ b/src/roles/haproxy/tasks/main.yml
@@ -210,7 +210,7 @@
   with_items:
     - 80
     - 443
-  when: docker_skip_tasks is not defined or not docker_skip_tasks
+  when: m_firewall_enabled and (docker_skip_tasks is not defined or not docker_skip_tasks)
 
 - name: Ensure firewalld port 1936 OPEN when haproxy stats ENABLED
   firewalld:
@@ -219,7 +219,7 @@
     immediate: true
     state: enabled
     zone: "{{m_public_networking_zone|default('public')}}"
-  when: enable_haproxy_stats and (docker_skip_tasks is not defined or not docker_skip_tasks)
+  when: m_firewall_enabled and enable_haproxy_stats and (docker_skip_tasks is not defined or not docker_skip_tasks)
 
 - name: Ensure firewalld port 1936 CLOSED when haproxy stats DISABLED
   firewalld:
@@ -228,7 +228,7 @@
     immediate: true
     state: disabled
     zone: "{{m_public_networking_zone|default('public')}}"
-  when: not enable_haproxy_stats and (docker_skip_tasks is not defined or not docker_skip_tasks)
+  when: m_firewall_enabled and not enable_haproxy_stats and (docker_skip_tasks is not defined or not docker_skip_tasks)
 
 - name: Ensure firewalld port 8088 OPEN when PHP profiling ENABLED
   firewalld:
@@ -237,7 +237,7 @@
     immediate: true
     state: enabled
     zone: "{{m_public_networking_zone|default('public')}}"
-  when: m_setup_php_profiling and (docker_skip_tasks is not defined or not docker_skip_tasks)
+  when: m_firewall_enabled and m_setup_php_profiling and (docker_skip_tasks is not defined or not docker_skip_tasks)
 
 - name: Ensure firewalld port 8088 CLOSED when PHP profiling DISABLED
   firewalld:
@@ -246,7 +246,7 @@
     immediate: true
     state: disabled
     zone: "{{m_public_networking_zone|default('public')}}"
-  when: not m_setup_php_profiling and (docker_skip_tasks is not defined or not docker_skip_tasks)
+  when: m_firewall_enabled and (not m_setup_php_profiling and (docker_skip_tasks is not defined or not docker_skip_tasks))
 
 
 # FIXME #747: haproxy will need to handle reverse proxy for Elasticsearch plugins

--- a/src/roles/setup-env/templates/hosts.j2
+++ b/src/roles/setup-env/templates/hosts.j2
@@ -10,6 +10,12 @@ localhost ansible_connection=local
 {{ server }}
 {% endfor %}
 
+# optional: load balancers that our firewall should know about; but not manage
+[load-balancers-unmanaged]
+{% for server in load_balancers_unmanaged %}
+{{ server }}
+{% endfor %}
+
 [app-servers]
 {% for server in app_servers %}
 {{ server }}
@@ -47,5 +53,11 @@ localhost ansible_connection=local
 
 [logging-servers]
 {% for server in logging_servers %}
+{{ server }}
+{% endfor %}
+
+# optional: servers you might manage, but never want meza to touch
+[exclude-all]
+{% for server in exclude_all %}
 {{ server }}
 {% endfor %}

--- a/src/scripts/meza.py
+++ b/src/scripts/meza.py
@@ -202,7 +202,8 @@ def meza_command_setup_env (argv, return_not_exit=False):
 
 
 	server_types = ['load_balancers','app_servers','memcached_servers',
-		'db_slaves','parsoid_servers','elastic_servers','backup_servers','logging_servers']
+		'db_slaves','parsoid_servers','elastic_servers','backup_servers','logging_servers',
+		'load_balancers_unmanaged','exclude_all']
 
 
 	for stype in server_types:


### PR DESCRIPTION
This branch is based off enterprisemediawiki/master, and introduces a new option to disable the firewall completely. The option **m_firewall_enabled** is set to **true** by default.

### Issues

* In some environments, notably Amazon AWS, you may have a firewall that you can't interact with in a friendly or coherent way. By disabling the internal firewall, application servers will stay "lit" through a deploy whereas previously the only work-around was to go "dark" during the whole deploy and then shut off the firewall as the last play.

