### PR TITLE
Fix for generating SSH keys for vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@ require 'yaml'
 
 if not File.file?("#{File.dirname(__FILE__)}/.vagrant/id_rsa")
   system("
-    ssh-keygen -f './.vagrant/id_rsa' -t rsa -N '' -C 'vagrant@vagrant'
+    ssh-keygen -f \"./.vagrant/id_rsa\" -t rsa -N \"\" -C \"vagrant@vagrant\"
   ")
 end
 


### PR DESCRIPTION
On first `vagrant up` it needs to generate SSH keys. Something changed in Vagrant regarding quoting.