### PR TITLE
Allow specifying timezone

### DIFF
--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -65,6 +65,7 @@ m_db_replication_log_file: /opt/data-meza/db_master_log_file
 m_db_replication_log_pos: /opt/data-meza/db_master_log_pos
 
 
+m_timezone: "America/Chicago"
 
 meza_server_log_db: meza_server_log
 

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -556,7 +556,7 @@ $wgDefaultUserOptions['watchcreations'] = 1;
 $wgDisableCookieCheck = true;
 
 #Set Default Timezone
-$wgLocaltimezone = "America/Chicago";
+$wgLocaltimezone = '{{ m_timezone }}';
 $oldtz = getenv("TZ");
 putenv("TZ=$wgLocaltimezone");
 


### PR DESCRIPTION
Allow specifying timezone with `m_timezone`. This supersedes #925. Also, this content is part of the mega-commit b19011ca3b12aebf1bebd6ee977b70c6d8871553, but that is not yet part of `master`. 

Example:

```yaml
m_timezone: "America/New_York"
```