### PR TITLE
Fix for error in Travis CI due to temp dir permissions

### DIFF
--- a/config/core/ansible.cfg
+++ b/config/core/ansible.cfg
@@ -24,3 +24,5 @@ stdout_callback = debug
 ; Connect to one remote/parallel process at a time if you run out of memory
 ; using <= 2GB RAM host
 ; forks = 1
+
+remote_tmp = /tmp/${USER}/ansible


### PR DESCRIPTION
Error was:


> Authentication or permission failure. In some cases, you may have been able to
authenticate and did not have permissions on the target directory. Consider
changing the remote tmp path in ansible.cfg to a path rooted in "/tmp". Failed
command was: ( umask 77 && mkdir -p "` echo
~None/.ansible/tmp/ansible-tmp-1528404466.59-59697674326589 `" && echo
ansible-tmp-1528404466.59-59697674326589="` echo
~None/.ansible/tmp/ansible-tmp-1528404466.59-59697674326589 `" ), exited with
result 1

Ref: https://travis-ci.org/enterprisemediawiki/meza/jobs/389426664#L2839

Source of fix: https://github.com/ansible/ansible/issues/5725#issuecomment-118381617
