### PR TITLE
Allow skipping wikis when performing an overwrite backup

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,7 +28,7 @@ Vagrant.configure("2") do |config|
 
     config.vm.define "app2" do |app2|
 
-      app2.vm.box = "bento/centos-7.3"
+      app2.vm.box = "bento/centos-7.4"
       app2.vm.hostname = 'app2'
 
       app2.vm.network :private_network, ip: "192.168.56.57"
@@ -79,7 +79,7 @@ Vagrant.configure("2") do |config|
 
     config.vm.define "db2" do |db2|
 
-      db2.vm.box = "bento/centos-7.3"
+      db2.vm.box = "bento/centos-7.4"
       db2.vm.hostname = 'db2'
 
       db2.vm.network :private_network, ip: "192.168.56.58"
@@ -128,7 +128,7 @@ Vagrant.configure("2") do |config|
   config.vm.define "app1", primary: true do |app1|
 
     # app1.vm.box = "centos/7"
-    app1.vm.box = "bento/centos-7.3"
+    app1.vm.box = "bento/centos-7.4"
     # app1.vm.box = "geerlingguy/centos7"
     app1.vm.hostname = 'app1'
     # app1.vm.box_url = "ubuntu/precise64"

--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -75,6 +75,13 @@ m_language: en
 
 allow_backup_downloads: false
 
+# Allow skipping certain wikis when doing backups
+# Example:
+# wikis_to_skip_overwrite
+#   - mywiki
+#   - yourwiki
+wikis_to_skip_overwrite: []
+
 m_force_debug: false
 
 enable_wiki_emails: true

--- a/src/roles/verify-wiki/tasks/main.yml
+++ b/src/roles/verify-wiki/tasks/main.yml
@@ -117,12 +117,12 @@
 - name: "{{ wiki_id }} - Set fact if INTEND overwrite data"
   set_fact:
     intend_overwrite_from_backup: True
-  when: force_overwrite_from_backup is defined and force_overwrite_from_backup == true
+  when: force_overwrite_from_backup is defined and force_overwrite_from_backup == true and wiki_id not in wikis_to_skip_overwrite
 
 - name: "{{ wiki_id }} - Set fact if NOT INTEND overwrite data"
   set_fact:
     intend_overwrite_from_backup: False
-  when: force_overwrite_from_backup is not defined or force_overwrite_from_backup == false
+  when: (force_overwrite_from_backup is not defined or force_overwrite_from_backup == false) or wiki_id in wikis_to_skip_overwrite
 
 
 #


### PR DESCRIPTION
### Changes

* Provide method to skip wikis when doing an `--overwrite` backup
* Bump Vagrant version of CentOS from 7.3 to 7.4

To skip wikis `iss` and `demo`, add the following to `public.yml`:

```yaml
wikis_to_skip_overwrite:
- iss
- demo
```

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Update documentation at https://www.mediawiki.org/wiki/Meza
