### PR TITLE
Wiki ID redirects/aliases

### DIFF
--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -82,6 +82,14 @@ allow_backup_downloads: false
 #   - yourwiki
 wikis_to_skip_overwrite: []
 
+# Allow redirecting wiki IDs to other wikis. This is useful if if wikis are renamed or merged.
+# Example:
+# wiki_id_redirects:
+#   eva: iss
+#   oso: iss
+#   robo: iss
+wiki_id_redirects: {}
+
 m_force_debug: false
 
 enable_wiki_emails: true

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -59,6 +59,33 @@ else {
 
 }
 
+
+{% if wiki_id_redirects is defined and wiki_id_redirects|length > 0 %}
+
+// array point wiki IDs to redirect from and to
+$wikiIdRedirects = [
+{% for from_id, to_id in wiki_id_redirects.items() %}
+	'{{ from_id }}' => '{{ to_id }}',
+{% endfor %}
+];
+
+// check if current wiki ID is a key in this array, and thus should redirect to another wiki
+if ( isset( $wikiIdRedirects[ $wikiId ] ) ) {
+
+        $newURI = preg_replace(
+		"/^\/([\w\d-_]+)/",
+		'/' . $wikiIdRedirects[$wikiId],
+		$_SERVER['REQUEST_URI']
+	);
+
+	// Redirect to target wiki with 301 code
+	header( 'Location: https://{{ wiki_app_fqdn }}' . $newURI , true, 301 );
+	exit;
+}
+{% endif %}
+
+
+
 // get all directory names in /wikis, minus the first two: . and ..
 $wikis = array_slice( scandir( "$m_htdocs/wikis" ), 2 );
 


### PR DESCRIPTION
### Changes

Allow specifying `wiki_id_redirects` like:

```yaml
wiki_id_redirects:
  someid: demo
  fake: real
```

This redirects `https://yourdomain.example.com/someid` to `https://yourdomain.example.com/demo`. Likewikewise for `fake` to `real`.

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Update documentation at https://www.mediawiki.org/wiki/Meza
