### PR TITLE
Fix for combination of MSSQL driver and autofs filesystem for /home

### DIFF
--- a/src/roles/apache-php/tasks/main.yml
+++ b/src/roles/apache-php/tasks/main.yml
@@ -29,6 +29,13 @@
   notify:
   - restart apache
 
+- name: Ensure Apache environment variables set properly
+  template:
+    src: etc-sysconfig-httpd.j2
+    dest: /etc/sysconfig/httpd
+  notify:
+    - restart apache
+
 - name: Install PHP
   include: php.yml
   # http://docs.ansible.com/ansible/playbooks_roles.html#dynamic-versus-static-includes

--- a/src/roles/apache-php/templates/etc-sysconfig-httpd.j2
+++ b/src/roles/apache-php/templates/etc-sysconfig-httpd.j2
@@ -1,0 +1,39 @@
+#
+# This file can be used to set additional environment variables for
+# the httpd process, or pass additional options to the httpd
+# executable.
+#
+# Note: With previous versions of httpd, the MPM could be changed by
+# editing an "HTTPD" variable here.  With the current version, that
+# variable is now ignored.  The MPM is a loadable module, and the
+# choice of MPM can be changed by editing the configuration file
+# /etc/httpd/conf.modules.d/00-mpm.conf.
+#
+
+#
+# To pass additional options (for instance, -D definitions) to the
+# httpd binary at startup, set OPTIONS here.
+#
+#OPTIONS=
+
+#
+# This setting ensures the httpd process is started in the "C" locale
+# by default.  (Some modules will not behave correctly if
+# case-sensitive string comparisons are performed in a different
+# locale.)
+#
+LANG=C
+
+
+#
+# This is required by Meza when using MSSQL Server Drivers [1] and if using
+# autofs to mount /home directories. The UnixODBC driver otherwise looks for the
+# file /home/.odbcinst.ini, and autofs will try to mount that file and creates a
+# long lag that can cause `systemctl start httpd` to timeout. Ref [2]. This
+# likely becomes obsolete when #750 [3] is closed
+#
+# [1] https://github.com/Microsoft/msphpsql
+# [2] https://github.com/Microsoft/msphpsql/issues/805
+# [3] https://github.com/enterprisemediawiki/meza/issues/750
+#
+HOME=/usr/share/httpd


### PR DESCRIPTION
Make sure systemd has a valid `$HOME` for Apache.

### Changes

Makes sure `$HOME` is set to a valid directory when running `systemctl (re)start httpd`. Without this, it appears that `$HOME` is set to `/home` by systemd. In most circumstances this has no impact, but when using the [Microsoft SQL Server driver for PHP](https://github.com/Microsoft/msphpsql) (aka SQLSRV) _AND_ if [autofs](https://wiki.archlinux.org/index.php/autofs) is used to manage users' home directories then a conflict can occur. SQLSRV will then look for the systemd user's `odbcinst.ini` file in `/home/.odbcinst.ini`, and because it doesn't exist `autofs` will attempt to mount it. Depending on autofs settings, this could lead to a very long lag (~2 minutes in one case). This autofs lag can cause `systemctl (re)start httpd` to timeout. 

### Issues

* Ref: Microsoft/msphpsql#805

### Post-merge actions

None
