### PR TITLE
Allow adding core and additional Mediawiki skins.

### DIFF
--- a/config/core/MezaCoreSkins.yml
+++ b/config/core/MezaCoreSkins.yml
@@ -1,0 +1,22 @@
+---
+list:
+
+- name: Vector
+  repo: https://gerrit.wikimedia.org/r/p/mediawiki/skins/Vector.git
+  type: skins
+  version: "{{ mediawiki_default_branch }}"
+
+- name: Modern
+  repo: https://gerrit.wikimedia.org/r/p/mediawiki/skins/Modern.git
+  type: skins
+  version: "{{ mediawiki_default_branch }}"
+
+- name: CologneBlue
+  repo: https://gerrit.wikimedia.org/r/p/mediawiki/skins/CologneBlue.git
+  type: skins
+  version: "{{ mediawiki_default_branch }}"
+
+- name: MonoBook
+  repo: https://gerrit.wikimedia.org/r/p/mediawiki/skins/MonoBook.git
+  type: skins
+  version: "{{ mediawiki_default_branch }}"

--- a/config/core/MezaCoreSkins.yml
+++ b/config/core/MezaCoreSkins.yml
@@ -6,17 +6,21 @@ list:
   type: skins
   version: "{{ mediawiki_default_branch }}"
 
-- name: Modern
-  repo: https://gerrit.wikimedia.org/r/p/mediawiki/skins/Modern.git
-  type: skins
-  version: "{{ mediawiki_default_branch }}"
-
-- name: CologneBlue
-  repo: https://gerrit.wikimedia.org/r/p/mediawiki/skins/CologneBlue.git
-  type: skins
-  version: "{{ mediawiki_default_branch }}"
-
-- name: MonoBook
-  repo: https://gerrit.wikimedia.org/r/p/mediawiki/skins/MonoBook.git
-  type: skins
-  version: "{{ mediawiki_default_branch }}"
+# 
+# If you'd like to use any of these skins it is recommended that these lines
+# be placed in /opt/conf-public/public/MezaLocalSkins.yml
+#
+#- name: Modern
+#  repo: https://gerrit.wikimedia.org/r/p/mediawiki/skins/Modern.git
+#  type: skins
+#  version: "{{ mediawiki_default_branch }}"
+#
+#- name: CologneBlue
+#  repo: https://gerrit.wikimedia.org/r/p/mediawiki/skins/CologneBlue.git
+#  type: skins
+#  version: "{{ mediawiki_default_branch }}"
+#
+#- name: MonoBook
+#  repo: https://gerrit.wikimedia.org/r/p/mediawiki/skins/MonoBook.git
+#  type: skins
+#  version: "{{ mediawiki_default_branch }}"

--- a/config/core/MezaCoreSkins.yml
+++ b/config/core/MezaCoreSkins.yml
@@ -8,7 +8,7 @@ list:
 
 # 
 # If you'd like to use any of these skins it is recommended that these lines
-# be placed in /opt/conf-public/public/MezaLocalSkins.yml
+# be placed in /opt/conf-meza/public/MezaLocalSkins.yml
 #
 #- name: Modern
 #  repo: https://gerrit.wikimedia.org/r/p/mediawiki/skins/Modern.git

--- a/src/roles/init-controller-config/tasks/main.yml
+++ b/src/roles/init-controller-config/tasks/main.yml
@@ -102,4 +102,5 @@
   run_once: true
   with_items:
     - MezaLocalExtensions.yml
+    - MezaLocalSkins.yml
     - public.yml

--- a/src/roles/init-controller-config/templates/MezaLocalSkins.yml.j2
+++ b/src/roles/init-controller-config/templates/MezaLocalSkins.yml.j2
@@ -1,0 +1,25 @@
+---
+list: []
+  # To add skins to this file, first remove the [] from the line above,
+  # then define a skins as follows:
+  #
+  # - name: Tweeki
+  #   repo: https://github.com/djflux/Tweeki.git
+  #   type: skins
+  #   version: master
+  #
+  # - name: Modern
+  #   repo: https://gerrit.wikimedia.org/r/p/mediawiki/skins/Modern.git
+  #   type: skins
+  #   version: "{{ mediawiki_default_branch }}"
+  #
+  # - name: CologneBlue
+  #   repo: https://gerrit.wikimedia.org/r/p/mediawiki/skins/CologneBlue.git
+  #   type: skins
+  #   version: "{{ mediawiki_default_branch }}"
+  #
+  # - name: MonoBook
+  #   repo: https://gerrit.wikimedia.org/r/p/mediawiki/skins/MonoBook.git
+  #   type: skins
+  #   version: "{{ mediawiki_default_branch }}"  
+

--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -83,23 +83,22 @@
           ignoreSubmodules = all
 
 #
-# SKINS
+# EXTENSIONS AND SKINS
 #
-# FIXME #819: Add skins in Meza(Core|Local)Extensions.yml
-- name: Ensure Vector skin installed
-  become: yes
-  become_user: "meza-ansible"
-  git:
-    repo: https://gerrit.wikimedia.org/r/p/mediawiki/skins/Vector.git
-    dest: "{{ m_mediawiki }}/skins/Vector"
-    version: "{{ mediawiki_default_branch }}"
-    umask: "0002"
+- name: Set variable holding list of core skins
+  include_vars:
+    file: "{{ m_config_core }}/MezaCoreSkins.yml"
+    name: meza_core_skins
+  tags:
+    - skins
 
+- name: Set variable holding list of local skins
+  include_vars:
+    file: "{{ m_local_public }}/MezaLocalSkins.yml"
+    name: meza_local_skins
+  tags:
+    - skins
 
-
-#
-# EXTENSIONS
-#
 - name: Set variable holding list of core extensions
   include_vars:
     file: "{{ m_config_core }}/MezaCoreExtensions.yml"
@@ -129,6 +128,17 @@
   tags:
     - always
 
+- name: Ensure core meza skins installed (non-Composer)
+  git:
+    repo: "{{ item.repo }}"
+    dest: "{{ m_mediawiki }}/skins/{{ item.name }}"
+    version: "{{ item.version }}"
+  with_items: "{{ meza_core_skins.list }}"
+  when: meza_core_skins.list[0] is defined and item.repo is defined
+  tags:
+    - skins
+    - core-skins
+
 - name: Ensure local meza extensions installed (non-Composer)
   become: yes
   become_user: "meza-ansible"
@@ -145,7 +155,19 @@
     - git-local-extensions
     - latest
 
+- name: Ensure local meza skins installed (non-Composer)
+  git:
+    repo: "{{ item.repo }}"
+    dest: "{{ m_mediawiki }}/skins/{{ item.name }}"
+    version: "{{ item.version }}"
+  with_items: "{{ meza_local_skins.list }}"
+  when: meza_local_skins.list[0] is defined and item.repo is defined
+  tags:
+    - skins
+    - local-skins
+
 # File holding extension loading and config for core and local extensions
+# as well as core and local skins
 - name: Ensure Extensions.php in place
   template:
     src: Extensions.php.j2
@@ -153,8 +175,8 @@
     owner: meza-ansible
     group: wheel
 
-# Adds extensions with composer param from MezaCoreExtensions.yml and
-# MezaLocalExtensions.yml
+# Adds extensions with composer param from MezaCoreExtensions.yml,
+# MezaLocalExtensions.yml, MezaCoreSkins.yml, and MezaLocalSkins.yml
 - name: Ensure composer.local.json in place to load composer-based extensions
   template:
     src: composer.local.json.j2
@@ -174,6 +196,7 @@
   tags:
     - composer-extensions
     - latest
+    - skins
 
 # install doesn't appear to do extensions
 - name: Run composer update on MediaWiki for extensions
@@ -188,6 +211,7 @@
   tags:
     - composer-extensions
     - latest
+    - skins
 
 - name: Ensure Git submodule requirements met for core meza extensions
   become: yes
@@ -213,7 +237,29 @@
     - git-submodules
     - latest
 
+# Are there skins that have submodules?
+- name: Ensure Git submodule requirements met for core meza skins
+  shell: |
+    cd "{{ m_mediawiki }}/skins/{{ item.name }}"
+    git submodule update --init
+  with_items: "{{ meza_core_skins.list }}"
+  when: meza_core_skins.list[0] is defined and item.git_submodules is defined and item.git_submodules == True
+  tags:
+    - git-submodules
+    - skins
+    - latest
 
+- name: Ensure Git submodule requirements met for local meza skins
+  shell: |
+    cd "{{ m_mediawiki }}/skins/{{ item.name }}"
+    git submodule update --init
+  with_items: "{{ meza_local_skins.list }}"
+  when: meza_local_skins.list[0] is defined and item.git_submodules is defined and item.git_submodules == True
+  tags:
+    - git-submodules
+    - skins
+    - local-skins
+    - latest
 
 #
 # LocalSettings.php

--- a/src/roles/mediawiki/templates/Extensions.php.j2
+++ b/src/roles/mediawiki/templates/Extensions.php.j2
@@ -19,6 +19,22 @@
 
 {% endfor %}
 
+/**
+ *  SECTION: CORE MEZA COMPOSER SKINS
+ *
+ *  Below is configuration for skins installed by Composer, which are part
+ *  of core meza. Further down the document is a section for Composer-installed
+ *  local skins config.
+ **/
+{% for ext in meza_core_skins['list'] if ext.composer is defined and ext.config is defined %}
+
+#
+# Config for Skin:{{ ext.name }}
+#
+{{ ext.config }}
+
+{% endfor %}
+
 
 
 /**
@@ -43,6 +59,26 @@
 {%- endfor %}
 
 
+/**
+ *  SECTION: CORE MEZA STANDARD SKINS
+ *
+ *  Skins below are part of core Meza. Further down in this file there may
+ *  be additional skins specified by this particular installation of meza
+ **/
+{% for ext in meza_core_skins['list'] if ext.composer is not defined %}
+
+{% if ext.legacy_load is defined and ext.legacy_load -%}
+	require_once "$IP/skins/{{ ext.name }}/{{ ext.name }}.php";
+{%- else -%}
+	wfLoadSkin( "{{ ext.name }}" );
+{%- endif -%}
+
+{%- if ext.config is defined %}
+
+{{ ext.config }}
+{%- endif -%}
+
+{%- endfor %}
 
 
 /**
@@ -62,6 +98,21 @@
 {% endfor %}
 
 
+/**
+ *  SECTION: LOCAL MEZA COMPOSER SKINS
+ *
+ *  Below is configuration for skins installed by Composer, which are part
+ *  of this local meza installation. This section may be blank if no Composer
+ *  skins are required for this local installation.
+ **/
+{% for ext in meza_local_skins['list'] if ext.composer is defined and ext.config is defined %}
+
+#
+# Config for Skin:{{ ext.name }}
+#
+{{ ext.config }}
+
+{% endfor %}
 
 
 /**
@@ -83,6 +134,40 @@
 		require_once "$IP/extensions/{{ ext.name }}/{{ ext.name }}.php";
 	{%- else -%}
 		wfLoadExtension( "{{ ext.name }}" );
+	{%- endif -%}
+
+	{%- if ext.config is defined %}
+
+{{ ext.config }}
+	{%- endif -%}
+
+
+{%- if ext.wikis is defined %}
+}
+{%- endif -%}
+
+{%- endfor %}
+
+
+/**
+ *  SECTION: LOCAL MEZA STANDARD SKINS
+ *
+ *  Skins configured by this installation of Meza, but not included in
+ *  core meza. These skins are defined in MezaLocalSkins.yml in
+ *  /opt/conf-meza/public. This section may be blank if no additional skins
+ *  are required for this local installation.
+ **/
+{% for ext in meza_local_skins['list'] if ext.composer is not defined %}
+
+{% if ext.wikis is defined -%}
+	if ( in_array( $wikiId, array( {% for wiki in ext.wikis -%}'{{ wiki}}', {%- endfor -%} ) ) ) {
+{%- endif -%}
+
+
+	{%- if ext.legacy_load is defined and ext.legacy_load -%}
+		require_once "$IP/skins/{{ ext.name }}/{{ ext.name }}.php";
+	{%- else -%}
+		wfLoadSkin( "{{ ext.name }}" );
 	{%- endif -%}
 
 	{%- if ext.config is defined %}

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -514,12 +514,14 @@ $wgRightsIcon = "";
 $wgDiff3 = "/usr/bin/diff3";
 
 ## Default skin: you can change the default skin. Use the internal symbolic
-## names, ie 'vector', 'monobook':
+## names, ie 'vector', 'monobook': see MezaCoreSkins.yml for choices.
 $wgDefaultSkin = "vector";
 
 # Enabled skins.
 # The following skins were automatically enabled:
-wfLoadSkin( 'Vector' );
+# wfLoadSkin( 'Vector' );
+#
+# No need to call wfLoadSkin() as this is handled automatically
 
 // allows users to remove the page title.
 // https://www.mediawiki.org/wiki/Manual:$wgRestrictDisplayTitle

--- a/src/roles/mediawiki/templates/composer.local.json.j2
+++ b/src/roles/mediawiki/templates/composer.local.json.j2
@@ -2,17 +2,23 @@
 	"require": {
 
 		{% for ext in meza_local_extensions['list'] if ext.composer is defined %}
-
 		"{{ ext.composer }}": "{{ ext.version }}",
 		{# Note: no loop.last check: more extensions listed below #}
+		{%- endfor -%}
 
+		{%- for ext in meza_local_skins['list'] if ext.composer is defined %}
+		"{{ ext.composer }}": "{{ ext.version }}",
+		{# Note: no loop.last check: more extensions listed below #}
+		{%- endfor -%}
+
+		{% for ext in meza_core_skins['list'] if ext.composer is defined %}
+		"{{ ext.composer }}": "{{ ext.version }}",
+		{# Note: no loop.last check: more extensions listed below #}
 		{%- endfor -%}
 
 		{%- for ext in meza_core_extensions['list'] if ext.composer is defined %}
-
 		"{{ ext.composer }}": "{{ ext.version }}"
 		{%- if not loop.last -%},{%- endif %}
-
 		{%- endfor %}
 
 	},


### PR DESCRIPTION
This pull request is an update of PR #930. It splits out meza core skins into a `MezaCoreSkins.yml` file. It also provides the ability for an administrator to add additional MediaWiki skins via a `MezaLocalSkins.yml` file. All of this work was original written by @freephile. Thanks for the great work.

### Changes

* MediaWiki core skins are specified in `/opt/meza/config/core/MezaCoreSkins.yml`
* Locally added skins are specified in `/opt/conf-meza/public/MezaLocalSkins.yml`

### Issues

* Closes #819 

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Create https://www.mediawiki.org/wiki/Meza/Installing_additional_skins page with instructions on how to include additional skins
