### PR TITLE
Add python3 for Extension:SyntaxHighlight in MW1.31+

### DIFF
--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -486,3 +486,23 @@
   tags:
   - update.php
   when: docker_skip_tasks is not defined or not docker_skip_tasks
+
+
+# Extension:SyntaxHighlight requires Python 3.x present in path as `python3` for
+# MediaWiki 1.31+.
+- name: Ensure Python3 present
+  yum:
+    name: python35u
+    state: latest
+  tags:
+  - latest
+
+- name: "Ensure python3 symlink in place"
+  file:
+    # dest = symlink, src = dir linked to
+    src: "/usr/bin/python3.5"
+    dest: "/usr/bin/python3"
+    state: link
+    owner: root
+    group: root
+    mode: 0755


### PR DESCRIPTION
### Changes

[Extension:SyntaxHighlight]() requires Python 3 for MediaWiki 1.31+. Python 3.5 added from IUS repository, in path via `python3`. This maintains Python 2.7.x as `python`.

### Issues

* None

### Post-merge actions

Post-merge, the following actions need to be addressed:

- None