### PR TITLE
fix variable wgVisualEditorAvailableNamespaces

### DIFF
--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -865,16 +865,26 @@ $wgVirtualRestConfig['modules']['parsoid'] = array(
 );
 
 // Define which namespaces will use VE
-$wgVisualEditorAvailableNamespaces = array_merge(
-	$wgContentNamespaces,
-	array(
-		NS_USER,
-		NS_HELP,
-		NS_PROJECT
-	)
-);
+// Per the docs, https://www.mediawiki.org/wiki/Extension:VisualEditor#Changing_active_namespaces
+// This is done a little differently in VE than in core or other extensions.
+// For VE, we use an array, keyed by the (string) canonical name of the namespace 
+// and a (boolean) value for enabled or not
 
+// $wgContentNamespaces gets added automatically.
 
+// finally, it should be mentioned that the Extension Registry is what provides for the 
+// merge strategy 
+
+$wgVisualEditorAvailableNamespaces = [
+    "User" => true,
+    "Project" => true,
+    "Help" => true,
+    "_merge_strategy" => "array_plus"
+];
+
+// quickly add a namespace, without figuring out what the merge strategy is
+// $wgVisualEditorAvailableNamespaces[] = NS_CUSTOM; 
+// $wgVisualEditorAvailableNamespaces[] = NS_PROJECT; 
 
 
 

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -865,7 +865,7 @@ $wgVirtualRestConfig['modules']['parsoid'] = array(
 );
 
 // Define which namespaces will use VE
-$wgVisualEditorNamespaces = array_merge(
+$wgVisualEditorAvailableNamespaces = array_merge(
 	$wgContentNamespaces,
 	array(
 		NS_USER,


### PR DESCRIPTION
Some time ago I believe there was a wgVisualEditorNamespaces, however it's not found in the current MW codebase. The correct array variable is $wgVisualEditorAvailableNamespaces (which defaults to $wgContentNamespaces) https://codesearch.wmflabs.org/search/?q=wgVisualEditorAvailableNamespaces&i=nope&files=&repos=

### Changes

A single variable name

### Issues

I want to extend the namespaces, so I discovered that the current setting is not having any effect.

### Post-merge actions

Post-merge, the following actions need to be addressed:

* None that I know of
