### PR TITLE
Make Approved Revs use official repo, v1.0-alpha

### DIFF
--- a/config/core/MezaCoreExtensions.yml
+++ b/config/core/MezaCoreExtensions.yml
@@ -229,9 +229,9 @@ list:
     repo: https://github.com/enterprisemediawiki/Wiretap.git
     version: master
   - name: ApprovedRevs
-    repo: https://github.com/jamesmontalvo3/MediaWiki-ApprovedRevs.git
-    version: master
-    legacy_load: true
+    repo: https://gerrit.wikimedia.org/r/mediawiki/extensions/ApprovedRevs.git
+    # Use this commit until a release tag for v1.0 is created
+    version: 251cf4db3ab99366fa281ea535e725672fa2b6c3
     config: |
       $egApprovedRevsAutomaticApprovals = false;
   - name: ImagesLoaded


### PR DESCRIPTION
Same as  #1001, but for `master` branch. This will be cherry-picked to `27.x` branch after passing.