### PR TITLE
Specify Extension:HeaderFooter version 2.2.1

### DIFF
--- a/config/core/MezaCoreExtensions.yml
+++ b/config/core/MezaCoreExtensions.yml
@@ -349,7 +349,7 @@ list:
     legacy_load: True
   - name: HeaderFooter
     repo: https://github.com/enterprisemediawiki/HeaderFooter.git
-    version: master
+    version: tags/2.2.1
     legacy_load: True
   - name: NumerAlpha
     repo: https://gerrit.wikimedia.org/r/mediawiki/extensions/NumerAlpha.git


### PR DESCRIPTION
### Changes

* Extension:HeaderFooter was specifying branch `master`. Make it specify the release tag for the tip of that branch (as of this writing) so upgrades to HeaderFooter don't automatically get pulled into Meza.

### Issues

None

### Post-merge actions

Post-merge, the following actions need to be addressed:

- None