### PR TITLE
Show visual diff option on all diff pages

### DIFF
--- a/config/core/MezaCoreExtensions.yml
+++ b/config/core/MezaCoreExtensions.yml
@@ -144,7 +144,11 @@ list:
     config: |
       // Parsoid servers are defined based upon Ansible hosts file and thus
       // cannot be easily added to base-extensions.yml. As such, VisualEditor config
-      // is included directly in LocalSettings.php.j2
+      // is included directly in LocalSettings.php.j2 (mostly)
+
+      // Show visual diff on regular diff pages
+      $wgVisualEditorEnableDiffPage = true;
+
   - name: Elastica
     repo: https://gerrit.wikimedia.org/r/mediawiki/extensions/Elastica.git
     version: "{{ mediawiki_default_branch }}"


### PR DESCRIPTION
### Changes

* VisualEditor has visual diff capability. By setting `$wgVisualEditorEnableDiffPage = true;` this can be added as an option to all diff pages (wikitext diff will still show by default).

### Issues

* None

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Add as awesome feature on https://www.mediawiki.org/wiki/Meza
