### PR TITLE
Bump SimpleSamlPhp from 1.15.4 to 1.16.1

### DIFF
--- a/src/roles/saml/tasks/main.yml
+++ b/src/roles/saml/tasks/main.yml
@@ -4,7 +4,7 @@
   git:
     repo: https://github.com/simplesamlphp/simplesamlphp.git
     dest: "{{ m_simplesamlphp_path }}"
-    version: "tags/v1.15.4"
+    version: "tags/v1.16.1"
     umask: "0002"
   tags:
     - latest


### PR DESCRIPTION
### Changes

* Get latest version of SimpleSamlPhp. Seeing some issues with accessing wikis with Chrome when using SAML. Hoping this will solve it.

### Issues

* None

### Post-merge actions

Post-merge, the following actions need to be addressed:

- None
