### PR TITLE
Bump to MW 1.31.1

### DIFF
--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -136,7 +136,7 @@ use_default_ssh_config: True
 #
 
 # Version of MediaWiki core
-mediawiki_version: "1.31.0"
+mediawiki_version: "1.31.1"
 
 # Branch to use on many extensions extensions and skins
 mediawiki_default_branch: "REL1_31"


### PR DESCRIPTION
### Changes

* Bump MW version from 1.31.0 to 1.31.1 after last night's release.

### Issues

None

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Update versions listed on https://www.mediawiki.org/wiki/Meza
