### PR TITLE
Make Meza control 10-opcache.ini

### DIFF
--- a/src/roles/apache-php/tasks/php.yml
+++ b/src/roles/apache-php/tasks/php.yml
@@ -119,6 +119,15 @@
   notify:
   - restart apache
 
+- name: Write php.d ini files
+  template:
+    src: "{{ item }}.j2"
+    dest: "/etc/php.d/{{ item }}"
+  with_items:
+  - 10-opcache.ini
+  notify:
+  - restart apache
+
 - name: Write freetds.conf file
   template:
     src: freetds.conf.j2

--- a/src/roles/apache-php/templates/10-opcache.ini.j2
+++ b/src/roles/apache-php/templates/10-opcache.ini.j2
@@ -1,0 +1,2 @@
+; Enable Zend OPcache extension module
+zend_extension=opcache.so


### PR DESCRIPTION
### Changes

Makes Meza control the `/etc/php.d/10-opcache.ini` file, which was overriding changes to opcache settings in `/etc/php.ini`. For now the `10-opcache.ini` file is essentially blank. We could choose to move all the opcache settings out of `php.ini` and into that file if that seemed cleaner.

### Issues

* Ref this comment: https://github.com/enterprisemediawiki/meza/pull/1019#issuecomment-424833166

### Post-merge actions

Post-merge, the following actions need to be addressed:

- None