### PR TITLE
Update enablerepo functionality to work better with Ansible 2.7.0

### DIFF
--- a/src/roles/database/tasks/setup-RedHat.yml
+++ b/src/roles/database/tasks/setup-RedHat.yml
@@ -1,8 +1,13 @@
 ---
 - name: Ensure MySQL packages are installed.
-  yum: "name={{ item }} state=installed enablerepo={{ mysql_enablerepo }}"
-  with_items: "{{ mysql_packages }}"
+  yum:
+    name: "{{ mysql_packages }}"
+    state: present
+    enablerepo: "{{ mysql_enablerepo | default(omit, true) }}"
   register: rh_mysql_install_packages
 
 - name: Ensure MySQL Python libraries are installed.
-  yum: "name=MySQL-python state=installed enablerepo={{ mysql_enablerepo }}"
+  yum:
+    name: MySQL-python
+    state: present
+    enablerepo: "{{ mysql_enablerepo | default(omit, true) }}"


### PR DESCRIPTION
### Changes

* Omit `enablerepo` if empty (breaks in latest Ansible)
* With `yum` module, do `name: "{{ mysql_packages }}"` rather than looping over all packages with `with_items "{{ mysql_packages }}"`. This change will need to be replicated in many other places.

### Issues

* ref: https://github.com/geerlingguy/ansible-role-mysql/commit/e65af067319eb0a6d273e0561428d2ece2f2f899

### Post-merge actions

N/A
