### PR TITLE
Bump SMW and SRF to 3.0.0. Bump SemanticCompoundQueries to 1.2.0

### DIFF
--- a/config/core/MezaCoreExtensions.yml
+++ b/config/core/MezaCoreExtensions.yml
@@ -3,7 +3,7 @@ list:
 
   - name: Semantic MediaWiki
     composer: "mediawiki/semantic-media-wiki"
-    version: "2.5.8"
+    version: "3.0.0"
     config: |
       // Enable Semantic MediaWiki semantics
       enableSemantics( $wikiId );
@@ -27,7 +27,7 @@ list:
 
   - name: Semantic Result Formats
     composer: "mediawiki/semantic-result-formats"
-    version: "2.5.6"
+    version: "3.0.0"
     config: |
       // SemanticResultFormats formats enabled (beyond defaults)
       // These are disabled by default because they send data to external
@@ -46,7 +46,7 @@ list:
 
   - name: SemanticCompoundQueries
     composer: "mediawiki/semantic-compound-queries"
-    version: "1.1.0"
+    version: "1.2.0"
   - name: SubPageList
     composer: "mediawiki/sub-page-list"
     version: "1.5.0"


### PR DESCRIPTION
### Changes

* Bump SMW to 3.0.0
* Bump SRF to 3.0.0
* Bump SCQ to 1.2.0

### Issues

* None

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Update documentation at https://www.mediawiki.org/wiki/Meza
