### PR TITLE
Upgrade CirrusSearch metastore before (re)indexing

### DIFF
--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -457,7 +457,9 @@
 #   when: not es_do_upgrade_stat.stat.exists
 
 
-
+- name: Verify metastore index upgraded
+  shell: WIKI={{ list_of_wikis[0] }} php /opt/htdocs/mediawiki/extensions/CirrusSearch/maintenance/metastore.php --upgrade
+  run_once: true
 
 # Wikis are totally built at this point, but SMW and search need rebuilding
 # FIXME #811: Will this work when controller is not an app server?
@@ -468,11 +470,6 @@
   run_once: true
   tags:
   - search-index
-
-# FIXME: Does this need to be run on all wikis or just one.
-- name: Verify metastore index upgraded
-  shell: WIKI={{ list_of_wikis[0] }} php /opt/htdocs/mediawiki/extensions/CirrusSearch/maintenance/metastore.php --upgrade
-  run_once: true
 
 - name: "(Re-)build SemanticMediaWiki data for: {{ wikis_to_rebuild_data | join(', ') }}"
   shell: "bash {{ m_deploy }}/smw-rebuild-all.sh \"{{ wikis_to_rebuild_data | join(' ') }}\""


### PR DESCRIPTION
### Changes

Upgrade CirrusSearch metastore index before (re)building search indices, which makes sense. Older versions of MW tolerated it being later, but this is a required change for MW master branch. Pulling back into MW 1.31 to minimize differences between MW master and 1.31.x

### Issues

None

### Post-merge actions

None