### PR TITLE
Set Parsoid strictAcceptCheck = false

### DIFF
--- a/src/roles/parsoid-settings/templates/config.yaml.j2
+++ b/src/roles/parsoid-settings/templates/config.yaml.j2
@@ -30,6 +30,11 @@ services:
         #   'Parsoid/<current-version-defined-in-package.json>'
         #userAgent: 'My-User-Agent-String'
 
+        # Supposedly this is required for compatibility for Parsoid 0.9.0 with
+        # MediaWiki before 1.31. Not sure why this is required for Parsoid, VE,
+        # and MW all running master branch.
+        strictAcceptCheck: False
+
         # Configure Parsoid to point to your MediaWiki instances.
         mwApis:
 


### PR DESCRIPTION
### Changes

Set `strictAcceptCheck = false` in Parsoid `config.yaml`. As specified in the comments, it is unknown why this is required in MW master, but it apparently is. Rolling this into Meza 31.x branch to simplify differences between MW master and MW 1.31.x.
 
### Issues

None

### Post-merge actions

None