### PR TITLE
Update Extension:Maps to 6.0.1

### DIFF
--- a/config/core/MezaCoreExtensions.yml
+++ b/config/core/MezaCoreExtensions.yml
@@ -52,7 +52,9 @@ list:
     version: "1.5.0"
   - name: Maps
     composer: "mediawiki/maps"
-    version: "5.0.2"
+    version: "6.0.1"
+    config: |
+      wfLoadExtension( 'Maps' );
 
   - name: DisplayTitle
     repo: https://gerrit.wikimedia.org/r/mediawiki/extensions/DisplayTitle.git


### PR DESCRIPTION
### Changes

Update Extension:Maps to 6.0.1

### Issues

Maps 5.6.x supports MW 1.27 - 1.31. Maps 6.0.x supports MW 1.31 - 1.32. Also, Maps 6.x requires PHP 7.1+, hence the previous upgrade of PHP.

Ref: https://github.com/JeroenDeDauw/Maps/blob/master/INSTALL.md#platform-compatibility-and-release-status

### Post-merge actions

None