### PR TITLE
Need to use wfLoadExtension on SemanticResultFormats; Also bump Maps version

### DIFF
--- a/config/core/MezaCoreExtensions.yml
+++ b/config/core/MezaCoreExtensions.yml
@@ -29,6 +29,9 @@ list:
     composer: "mediawiki/semantic-result-formats"
     version: "3.0.0"
     config: |
+      // In SRF 3.0+ you need to do this, too:
+      wfLoadExtension( 'SemanticResultFormats' );
+
       // SemanticResultFormats formats enabled (beyond defaults)
       // These are disabled by default because they send data to external
       // web services for rendering, which may be considered a data leak
@@ -52,8 +55,9 @@ list:
     version: "1.5.0"
   - name: Maps
     composer: "mediawiki/maps"
-    version: "6.0.1"
+    version: "6.0.3"
     config: |
+      // In Maps 6.0+ you need to also load the extension
       wfLoadExtension( 'Maps' );
 
   - name: DisplayTitle

--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -144,18 +144,7 @@ mediawiki_default_branch: "REL1_31"
 # PHP version
 php_ius_version: "php71u"
 
-# Parsoid v0.5.2 on May 2, 2016
-# MediaWiki REL1_28 branch point on 2016-10-25
-# Parsoid v0.5.3 on Oct 31, 2016 <-- Use this for MW1.28
-# Parsoid v0.6.0 on Nov 7, 2016 <-- Requires config.yml, not localsettings.js
-# Parsoid v0.6.1 on Nov 14, 2016
-# Parsoid v0.7.0 on Apr 3, 2017
-# Parsoid v0.7.1 on Apr 5, 2017 <-- Use this for MW1.29
-# MediaWiki REL1_29 branch point ~July 2017
-# Parsoid v0.8.0 on Oct 23, 2017 <-- Use this for MW1.30
-# MediaWiki REL1_30 branch point ~Nov 2017
-# Parsoid v0.9.0 on Mar 22, 2018 <-- Use this for MW1.31
-# MediaWiki REL1_31 branch point ~Apr 2018
+# Parsoid version
 m_parsoid_version: "tags/v0.9.0"
 
 # MediaWiki 1.27 and earlier require ElasticSearch 1.6


### PR DESCRIPTION
### Changes

* Add `wfLoadExtension( 'SemanticResultFormats' );` despite the fact that it's loaded with Composer
* Bump Maps from 6.0.1 to 6.0.3
* Add a comment to maps, since it uses `wfLoadExtension` in the same manner

### Issues

* None

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Update documentation at https://www.mediawiki.org/wiki/Meza with info about Composer+wfLoadExtension
