### PR TITLE
DataTransfer 1.0 doesn't have fixes for MW 1.31, use release branch instead

### DIFF
--- a/config/core/MezaCoreExtensions.yml
+++ b/config/core/MezaCoreExtensions.yml
@@ -350,7 +350,7 @@ list:
 
   - name: DataTransfer
     repo: https://gerrit.wikimedia.org/r/p/mediawiki/extensions/DataTransfer.git
-    version: tags/1.0
+    version: "{{ mediawiki_default_branch }}"
   - name: PageImporter
     repo: https://github.com/enterprisemediawiki/PageImporter.git
     version: master


### PR DESCRIPTION
### Changes

* Datatransfer version from 1.0 --> release branch

### Issues

None

### Post-merge actions

None