### PR TITLE
Add BEGIN rules to awk scripts

### DIFF
--- a/src/roles/meza-log/templates/server-performance.sh.j2
+++ b/src/roles/meza-log/templates/server-performance.sh.j2
@@ -118,7 +118,7 @@ parsoidtotalmem=$(echo "$topdata" | grep "parsoid" | awk 'BEGIN { sum = 0 } { su
 apachetotalmem=$(echo "$topdata" | grep "apache" | awk 'BEGIN { sum = 0 } { sum += $10 } END { print sum }')
 
 
-insert_sql=`cat <<EOF
+insert_sql=`printf "
 	INSERT INTO meza_server_log.performance
 	(
 		datetime,
@@ -133,21 +133,19 @@ insert_sql=`cat <<EOF
 		apache,
 		jobs
 	)
-	VALUES
-	(
-		'$datetime',
-		$loadavg1,
-		$loadavg5,
-		$loadavg15,
-		$memorypercentused,
-		$mysqltotalmem,
-		$elastictotalmem,
-		$memcachedtotalmem,
-		$parsoidtotalmem,
-		$apachetotalmem,
-		$jobs
-	);
-EOF`
+	VALUES ( '%s', %f, %f, %f, %f, %f, %f, %f, %f, %f, %f );" \
+		"$datetime"                	   	   	   	   	   	  	  \
+		"$loadavg1"				  							  \
+		"$loadavg5"				  							  \
+		"$loadavg15"			  							  \
+		"$memorypercentused"	  							  \
+		"$mysqltotalmem"		  							  \
+		"$elastictotalmem"		  							  \
+		"$memcachedtotalmem"	  							  \
+		"$parsoidtotalmem"		  							  \
+		"$apachetotalmem"		  							  \
+		"$jobs"`
+
 
 
 # add data point to database

--- a/src/roles/meza-log/templates/server-performance.sh.j2
+++ b/src/roles/meza-log/templates/server-performance.sh.j2
@@ -111,11 +111,11 @@ topapache=$(echo "$topdata" | grep "apache")
 # 11925 apache    20   0  706516  77052  50568 S   0.0  0.5   0:06.94 httpd
 
 # calculate total memory% used by all tasks of each application
-mysqltotalmem=$(echo "$topdata" | grep "mysql" | awk '{ sum += $10 } END { print sum }')
-elastictotalmem=$(echo "$topdata" | grep "elastic" | awk '{ sum += $10 } END { print sum }')
-memcachedtotalmem=$(echo "$topdata" | grep "memcach" | awk '{ sum += $10 } END { print sum }')
-parsoidtotalmem=$(echo "$topdata" | grep "parsoid" | awk '{ sum += $10 } END { print sum }')
-apachetotalmem=$(echo "$topdata" | grep "apache" | awk '{ sum += $10 } END { print sum }')
+mysqltotalmem=$(echo "$topdata" | grep "mysql" | awk 'BEGIN { sum = 0 } { sum += $10 } END { print sum }')
+elastictotalmem=$(echo "$topdata" | grep "elastic" | awk 'BEGIN { sum = 0 } { sum += $10 } END { print sum }')
+memcachedtotalmem=$(echo "$topdata" | grep "memcach" | awk 'BEGIN { sum = 0 } { sum += $10 } END { print sum }')
+parsoidtotalmem=$(echo "$topdata" | grep "parsoid" | awk 'BEGIN { sum = 0 } { sum += $10 } END { print sum }')
+apachetotalmem=$(echo "$topdata" | grep "apache" | awk 'BEGIN { sum = 0 } { sum += $10 } END { print sum }')
 
 
 insert_sql=`cat <<EOF
@@ -212,6 +212,3 @@ if [ $notifyslack == "true" ] && [ $slack_token ]; then
 		color=$slack_msg_color"
 
 fi
-
-
-


### PR DESCRIPTION
This fixes #1062.  `insert_sql` should probably be initialized with printf, as well.
