### PR TITLE
'allow_skip_saml_users' can now take IP addresses or CIDR notation subnets

### DIFF
--- a/src/roles/saml/templates/samlLocalSettings.php.j2
+++ b/src/roles/saml/templates/samlLocalSettings.php.j2
@@ -89,8 +89,61 @@ if ( isset( $_SERVER['HTTP_X_SKIP_SAML'] ) ) {
 			if ( $wgMezaAllowSkipSamlUsers[$username][0] === '*' ) {
 				return true;
 			}
+			
+			$addressesToCheck = $wgMezaAllowSkipSamlUsers[$username];
 
 			// user allowed from this IP address only -OR- this IP address is one of many allowed
+			return array_reduce( $addressesToCheck, function ( $carry, $check ) {
+				// Check if incoming address is IPv4
+				if ( filter_var( $ipaddr, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
+					list ( $subnet, $bits ) = explode( '/', $range );
+					
+					// Allows passing in CIDR or maskless IP
+					if ( $bits === null ) {
+						$bits = 32;
+					}
+					$ip = ip2long( $ipaddr );
+					$subnet = ip2long( $subnet );
+					$mask = -1 << (32 - $bits);
+					$subnet &= $mask; # nb: in case the supplied subnet wasn't correctly aligned
+					return $carry || ( ( $ip & $mask ) == $subnet );
+				}
+				
+				// Check if PHP was compiled with IPV6 and incoming address 
+				// is valid IPv6 format
+				elseif (
+					defined( 'AF_INET6' ) &&
+					filter_var( $ipaddr, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 )
+				) {
+					$inet = inet_pton( $ipaddr );
+					
+					// converts inet_pton output to string with bits
+					$unpacked = unpack( 'A16', $inet );
+					$unpacked = str_split( $unpacked[1] );
+					$binaryip = '';
+					foreach ( $unpacked as $char ) {
+						 $binaryip .= str_pad( decbin( ord( $char ) ), 8, '0', STR_PAD_LEFT );
+					}
+
+					list( $subnet, $bits ) = explode( '/', $cidrnet );
+					if ( $bits === null) {
+						$bits = 128;
+					}
+					
+					// Convert subnet to binary string
+					$subnet = inet_pton( $subnet );
+					$binarynet = inet_to_bits( $subnet );
+
+					$ip_net_bits = substr( $binaryip, 0, $bits );
+					$net_bits = substr( $binarynet, 0, $bits );
+					
+					return $carry || ( $ip_net_bits === $net_bits );
+				}
+				
+				return $carry || false;
+			}, false)
+			
+			
 			elseif ( in_array( $ipaddr, $wgMezaAllowSkipSamlUsers[$username] ) ) {
 				return true;
 			}

--- a/src/roles/saml/templates/samlLocalSettings.php.j2
+++ b/src/roles/saml/templates/samlLocalSettings.php.j2
@@ -89,59 +89,67 @@ if ( isset( $_SERVER['HTTP_X_SKIP_SAML'] ) ) {
 			if ( $wgMezaAllowSkipSamlUsers[$username][0] === '*' ) {
 				return true;
 			}
-			
+
+			$IPv4matchesCIDR = function( $ip, $cidr) {
+				list ( $subnet, $bits ) = explode( '/', $cidr );
+					
+				// Allows passing in CIDR or maskless IP
+				if ( $bits === null ) {
+					$bits = 32;
+				}
+				$ip = ip2long( $ip );
+				$subnet = ip2long( $subnet );
+				$mask = -1 << (32 - $bits);
+				$subnet &= $mask; # nb: in case the supplied subnet wasn't correctly aligned
+				return ( $ip & $mask ) == $subnet;
+			}
+
+			$IPv6matchesCIDR = function ( $ip, $cidr) {
+				$inet = inet_pton( $ip );
+					
+				// converts inet_pton output to string with bits
+				$unpacked = unpack( 'A16', $inet );
+				$unpacked = str_split( $unpacked[1] );
+				$binaryip = '';
+				foreach ( $unpacked as $char ) {
+						$binaryip .= str_pad( decbin( ord( $char ) ), 8, '0', STR_PAD_LEFT );
+				}
+
+				list( $subnet, $bits ) = explode( '/', $cidr );
+				if ( $bits === null) {
+					$bits = 128;
+				}
+				
+				// Convert subnet to binary string
+				$subnet = inet_pton( $subnet );
+				$binarynet = inet_to_bits( $subnet );
+
+				$ip_net_bits = substr( $binaryip, 0, $bits );
+				$net_bits = substr( $binarynet, 0, $bits );
+				
+				return $ip_net_bits === $net_bits;
+			}
+
 			$addressesToCheck = $wgMezaAllowSkipSamlUsers[$username];
 
-			// user allowed from this IP address only -OR- this IP address is one of many allowed
-			return array_reduce( $addressesToCheck, function ( $carry, $check ) {
-				// Check if incoming address is IPv4
-				if ( filter_var( $ipaddr, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
-					list ( $subnet, $bits ) = explode( '/', $check );
-					
-					// Allows passing in CIDR or maskless IP
-					if ( $bits === null ) {
-						$bits = 32;
-					}
-					$ip = ip2long( $ipaddr );
-					$subnet = ip2long( $subnet );
-					$mask = -1 << (32 - $bits);
-					$subnet &= $mask; # nb: in case the supplied subnet wasn't correctly aligned
-					return $carry || ( ( $ip & $mask ) == $subnet );
+			// Loop through all addresses, returning true on first where client's IP matches
+			// Otherwise, fall through to $forbidden()
+			foreach( $addressesToCheck as $check ) {
+				if (
+					filter_var( $ipaddr, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) &&
+					$IPv4matchesCIDR( $ipaddr, $check )
+				) {
+					return true;
 				}
-				
-				// Check if PHP was compiled with IPV6 and incoming address 
-				// is valid IPv6 format
+			
 				elseif (
 					defined( 'AF_INET6' ) &&
-					filter_var( $ipaddr, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 )
+					filter_var( $ipaddr, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 ) &&
+					$IPv6matchesCIDR( $ipaddr, $check )
 				) {
-					$inet = inet_pton( $ipaddr );
-					
-					// converts inet_pton output to string with bits
-					$unpacked = unpack( 'A16', $inet );
-					$unpacked = str_split( $unpacked[1] );
-					$binaryip = '';
-					foreach ( $unpacked as $char ) {
-						 $binaryip .= str_pad( decbin( ord( $char ) ), 8, '0', STR_PAD_LEFT );
-					}
-
-					list( $subnet, $bits ) = explode( '/', $check );
-					if ( $bits === null) {
-						$bits = 128;
-					}
-					
-					// Convert subnet to binary string
-					$subnet = inet_pton( $subnet );
-					$binarynet = inet_to_bits( $subnet );
-
-					$ip_net_bits = substr( $binaryip, 0, $bits );
-					$net_bits = substr( $binarynet, 0, $bits );
-					
-					return $carry || ( $ip_net_bits === $net_bits );
+					return true;
 				}
-				
-				return $carry || false;
-			}, false);
+			}
 		}
 
 		$forbidden();

--- a/src/roles/saml/templates/samlLocalSettings.php.j2
+++ b/src/roles/saml/templates/samlLocalSettings.php.j2
@@ -96,7 +96,7 @@ if ( isset( $_SERVER['HTTP_X_SKIP_SAML'] ) ) {
 			return array_reduce( $addressesToCheck, function ( $carry, $check ) {
 				// Check if incoming address is IPv4
 				if ( filter_var( $ipaddr, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
-					list ( $subnet, $bits ) = explode( '/', $range );
+					list ( $subnet, $bits ) = explode( '/', $check );
 					
 					// Allows passing in CIDR or maskless IP
 					if ( $bits === null ) {
@@ -125,7 +125,7 @@ if ( isset( $_SERVER['HTTP_X_SKIP_SAML'] ) ) {
 						 $binaryip .= str_pad( decbin( ord( $char ) ), 8, '0', STR_PAD_LEFT );
 					}
 
-					list( $subnet, $bits ) = explode( '/', $cidrnet );
+					list( $subnet, $bits ) = explode( '/', $check );
 					if ( $bits === null) {
 						$bits = 128;
 					}

--- a/src/roles/saml/templates/samlLocalSettings.php.j2
+++ b/src/roles/saml/templates/samlLocalSettings.php.j2
@@ -141,12 +141,7 @@ if ( isset( $_SERVER['HTTP_X_SKIP_SAML'] ) ) {
 				}
 				
 				return $carry || false;
-			}, false)
-			
-			
-			elseif ( in_array( $ipaddr, $wgMezaAllowSkipSamlUsers[$username] ) ) {
-				return true;
-			}
+			}, false);
 		}
 
 		$forbidden();


### PR DESCRIPTION
#### Links for matching algorithms

[IPv4](https://stackoverflow.com/a/594134/6190673)

[IPv6](https://stackoverflow.com/a/7951507/6190673)

* If string passed does not contain a mask, the mask value is set to 32 and 128 for IPv4 and IPv6 respectively.

* IPv6 checking only occurs if PHP was compiled with IPv6 support enabled

