### PR TITLE
Make public config mode/owner configurable

### DIFF
--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -239,15 +239,24 @@ m_cache_directory_mode: "0770"
 m_cache_directory_owner: "{{ user_apache }}"
 m_cache_directory_group: "{{ group_apache }}"
 
-
 m_logs_mode: "0755"
 m_logs_owner: meza-ansible
 m_logs_group: wheel
 
-
 m_backups_mode: "0755"
 m_backups_owner: root
 m_backups_group: root
+
+# Public config is present on the controller at /opt/conf-meza/public (set above
+# in `m_local_public`). That directory is deployed to all servers into the
+# /opt/.deploy-meza/public directory. Below allows setting mode and ownership
+# for each destination.
+m_public_config_mode: "0755"
+m_public_config_owner: root
+m_public_config_group: root
+m_public_config_deployed_mode: "0755"
+m_public_config_deployed_owner: root
+m_public_config_deployed_group: root
 
 
 #
@@ -261,7 +270,7 @@ php_opcache_memory_consumption: 256
 php_opcache_interned_strings_buffer: 16
 
 # The amount of input variables that may be accepted
-php_max_input_vars: 2000 
+php_max_input_vars: 2000
 
 # It's important for this number to be greater than the number of PHP files on a
 # server.

--- a/src/roles/configure-wiki/tasks/main.yml
+++ b/src/roles/configure-wiki/tasks/main.yml
@@ -22,8 +22,8 @@
   file:
     path: "/opt/conf-meza/public/wikis/{{ wiki_id }}"
     state: directory
-    owner: "{{ user_apache }}"
-    group: "{{ group_apache }}"
+    owner: "{{ m_public_config_owner }}"
+    group: "{{ m_public_config_group }}"
     mode: 0755
   delegate_to: localhost
   run_once: true
@@ -36,8 +36,8 @@
     dest: "/opt/conf-meza/public/wikis/{{ wiki_id }}/{{ item }}"
     # force=no: this will not overwrite
     force: no
-    owner: "{{ user_apache }}"
-    group: "{{ group_apache }}"
+    owner: "{{ m_public_config_owner }}"
+    group: "{{ m_public_config_group }}"
     mode: 0755
   with_items:
     - favicon.ico
@@ -49,8 +49,8 @@
   file:
     path: "/opt/conf-meza/public/wikis/{{ wiki_id }}/{{ item }}"
     state: directory
-    owner: "{{ user_apache }}"
-    group: "{{ group_apache }}"
+    owner: "{{ m_public_config_owner }}"
+    group: "{{ m_public_config_group }}"
     mode: 0755
   delegate_to: localhost
   run_once: true
@@ -64,8 +64,8 @@
     dest: "/opt/conf-meza/public/wikis/{{ wiki_id }}/{{ item }}"
     # force=no: Non-default for templates. Destination files will not be overwritten
     force: no
-    owner: "{{ user_apache }}"
-    group: "{{ group_apache }}"
+    owner: "{{ m_public_config_owner }}"
+    group: "{{ m_public_config_group }}"
     mode: 0755
   with_items:
     - preLocalSettings.d/base.php

--- a/src/roles/init-controller-config/tasks/main.yml
+++ b/src/roles/init-controller-config/tasks/main.yml
@@ -55,9 +55,9 @@
   file:
     path: "{{ m_local_public }}"
     state: directory
-    owner: root
-    group: root
-    mode: 0755
+    owner: "{{ m_public_config_owner }}"
+    group: "{{ m_public_config_group }}"
+    mode: "{{ m_public_config_mode }}"
     recurse: true
   delegate_to: localhost
   run_once: true
@@ -69,9 +69,9 @@
   file:
     path: "{{ m_local_public }}/wikis"
     state: directory
-    owner: root
-    group: root
-    mode: 0755
+    owner: "{{ m_public_config_owner }}"
+    group: "{{ m_public_config_group }}"
+    mode: "{{ m_public_config_mode }}"
   delegate_to: localhost
   run_once: true
 
@@ -80,9 +80,9 @@
   file:
     path: "/opt/conf-meza/public/{{ item }}"
     state: directory
-    owner: root
-    group: root
-    mode: 0755
+    owner: "{{ m_public_config_owner }}"
+    group: "{{ m_public_config_group }}"
+    mode: "{{ m_public_config_mode }}"
   delegate_to: localhost
   run_once: true
   with_items:
@@ -94,9 +94,9 @@
   template:
     src: "templates/{{ item }}.j2"
     dest: "{{ m_local_public }}/{{ item }}"
-    owner: root
-    group: root
-    mode: 0755
+    owner: "{{ m_public_config_owner }}"
+    group: "{{ m_public_config_group }}"
+    mode: "{{ m_public_config_mode }}"
     force: no
   delegate_to: localhost
   run_once: true

--- a/src/roles/sync-configs/tasks/main.yml
+++ b/src/roles/sync-configs/tasks/main.yml
@@ -4,9 +4,9 @@
   file:
     path: "{{ m_deploy }}/public"
     state: directory
-    owner: root
-    group: root
-    mode: 0755
+    owner: "{{ m_public_config_deployed_owner }}"
+    group: "{{ m_public_config_deployed_group }}"
+    mode: "{{ m_public_config_deployed_mode }}"
     recurse: yes
 
 # At this point the controller must have a local config. Now force it upon the
@@ -28,8 +28,8 @@
   file:
     path: "{{ m_deploy }}"
     state: directory
-    owner: root
-    group: root
-    mode: 0755
+    owner: "{{ m_public_config_deployed_owner }}"
+    group: "{{ m_public_config_deployed_group }}"
+    mode: "{{ m_public_config_deployed_mode }}"
     recurse: yes
 


### PR DESCRIPTION
### Changes

Set public config user/group/mode with config variable, so all can be modified simultaneously.

### Issues

* First step for #1072. Subsequent PR will actually adjust public config mode.
* Addresses #530

### Post-merge actions

None.