### PR TITLE
Use failed_when instead of ignore_errors

### DIFF
--- a/src/playbooks/site.yml
+++ b/src/playbooks/site.yml
@@ -49,7 +49,7 @@
       owner: alt-meza-ansible
       group: wheel
       mode: "{{ item.mode }}"
-    ignore_errors: True
+    failed_when: False
     with_items:
     - name: known_hosts
       mode: "0600"
@@ -59,7 +59,7 @@
       ansible-vault encrypt
       /opt/conf-meza/secret/{{ env }}/secret.yml
       --vault-password-file {{ m_home }}/meza-ansible/.vault-pass-{{ env }}.txt
-    ignore_errors: True
+    failed_when: False
 
   # Note: without this, the encryption above changes mode to 0600 and ownership
   # to root:root. This makes it impossible to include_vars later.

--- a/src/roles/database/tasks/replication.yml
+++ b/src/roles/database/tasks/replication.yml
@@ -37,7 +37,7 @@
 #
 - name: Check slave replication status.
   mysql_replication: mode=getslave
-  ignore_errors: true
+  failed_when: False
   register: slave
   when: >
     not role_is_valid_slave|skipped
@@ -147,7 +147,7 @@
     master_password: "{{ mysql_replication_user.password }}"
     master_log_file: "{{ master.File }}"
     master_log_pos: "{{ master.Position }}"
-  ignore_errors: True
+  failed_when: False
   when: >
     not slave_needs_configuration|skipped
     and not role_is_valid_slave|skipped

--- a/src/roles/elasticsearch/tasks/es_upgrade.yml
+++ b/src/roles/elasticsearch/tasks/es_upgrade.yml
@@ -20,7 +20,7 @@
 # them manually.
 - name: Ensure elasticsearch plugins removed
   shell: "/usr/share/elasticsearch/bin/plugin remove {{ item }}"
-  ignore_errors: True
+  failed_when: False
   with_items:
     - bigdesk
     - head

--- a/src/roles/haproxy/tasks/main.yml
+++ b/src/roles/haproxy/tasks/main.yml
@@ -56,7 +56,7 @@
     ansible-vault encrypt
     {{ item }}
     --vault-password-file {{ m_home }}/meza-ansible/.vault-pass-{{ env }}.txt
-  ignore_errors: True
+  failed_when: False
   delegate_to: localhost
   run_once: True
   with_items:

--- a/src/roles/key-transfer/tasks/grant-keys.yml
+++ b/src/roles/key-transfer/tasks/grant-keys.yml
@@ -25,4 +25,4 @@
     group: root
     mode: "0644"
   delegate_to: "{{ granted_server }}"
-  ignore_errors: True
+  failed_when: False

--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -39,7 +39,7 @@
     owner: meza-ansible
     group: wheel
     mode: "{{ item.mode }}"
-  ignore_errors: True
+  failed_when: False
   with_items:
   - name: known_hosts
     mode: "0600"
@@ -57,7 +57,7 @@
     block: |
       [diff]
           ignoreSubmodules = all
-  ignore_errors: True
+  failed_when: False
   tags:
     - mediawiki-core
 - name: Ensure MediaWiki core owned by meza-ansible


### PR DESCRIPTION
### Changes

Using `ignore_errors: True` on a task makes it show red text when it fails, followed by a statement that the error was ignored. Using `failed_when: False` achieves the same outcome but without the scary red text. New users are often confused by the red text and error messages.

### Issues

* Closes #1068 

### Post-merge actions

None