### PR TITLE
Move prolific log files into sub-directories

### DIFF
--- a/src/roles/apache-php/templates/php.ini.j2
+++ b/src/roles/apache-php/templates/php.ini.j2
@@ -572,7 +572,7 @@ html_errors = On
 ; empty.
 ; http://php.net/error-log
 ; Example:
-error_log = {{ m_logs }}/php_errors.log
+error_log = {{ m_logs }}/php/php_errors.log
 ; Log errors to syslog (Event Log on Windows).
 ;error_log = syslog
 
@@ -1937,7 +1937,7 @@ opcache.fast_shutdown=1
 opcache.force_restart_timeout=3600
 
 ; OPcache error_log file name. Empty string assumes "stderr".
-opcache.error_log=/opt/data-meza/logs/opcache_error.log
+opcache.error_log=/opt/data-meza/logs/php/opcache_error.log
 
 ; All OPcache errors go to the Web server log.
 ; By default, only fatal errors (level 0) or errors (level 1) are logged.

--- a/src/roles/base/tasks/main.yml
+++ b/src/roles/base/tasks/main.yml
@@ -226,6 +226,21 @@
     mode: "{{ m_logs_mode }}"
     state: directory
 
+- name: "Ensure {{ m_logs }} sub directories exist"
+  file:
+    path: "{{ m_logs }}/{{ item }}"
+    owner: "{{ m_logs_owner }}"
+    group: "{{ m_logs_group }}"
+    mode: "{{ m_logs_mode }}"
+    state: directory
+  with_items:
+    - jobqueue
+    - php
+    - deploy
+    - deploy-output
+    - usr
+    - cleanup
+
 # Prevent runJobs and other scripts from running when application may be in
 # indeterminate state
 - name: Ensure crontab empty for meza-ansible when overwriting wikis

--- a/src/roles/cron/templates/meza-ansible.crontab.j2
+++ b/src/roles/cron/templates/meza-ansible.crontab.j2
@@ -28,14 +28,14 @@
 # Run a small set of jobs across all wikis periodically
 #
 # run_jobs_freq_maxtime run_jobs_freq_totalmaxtime run_jobs_freq_maxjobs run_jobs_freq_maxload
-{{ run_jobs_freq_crontime }} WIKI={{ list_of_wikis[0] }} php {{ m_deploy }}/runAllJobs.php {{ run_jobs_freq_maxtime }} {{ run_jobs_freq_totalmaxtime }} {{ run_jobs_freq_maxjobs }} {{ run_jobs_freq_maxload }} >> {{ m_logs }}/jobs_`date "+\%Y\%m\%d"`_cron.log 2>&1
+{{ run_jobs_freq_crontime }} WIKI={{ list_of_wikis[0] }} php {{ m_deploy }}/runAllJobs.php {{ run_jobs_freq_maxtime }} {{ run_jobs_freq_totalmaxtime }} {{ run_jobs_freq_maxjobs }} {{ run_jobs_freq_maxload }} >> {{ m_logs }}/jobqueue/cron_runAllJobs_`date "+\%Y\%m\%d"`.log 2>&1
 
 #
 # Run all jobs on all wikis
 # Note: WIKI=<wiki_id> does not matter which wiki. Just needs one to load
 # settings.
 #
-{{ run_all_jobs_crontime }} WIKI={{ list_of_wikis[0] }} php {{ m_deploy }}/runAllJobs.php >> {{ m_logs }}/jobs_`date "+\%Y\%m\%d"`_cron.log 2>&1
+{{ run_all_jobs_crontime }} WIKI={{ list_of_wikis[0] }} php {{ m_deploy }}/runAllJobs.php >> {{ m_logs }}/jobqueue/cron_runAllJobs_`date "+\%Y\%m\%d"`.log 2>&1
 
 {% endif %}
 
@@ -43,7 +43,7 @@
 #
 # Clean out uploads temporary files nightly
 #
-{{ clean_upload_stash_crontime }} sudo meza maint cleanuploadstash {{ env }} >> {{ m_logs }}/cleanuploadstash_`date "+\%Y-\%m"`_cron.log 2>&1
+{{ clean_upload_stash_crontime }} sudo meza maint cleanuploadstash {{ env }} >> {{ m_logs }}/cleanup/uploadstash_`date "+\%Y-\%m"`.log 2>&1
 
 {% endif %}
 

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -190,7 +190,7 @@ if ( $debug ) {
 	ini_set( 'log_errors', 1 );
 
 	// Output errors to log file
-	ini_set( 'error_log', "$m_meza_data/logs/php.log" );
+	ini_set( 'error_log', "$m_meza_data/logs/php/php_errors.log" );
 
 
 	// Displays debug data at the bottom of the content area in a formatted
@@ -869,13 +869,13 @@ $wgVirtualRestConfig['modules']['parsoid'] = array(
 // Define which namespaces will use VE
 // Per the docs, https://www.mediawiki.org/wiki/Extension:VisualEditor#Changing_active_namespaces
 // This is done a little differently in VE than in core or other extensions.
-// For VE, we use an array, keyed by the (string) canonical name of the namespace 
+// For VE, we use an array, keyed by the (string) canonical name of the namespace
 // and a (boolean) value for enabled or not
 
 // $wgContentNamespaces gets added automatically.
 
-// finally, it should be mentioned that the Extension Registry is what provides for the 
-// merge strategy 
+// finally, it should be mentioned that the Extension Registry is what provides for the
+// merge strategy
 
 $wgVisualEditorAvailableNamespaces = [
     "User" => true,
@@ -885,8 +885,8 @@ $wgVisualEditorAvailableNamespaces = [
 ];
 
 // quickly add a namespace, without figuring out what the merge strategy is
-// $wgVisualEditorAvailableNamespaces[] = NS_CUSTOM; 
-// $wgVisualEditorAvailableNamespaces[] = NS_PROJECT; 
+// $wgVisualEditorAvailableNamespaces[] = NS_CUSTOM;
+// $wgVisualEditorAvailableNamespaces[] = NS_PROJECT;
 
 
 


### PR DESCRIPTION
### Changes

Things that generate lots of log files should go into sub-directories of `/opt/data-meza/logs`

### Issues

* Closes #1076 

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Update documentation at https://www.mediawiki.org/wiki/Meza regarding location of logs
