### PR TITLE
Make apache ServerAdmin email configurable

### DIFF
--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -69,7 +69,7 @@ m_db_replication_dump_file: /opt/data-meza/db_master_for_replication.sql
 m_db_replication_log_file: /opt/data-meza/db_master_log_file
 m_db_replication_log_pos: /opt/data-meza/db_master_log_pos
 
-
+m_httpd_server_admin: "admin@example.com"
 m_timezone: "America/Chicago"
 
 meza_server_log_db: meza_server_log
@@ -225,7 +225,7 @@ php_opcache_memory_consumption: 256
 php_opcache_interned_strings_buffer: 16
 
 # The amount of input variables that may be accepted
-php_max_input_vars: 2000 
+php_max_input_vars: 2000
 
 # It's important for this number to be greater than the number of PHP files on a
 # server.

--- a/src/roles/apache-php/templates/httpd.conf.j2
+++ b/src/roles/apache-php/templates/httpd.conf.j2
@@ -86,7 +86,7 @@ Group apache
 # e-mailed.  This address appears on some server-generated pages, such
 # as error documents.  e.g. admin@your-domain.com
 #
-ServerAdmin you@example.com
+ServerAdmin {{ m_httpd_server_admin }}
 
 #
 # ServerName gives the name and port that the server uses to identify itself.


### PR DESCRIPTION
### Changes

* Makes it possible to specify apache ServerAdmin instead of sticking with default `you@example.com`

### Issues

* Closes #289

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Update documentation at https://www.mediawiki.org/wiki/Meza
