### PR TITLE
Don't force-encrypt secret.yml and encourage variable-encryption

### DIFF
--- a/src/playbooks/site.yml
+++ b/src/playbooks/site.yml
@@ -54,13 +54,6 @@
     - name: known_hosts
       mode: "0600"
 
-  - name: Ensure secret.yml encrypted
-    shell: >
-      ansible-vault encrypt
-      /opt/conf-meza/secret/{{ env }}/secret.yml
-      --vault-password-file {{ m_home }}/meza-ansible/.vault-pass-{{ env }}.txt
-    failed_when: False
-
   # Note: without this, the encryption above changes mode to 0600 and ownership
   # to root:root. This makes it impossible to include_vars later.
   - name: Ensure secret.yml owned by meza-ansible

--- a/src/playbooks/site.yml
+++ b/src/playbooks/site.yml
@@ -54,8 +54,9 @@
     - name: known_hosts
       mode: "0600"
 
-  # Note: without this, the encryption above changes mode to 0600 and ownership
-  # to root:root. This makes it impossible to include_vars later.
+  # Note: without this, if the user decides to encrypt secret.yml with Ansible
+  # vault then it changes mode to 0600 and ownership to root:root. This makes it
+  # impossible to include_vars later.
   - name: Ensure secret.yml owned by meza-ansible
     file:
       path: "/opt/conf-meza/secret/{{ env }}/secret.yml"

--- a/src/scripts/meza.py
+++ b/src/scripts/meza.py
@@ -315,7 +315,7 @@ def meza_command_setup_env (argv, return_not_exit=False):
 	print
 	print "Please review your host file. Run command:"
 	print "  sudo vi /opt/conf-meza/secret/{}/hosts".format(env)
-	print "Please review your secret config. It is encrypted, so edit by running:"
+	print "Please review your secret config. Run command:"
 	print "  sudo vi /opt/conf-meza/secret/{}/secret.yml".format(env)
 	if return_not_exit:
 		return rc
@@ -597,7 +597,7 @@ def playbook_cmd ( playbook, env=False, more_extra_vars=False ):
 		meza_chown( secret_file, 'meza-ansible', 'wheel' )
 		os.chmod( secret_file, 0o660 )
 
-		# Setup password file if not exists (environment info is encrypted)
+		# Setup password file if not exists (environment info is potentially encrypted)
 		vault_pass_file = get_vault_pass_file( env )
 
 		command = command + [ '-i', host_file, '--vault-password-file', vault_pass_file ]

--- a/src/scripts/meza.py
+++ b/src/scripts/meza.py
@@ -579,7 +579,8 @@ def meza_command_maint_encrypt_string (argv):
 	if len(argv) == 2:
 		shell_cmd = shell_cmd + ["--name",argv[1]]
 
-	rc = meza_shell_exec( shell_cmd )
+	# false = don't print command prior to running
+	rc = meza_shell_exec( shell_cmd, False )
 
 	# exit with same return code as ansible command
 	meza_shell_exec_exit(rc)
@@ -617,7 +618,9 @@ sudo meza maint decrypt_string <env> '$ANSIBLE_VAULT;1.1;AES256
 	tmp_file = write_vault_decryption_tmp_file( env, encrypted_string )
 
 	shell_cmd = ["ansible-vault","decrypt",tmp_file,"--vault-password-file",vault_pass_file]
-	rc = meza_shell_exec( shell_cmd )
+
+	# false = don't print command prior to running
+	rc = meza_shell_exec( shell_cmd, False )
 
 	decrypted_value = read_vault_decryption_tmp_file( env )
 
@@ -697,7 +700,7 @@ def playbook_cmd ( playbook, env=False, more_extra_vars=False ):
 
 # FIXME install --> setup dev-networking, setup docker, deploy monolith (special case)
 
-def meza_shell_exec ( shell_cmd ):
+def meza_shell_exec ( shell_cmd, print_command=True ):
 
 	# Get errors with user meza-ansible trying to write to the calling-user's
 	# home directory if don't cd to a neutral location. By cd'ing to this
@@ -728,7 +731,8 @@ def meza_shell_exec ( shell_cmd ):
 	else:
 		cmd = ' '.join(shell_cmd)
 
-	print cmd
+	if print_command:
+		print cmd
 	rc = os.system(cmd)
 
 	# Move back to original working directory

--- a/src/scripts/meza.py
+++ b/src/scripts/meza.py
@@ -312,20 +312,11 @@ def meza_command_setup_env (argv, return_not_exit=False):
 
 	os.remove(extra_vars_file)
 
-	# Now that the env is setup, generate a vault password file and use it to
-	# encrypt secret.yml
-	vault_pass_file = get_vault_pass_file( env )
-	secret_yml = "/opt/conf-meza/secret/{}/secret.yml".format(env)
-	cmd = "ansible-vault encrypt {} --vault-password-file {}".format(secret_yml, vault_pass_file)
-	os.system(cmd)
-
-
-
 	print
 	print "Please review your host file. Run command:"
 	print "  sudo vi /opt/conf-meza/secret/{}/hosts".format(env)
 	print "Please review your secret config. It is encrypted, so edit by running:"
-	print "  sudo ansible-vault edit /opt/conf-meza/secret/{}/secret.yml --vault-password-file /opt/conf-meza/users/meza-ansible/.vault-pass-{}.txt".format(env,env)
+	print "  sudo vi /opt/conf-meza/secret/{}/secret.yml".format(env)
 	if return_not_exit:
 		return rc
 	else:

--- a/src/scripts/meza.py
+++ b/src/scripts/meza.py
@@ -550,6 +550,85 @@ def meza_command_maint_cleanuploadstash (argv):
 	meza_shell_exec_exit(rc)
 
 
+def meza_command_maint_encrypt_string (argv):
+
+	env = argv[0]
+
+	rc = check_environment(env)
+
+	# return code != 0 means failure
+	if rc != 0:
+		meza_shell_exec_exit(rc)
+
+	# strip environment off of it
+	argv = argv[1:]
+
+	if len(argv) == 0:
+		print "encrypt_string requires value to encrypt. Ex:"
+		print "  sudo meza maint encrypt_string <env> somesecretvalue"
+		print "Additionally, you can supply the variable name. Ex:"
+		print "  sudo meza maint encrypt_string <env> somesecretvalue var_name"
+		sys.exit(1)
+
+	varvalue = argv[0]
+	vault_pass_file = get_vault_pass_file( env )
+
+	shell_cmd = ["ansible-vault","encrypt_string","--vault-id",vault_pass_file,varvalue]
+
+	# If name argument passed in, use it
+	if len(argv) == 2:
+		shell_cmd = shell_cmd + ["--name",argv[1]]
+
+	rc = meza_shell_exec( shell_cmd )
+
+	# exit with same return code as ansible command
+	meza_shell_exec_exit(rc)
+
+
+# sudo meza maint decrypt_string <env> <encrypted_string>
+def meza_command_maint_decrypt_string (argv):
+
+	env = argv[0]
+
+	rc = check_environment(env)
+
+	# return code != 0 means failure
+	if rc != 0:
+		meza_shell_exec_exit(rc)
+
+	# strip environment off of it
+	argv = argv[1:]
+
+	if len(argv) == 0:
+		print "decrypt_string requires you to supply encrypted string. Ex:"
+		print """
+sudo meza maint decrypt_string <env> '$ANSIBLE_VAULT;1.1;AES256
+31386561343430626435373766393066373464656262383063303630623032616238383838346132
+6162313461666439346337616166396133616466363935360a373333313165343535373761333634
+62636634306632633539306436363866323639363332613363346663613235653138373837303337
+6133383864613430370a623661653462336565376565346638646238643132636663383761613966
+6566'
+"""
+		sys.exit(1)
+
+	encrypted_string = argv[0]
+	vault_pass_file = get_vault_pass_file( env )
+
+	tmp_file = write_vault_decryption_tmp_file( env, encrypted_string )
+
+	shell_cmd = ["ansible-vault","decrypt",tmp_file,"--vault-password-file",vault_pass_file]
+	rc = meza_shell_exec( shell_cmd )
+
+	decrypted_value = read_vault_decryption_tmp_file( env )
+
+	print ""
+	print "Decrypted value:"
+	print decrypted_value
+
+	# exit with same return code as ansible command
+	meza_shell_exec_exit(rc)
+
+
 def meza_command_docker (argv):
 
 	if argv[0] == "run":
@@ -684,6 +763,31 @@ def get_vault_pass_file ( env ):
 	os.chmod( vault_pass_file, 0o600 )
 
 	return vault_pass_file
+
+def write_vault_decryption_tmp_file ( env, value ):
+	home_dir = defaults['m_home']
+	temp_decrypt_file = '{}/meza-ansible/.vault-temp-decrypt-{}.txt'.format(home_dir,env)
+
+	with open( temp_decrypt_file, 'w' ) as filetowrite:
+	    filetowrite.write( value )
+	    filetowrite.close()
+
+	return temp_decrypt_file
+
+def read_vault_decryption_tmp_file ( env ):
+	home_dir = defaults['m_home']
+	temp_decrypt_file = '{}/meza-ansible/.vault-temp-decrypt-{}.txt'.format(home_dir,env)
+
+	f = open( temp_decrypt_file, "r" )
+	if f.mode == 'r':
+		contents = f.read()
+		f.close()
+		os.remove( temp_decrypt_file )
+	else:
+		contents = "[decryption error]"
+
+	return contents
+
 
 def meza_chown ( path, username, groupname ):
 	import pwd

--- a/tests/docker/import-from-alt-remote.setup.sh
+++ b/tests/docker/import-from-alt-remote.setup.sh
@@ -50,7 +50,7 @@ ${docker_exec_1[@]} sed -r -i "s/INSERT_FQDN/$docker_ip_1/g;" "$secret_yml"
 # ${docker_exec_1[@]} bash -c "echo -e '[backup-src]\n$docker_ip_2 alt_remote_user=test-user\n' >> $hosts_file"
 ${docker_exec_1[@]} bash -c "echo -e '\n[exclude-all]\n$docker_ip_2\n' >> $hosts_file"
 
-# Note: secret.yml is __not__ encrypted yet at this point in the test
+# Note: secret.yml is __not__ encrypted
 ${docker_exec_1[@]} bash -c "echo -e '\n' >> $secret_yml"
 ${docker_exec_1[@]} bash -c "echo -e 'backups_server_alt_source:\n' >> $secret_yml"
 ${docker_exec_1[@]} bash -c "echo -e '  addr: $docker_ip_2\n' >> $secret_yml"
@@ -82,8 +82,9 @@ ${docker_exec_1[@]} sudo -u meza-ansible ansible-playbook \
 # `meza backup`
 ${docker_exec_1[@]} bash /opt/meza/tests/deploys/import-from-remote.controller.sh "$env_name"
 
-# secret.yml is encrypted. decrypt first, make edits, re-encrypt.
-${docker_exec_1[@]} bash -c "ansible-vault decrypt $secret_yml --vault-password-file $vault_pass"
+# secret.yml is no longer engrypted by default. If it was: decrypt first, make
+# edits, re-encrypt.
+# ${docker_exec_1[@]} bash -c "ansible-vault decrypt $secret_yml --vault-password-file $vault_pass"
 
 ${docker_exec_1[@]} bash -c "echo -e '\n' >> $secret_yml"
 ${docker_exec_1[@]} bash -c "echo -e 'backups_server_db_dump:\n' >> $secret_yml"
@@ -92,6 +93,9 @@ ${docker_exec_1[@]} bash -c "echo -e '  remote_user: test-user\n' >> $secret_yml
 ${docker_exec_1[@]} bash -c "echo -e '  mysql_user: root\n' >> $secret_yml"
 ${docker_exec_1[@]} bash -c "echo -e '  mysql_pass: 1234\n' >> $secret_yml"
 ${docker_exec_1[@]} bash -c "echo -e '\n' >> $secret_yml"
+
+# While secret.yml is no longer encrypted by default, it can still handle being
+# encrypted. Encrypt here to test that.
 ${docker_exec_1[@]} bash -c "ansible-vault encrypt $secret_yml --vault-password-file $vault_pass"
 
 # Add database source (e.g. pull direct from database) to inventory, make some


### PR DESCRIPTION
### Changes

* Remove forced (re)encryption of `secret.yml` on all deploys
* Remove initial encryption of `secret.yml` on `meza setup env`
* Remove `secret.yml` decryption in test `tests/docker/import-from-alt-remote.setup.sh`
* Add functions for encrypting/decrypting individual variables (recommended versus full file encryption):
  * `meza maint encrypt_string <environment> <value-to-encrypt> <optional-var-name>`
  * `meza maint decrypt_string <environment> <value-to-decrypt>`

### Examples

Encrypting a value: `sudo meza maint encrypt_string <environment> supersecretpassword`

```
!vault |
          $ANSIBLE_VAULT;1.1;AES256
          61326233653335326662353765626565323363653033323664306332366163643236323238613466
          6335373233663436653062633938613837306235666438660a356464623139646534653837303537
          36356665616138333264343364323138303662626261383865333463316664613932383035343935
          3130323264353661330a313762666636386432346430353135643138346163383439373763336131
          37333266616362353631313566623336393763363231343263393330633066326565
Encryption successful
```

Encrypting a value with a variable name: `sudo meza maint encrypt_string <environment> supersecretpassword variablename`

```
variablename: !vault |
          $ANSIBLE_VAULT;1.1;AES256
          66363433396637373635653762366138346331663838613335316230663965386631313761336237
          3635636464333739626363643733656636653063396434610a656566326139663331653566373133
          39346337316236376133363265323265633033333235613738613735326534383530643065346334
          3065663032653962310a306631353934346265626565386265363330333034336464333831383862
          65313232373662326330653264666161393934366236646535336331373439666338
Encryption successful
```

Decrypting a value is a little harder. You need to take the encrypted part from above starting with `$ANSIBLE_VAULT` and remove all preceding spaces and wrap in _single quotes_:

```
sudo meza maint decrypt_string <environment> '$ANSIBLE_VAULT;1.1;AES256
66363433396637373635653762366138346331663838613335316230663965386631313761336237
3635636464333739626363643733656636653063396434610a656566326139663331653566373133
39346337316236376133363265323265633033333235613738613735326534383530643065346334
3065663032653962310a306631353934346265626565386265363330333034336464333831383862
65313232373662326330653264666161393934366236646535336331373439666338'
```

Output:

```
Decryption successful

Decrypted value:
supersecretpassword
```

### Issues

* Closes #1078

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Update documentation at https://www.mediawiki.org/wiki/Meza
- [ ] Specifically update https://www.mediawiki.org/wiki/Meza/Secret_config
