### PR TITLE
Don't backup LocalSettings.php

### DIFF
--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -277,7 +277,7 @@
   template:
     src: LocalSettings.php.j2
     dest: "{{ m_mediawiki }}/LocalSettings.php"
-    backup: yes
+    # backup: yes
     owner: meza-ansible
     group: wheel
 


### PR DESCRIPTION
### Changes

* Don't create backups of LocalSettings.php which clobber the MediaWiki directory. Config should be git managed and that is backup enough

### Issues

* Closes #710 

### Post-merge actions

None
