### PR TITLE
Cleanup deprecation warnings

### DIFF
--- a/src/playbooks/getdocker.yml
+++ b/src/playbooks/getdocker.yml
@@ -15,14 +15,13 @@
   tasks:
     - name: Ensure CentOS-provided Docker repos are removed
       yum:
-        name: "{{ item }}"
+        name:
+          - docker
+          - docker-common
+          - container-selinux
+          - docker-selinux
+          - docker-engine
         state: absent
-      with_items:
-        - docker
-        - docker-common
-        - container-selinux
-        - docker-selinux
-        - docker-engine
 
     - name: Ensure yum-utils present
       yum:

--- a/src/roles/apache-php/tasks/main.yml
+++ b/src/roles/apache-php/tasks/main.yml
@@ -37,9 +37,8 @@
     - restart apache
 
 - name: Install PHP
-  include: php.yml
+  import_tasks: php.yml
   # http://docs.ansible.com/ansible/playbooks_roles.html#dynamic-versus-static-includes
-  static: yes
 
 #
 # Apache modules
@@ -78,9 +77,8 @@
     name: composer
 
 # - name: Ensure PHP profiling configured
-#   include: profiling.yml
+#   import_tasks: profiling.yml
 #   # http://docs.ansible.com/ansible/playbooks_roles.html#dynamic-versus-static-includes
-#   static: yes
 #   when: m_setup_php_profiling
 
 # If profiling not enabled, disable MongoDB if it exists (e.g. profiling had

--- a/src/roles/apache-php/tasks/main.yml
+++ b/src/roles/apache-php/tasks/main.yml
@@ -48,29 +48,26 @@
 #
 - name: Ensure Apache modules installed (RedHat/CentOS only)
   yum:
-    name: "{{ item }}"
+    name:
+      - mod_ssl
+      - mod_proxy_html
     state: installed
-  with_items:
-    - mod_ssl
-    - mod_proxy_html
   when: ansible_os_family == 'RedHat'
 
 - name: Ensure Apache modules installed (Debian only)
   apt:
+    name:
+      - "libapache2-mod-php{{ php_debian_version }}"
     state: present
-    name: "{{ item }}"
-  with_items:
-    - "libapache2-mod-php{{ php_debian_version }}"
   when: ansible_os_family == 'Debian'
 
 - name: Ensure Apache modules enabled (Debian only)
   apache2_module:
+    name:
+      - proxy_html
+      - ssl
+      - rewrite
     state: present
-    name: "{{ item }}"
-  with_items:
-    - proxy_html
-    - ssl
-    - rewrite
   when: ansible_os_family == 'Debian'
 
 #

--- a/src/roles/apache-php/tasks/mssql_driver_for_php.yml
+++ b/src/roles/apache-php/tasks/mssql_driver_for_php.yml
@@ -2,11 +2,10 @@
 
 - name: Ensure prerequisites for sqlsrv in place
   yum:
-    name: "{{item}}"
+    name:
+      - re2c
+      - gcc-c++
     state: installed
-  with_items:
-  - re2c
-  - gcc-c++
 
 # Install ODBC driver
 - name: install mssql-server repo (CentOS, RedHat)
@@ -17,11 +16,10 @@
 
 - name: Ensure conflicting ODBC drivers removed
   yum:
-    name: "{{item}}"
+    name:
+      - unixODBC-utf16
+      - unixODBC-utf16-devel
     state: absent
-  with_items:
-  - unixODBC-utf16
-  - unixODBC-utf16-devel
 
 - name: install MS ODBC driver package
   yum:

--- a/src/roles/apache-php/tasks/php-debian.yml
+++ b/src/roles/apache-php/tasks/php-debian.yml
@@ -45,16 +45,15 @@
 # PHP package purges.
 - name: Purge PHP version packages.
   apt:
-    name: "{{ item }}"
+    name:
+      - php5.6-common
+      - php7.0-common
+      - php7.1-common
+      - php7.2-common
+      - php7.3-common
     state: absent
     purge: true
     force: true
-  with_items:
-    - php5.6-common
-    - php7.0-common
-    - php7.1-common
-    - php7.2-common
-    - php7.3-common
   when: "'php' + php_debian_version not in item"
 
 

--- a/src/roles/apache-php/tasks/php-redhat.yml
+++ b/src/roles/apache-php/tasks/php-redhat.yml
@@ -17,32 +17,31 @@
 
 - name: Ensure PHP 5.6 packages removed
   yum:
-    name: "{{item}}"
+    name:
+      - php56u
+      - php56u-cli
+      - php56u-common
+      - php56u-devel
+      - php56u-gd
+      - php56u-pecl-memcache
+      - php56u-pspell
+      - php56u-snmp
+      - php56u-xml
+      - php56u-xmlrpc
+      - php56u-mysqlnd
+      - php56u-pdo
+      - php56u-odbc
+      - php56u-pear
+      - php56u-pecl-jsonc
+      - php56u-process
+      - php56u-bcmath
+      - php56u-intl
+      - php56u-opcache
+      - php56u-soap
+      - php56u-mbstring
+      - php56u-mcrypt
+      - php56u-mssql
     state: absent
-  with_items:
-    - php56u
-    - php56u-cli
-    - php56u-common
-    - php56u-devel
-    - php56u-gd
-    - php56u-pecl-memcache
-    - php56u-pspell
-    - php56u-snmp
-    - php56u-xml
-    - php56u-xmlrpc
-    - php56u-mysqlnd
-    - php56u-pdo
-    - php56u-odbc
-    - php56u-pear
-    - php56u-pecl-jsonc
-    - php56u-process
-    - php56u-bcmath
-    - php56u-intl
-    - php56u-opcache
-    - php56u-soap
-    - php56u-mbstring
-    - php56u-mcrypt
-    - php56u-mssql
 
 # Check if the desired version of PHP is installed. If it is not, ensure any
 # other versions of PHP are not installed
@@ -62,45 +61,44 @@
 
 - name: Ensure PHP IUS packages installed
   yum:
-    name: "{{item}}"
+    name:
+      # The following items exist in php56u, php70u, php71u, and php72u
+      - "{{ php_ius_version }}"
+      - "{{ php_ius_version }}-cli"
+      - "{{ php_ius_version }}-common"
+      - "{{ php_ius_version }}-devel"
+      - "{{ php_ius_version }}-gd"
+      - "{{ php_ius_version }}-pspell"
+      - "{{ php_ius_version }}-snmp"
+      - "{{ php_ius_version }}-xml"
+      - "{{ php_ius_version }}-xmlrpc"
+      - "{{ php_ius_version }}-mysqlnd"
+      - "{{ php_ius_version }}-pdo"
+      - "{{ php_ius_version }}-odbc"
+      - "{{ php_ius_version }}-process"
+      - "{{ php_ius_version }}-bcmath"
+      - "{{ php_ius_version }}-intl"
+      - "{{ php_ius_version }}-opcache"
+      - "{{ php_ius_version }}-soap"
+      - "{{ php_ius_version }}-mbstring"
+
+      # php56u has memcache and memcached; php7Xu only has memcached
+      # legacy Meza used php56u-pecl-memcache
+      - "{{ php_ius_version }}-pecl-memcached"
+
+      # Available for php56u, php70u, and php71u. NOT for php72u.
+      - "{{ php_ius_version }}-mcrypt"
+
+      # Available for php56u and php70u. NOT php71u or php72u
+      # - "{{ php_ius_version }}-pear"
+      # Post 7.0, use the pear1u package for all versions of PHP
+      - pear1u
+
+      # Not available for PHP 7, due to being built into PHP 7
+      # - php56u-pecl-jsonc
+
+      # Not available in PHP 7
+      # Get alternative method of accessing SQL Server:
+      # https://docs.microsoft.com/en-us/sql/connect/php/installation-tutorial-linux-mac?view=sql-server-2017#installing-the-drivers-on-red-hat-7
+      # - php56u-mssql
     state: installed
-  with_items:
-    # The following items exist in php56u, php70u, php71u, and php72u
-    - "{{ php_ius_version }}"
-    - "{{ php_ius_version }}-cli"
-    - "{{ php_ius_version }}-common"
-    - "{{ php_ius_version }}-devel"
-    - "{{ php_ius_version }}-gd"
-    - "{{ php_ius_version }}-pspell"
-    - "{{ php_ius_version }}-snmp"
-    - "{{ php_ius_version }}-xml"
-    - "{{ php_ius_version }}-xmlrpc"
-    - "{{ php_ius_version }}-mysqlnd"
-    - "{{ php_ius_version }}-pdo"
-    - "{{ php_ius_version }}-odbc"
-    - "{{ php_ius_version }}-process"
-    - "{{ php_ius_version }}-bcmath"
-    - "{{ php_ius_version }}-intl"
-    - "{{ php_ius_version }}-opcache"
-    - "{{ php_ius_version }}-soap"
-    - "{{ php_ius_version }}-mbstring"
-
-    # php56u has memcache and memcached; php7Xu only has memcached
-    # legacy Meza used php56u-pecl-memcache
-    - "{{ php_ius_version }}-pecl-memcached"
-
-    # Available for php56u, php70u, and php71u. NOT for php72u.
-    - "{{ php_ius_version }}-mcrypt"
-
-    # Available for php56u and php70u. NOT php71u or php72u
-    # - "{{ php_ius_version }}-pear"
-    # Post 7.0, use the pear1u package for all versions of PHP
-    - pear1u
-
-    # Not available for PHP 7, due to being built into PHP 7
-    # - php56u-pecl-jsonc
-
-    # Not available in PHP 7
-    # Get alternative method of accessing SQL Server:
-    # https://docs.microsoft.com/en-us/sql/connect/php/installation-tutorial-linux-mac?view=sql-server-2017#installing-the-drivers-on-red-hat-7
-    # - php56u-mssql

--- a/src/roles/apache-php/tasks/php.yml
+++ b/src/roles/apache-php/tasks/php.yml
@@ -1,9 +1,8 @@
 ---
 - name: Install php dependency packages
   package:
-    name: "{{ item }}"
+    name: "{{ package_php_apache_deps }}"
     state: installed
-  with_items: "{{ package_php_apache_deps }}"
 
 - name: Install PHP (RedHat/CentOS only)
   include: php-redhat.yml

--- a/src/roles/base-extras/tasks/main.yml
+++ b/src/roles/base-extras/tasks/main.yml
@@ -1,6 +1,5 @@
 ---
 - name: Install base-extras packages
   package:
-    name: "{{ item }}"
+    name: "{{ package_base_extras }}"
     state: installed
-  with_items: "{{ package_base_extras }}"

--- a/src/roles/base/tasks/main.yml
+++ b/src/roles/base/tasks/main.yml
@@ -128,22 +128,23 @@
   - latest
 
 - name: Ensure base packages installed
-  package: name={{item}} state=installed
-  with_items:
-    - ntp
-    - ntpdate
-    - ntp-doc
-    - openssh-server
-    - "{{ package_openssh_client }}"
-    - vim
-    - git
-    - net-tools
-    - "{{ package_firewall }}"
-    - rsyslog
-    - jq
-    - tree
-    - "{{ package_cron }}"
-    - rsync
+  package:
+    name:
+      - ntp
+      - ntpdate
+      - ntp-doc
+      - openssh-server
+      - "{{ package_openssh_client }}"
+      - vim
+      - git
+      - net-tools
+      - "{{ package_firewall }}"
+      - rsyslog
+      - jq
+      - tree
+      - "{{ package_cron }}"
+      - rsync
+    state: installed
   tags:
   - latest
 

--- a/src/roles/database/tasks/main.yml
+++ b/src/roles/database/tasks/main.yml
@@ -3,13 +3,11 @@
 - include: variables.yml
 
 # Setup/install tasks.
-- include: setup-RedHat.yml
+- include_tasks: setup-RedHat.yml
   when: ansible_os_family == 'RedHat'
-  static: no
 
-- include: setup-Debian.yml
+- include_tasks: setup-Debian.yml
   when: ansible_os_family == 'Debian'
-  static: no
 
 - name: Check if MySQL packages were installed.
   set_fact:

--- a/src/roles/database/tasks/replication.yml
+++ b/src/roles/database/tasks/replication.yml
@@ -2,7 +2,6 @@
 #
 # The following conditionals are reused many times in the tasks in this file.
 # As such, they've been encapsulated in these tasks and registered to vars.
-# FIXME #812: The logic "not role_is_valid_slave|skipped" is awkward
 - name: Check if valid slave
   command: /bin/true
   register: role_is_valid_slave
@@ -10,6 +9,10 @@
     (mysql_replication_role == 'slave')
     and mysql_replication_user
     and (mysql_replication_master != '')
+- set_fact:
+    role_is_valid_slave: False
+  when: role_is_valid_slave is skipped
+
 - name: Check if valid master
   command: /bin/true
   register: role_is_valid_master
@@ -17,6 +20,10 @@
     (mysql_replication_role == 'master')
     and mysql_replication_user
     and (mysql_replication_master != '')
+- set_fact:
+    role_is_valid_master: False
+  when: role_is_valid_master is skipped
+
 
 
 #
@@ -29,8 +36,7 @@
     password: "{{ mysql_replication_user.password }}"
     priv: "{{ mysql_replication_user.priv | default('*.*:REPLICATION SLAVE') }}"
     state: present
-  when: >
-    not role_is_valid_master|skipped
+  when: role_is_valid_master
 
 #
 # Get slave replication status
@@ -39,8 +45,7 @@
   mysql_replication: mode=getslave
   failed_when: False
   register: slave
-  when: >
-    not role_is_valid_slave|skipped
+  when: role_is_valid_slave
 - debug: { var: slave }
 
 #
@@ -52,7 +57,7 @@
   when: >
     (
       (slave.Is_Slave is defined and not slave.Is_Slave)
-      or (slave.Is_Slave is not defined and slave|failed)
+      or (slave.Is_Slave is not defined and slave is failed)
       or (slave.Slave_IO_Running is defined and slave.Slave_SQL_Running == 'No')
       or (mysql_force_slave_configuration is defined and mysql_force_slave_configuration)
     )
@@ -66,9 +71,9 @@
   mysql_replication: mode=getmaster
   delegate_to: "{{ mysql_replication_master }}"
   register: master
-  when: >
-    not slave_needs_configuration|skipped
-    and not role_is_valid_slave|skipped
+  when:
+    - slave_needs_configuration
+    - role_is_valid_slave
 - debug: { var: master }
 
 
@@ -82,16 +87,16 @@
   command: mysql -NBe "SELECT DISTINCT(TABLE_SCHEMA) FROM information_schema.tables WHERE TABLE_SCHEMA NOT IN ('information_schema', 'performance_schema', 'mysql')"
   register: mysql_content_databases
   delegate_to: "{{ mysql_replication_master }}"
-  when: >
-    not slave_needs_configuration|skipped
-    and not role_is_valid_slave|skipped
+  when:
+    - slave_needs_configuration
+    - role_is_valid_slave
 
 - name: export dump file on master
   shell: "mysqldump --databases {{ mysql_content_databases.stdout }} | gzip > {{ m_tmp }}/mysqldump-onmaster.sql.gz"
   delegate_to: "{{ mysql_replication_master }}"
-  when: >
-    not slave_needs_configuration|skipped
-    and not role_is_valid_slave|skipped
+  when:
+    - slave_needs_configuration
+    - role_is_valid_slave
 
 
 
@@ -108,16 +113,16 @@
     dest: "{{ m_tmp }}/mysqldump-oncontrol.sql.gz"
     flat: yes
   delegate_to: "{{ mysql_replication_master }}"
-  when: >
-    not slave_needs_configuration|skipped
-    and not role_is_valid_slave|skipped
+  when:
+    - slave_needs_configuration
+    - role_is_valid_slave
 - name: put dump file
   copy:
     src: "{{ m_tmp }}/mysqldump-oncontrol.sql.gz"
     dest: "{{ m_tmp }}/mysqldump-onslave.sql.gz"
-  when: >
-    not slave_needs_configuration|skipped
-    and not role_is_valid_slave|skipped
+  when:
+    - slave_needs_configuration
+    - role_is_valid_slave
 
 #
 # Import SQL file from above
@@ -127,18 +132,18 @@
     state: import
     name: all
     target: "{{ m_tmp }}/mysqldump-onslave.sql.gz"
-  when: >
-    not slave_needs_configuration|skipped
-    and not role_is_valid_slave|skipped
+  when:
+    - slave_needs_configuration
+    - role_is_valid_slave
 
 #
 # Stop slave, configure, start slave.
 #
 - mysql_replication:
     mode: stopslave
-  when: >
-    not slave_needs_configuration|skipped
-    and not role_is_valid_slave|skipped
+  when:
+    - slave_needs_configuration
+    - role_is_valid_slave
 - name: Configure replication on the slave.
   mysql_replication:
     mode: changemaster
@@ -148,11 +153,11 @@
     master_log_file: "{{ master.File }}"
     master_log_pos: "{{ master.Position }}"
   failed_when: False
-  when: >
-    not slave_needs_configuration|skipped
-    and not role_is_valid_slave|skipped
+  when:
+    - slave_needs_configuration
+    - role_is_valid_slave
 - name: Start replication.
   mysql_replication: mode=startslave
-  when: >
-    not slave_needs_configuration|skipped
-    and not role_is_valid_slave|skipped
+  when:
+    - slave_needs_configuration
+    - role_is_valid_slave

--- a/src/roles/database/tasks/setup-Debian.yml
+++ b/src/roles/database/tasks/setup-Debian.yml
@@ -11,8 +11,9 @@
   apt: "name=python-mysqldb state=installed"
 
 - name: Ensure MySQL packages are installed.
-  apt: "name={{ item }} state=installed"
-  with_items: "{{ mysql_packages }}"
+  apt:
+    name: "{{ mysql_packages }}"
+    state: installed
   register: deb_mysql_install_packages
 
 # Because Ubuntu starts MySQL as part of the install process, we need to stop

--- a/src/roles/gluster/tasks/setup-Debian.yml
+++ b/src/roles/gluster/tasks/setup-Debian.yml
@@ -9,18 +9,16 @@
 
 - name: Ensure GlusterFS will reinstall if the PPA was just added.
   apt:
-    name: "{{ item }}"
+    name:
+      - glusterfs-server
+      - glusterfs-client
     state: absent
-  with_items:
-    - glusterfs-server
-    - glusterfs-client
   when: glusterfs_ppa_added.changed
 
 - name: Ensure GlusterFS is installed.
   apt:
-    name: "{{ item }}"
+    name:
+      - glusterfs-server
+      - glusterfs-client
     state: installed
     default_release: "{{ glusterfs_default_release }}"
-  with_items:
-    - glusterfs-server
-    - glusterfs-client

--- a/src/roles/gluster/tasks/setup-RedHat.yml
+++ b/src/roles/gluster/tasks/setup-RedHat.yml
@@ -10,17 +10,15 @@
 
 - name: Ensure CentOS prerequisites in place
   yum:
-    name: "{{ item }}"
+    name:
+      - "centos-release-gluster{{ glusterfs_default_release }}"
     state: present
-  with_items:
-    - "centos-release-gluster{{ glusterfs_default_release }}"
   when: ansible_distribution == "CentOS"
 
 
 - name: Install Packages
   yum:
-    name: "{{ item }}"
+    name:
+      - glusterfs-server
+      - glusterfs-client
     state: present
-  with_items:
-    - glusterfs-server
-    - glusterfs-client

--- a/src/roles/haproxy/tasks/main.yml
+++ b/src/roles/haproxy/tasks/main.yml
@@ -8,12 +8,11 @@
 
 - name: Install haproxy packages
   package:
-    name: "{{ item }}"
+    name:
+      - haproxy
+      - openssl
+      # - keepalived ?
     state: latest
-  with_items:
-    - haproxy
-    - openssl
-    # - keepalived ?
 
 - name: Ensure haproxy certs directory exists
   file:

--- a/src/roles/memcached/tasks/main.yml
+++ b/src/roles/memcached/tasks/main.yml
@@ -5,13 +5,12 @@
 
 - name: Ensure memcached and netcat packages latest
   yum:
-    name: "{{ item }}"
+    name:
+      - memcached
+      - "{{ package_nmap }}"
     state: latest
   tags:
-  - latest
-  with_items:
-  - memcached
-  - "{{ package_nmap }}"
+    - latest
 
 - name: Write the memcached config file
   template:

--- a/src/roles/nodejs/tasks/main.yml
+++ b/src/roles/nodejs/tasks/main.yml
@@ -23,20 +23,18 @@
 
 # - name: Ensure Node.js and npm are installed.
 #   yum:
-#     name: "{{ item }}"
+#     name:
+#       - nodejs
+#       - npm
 #     state: present
 #     enablerepo: epel
-#   with_items:
-#     - nodejs
-#     - npm
 
 - name: Ensure Node.js and npm from yum are REMOVED
   yum:
-    name: "{{ item }}"
+    name:
+      - nodejs
+      - npm
     state: absent
-  with_items:
-    - nodejs
-    - npm
   when: ansible_os_family == 'RedHat'
 
 

--- a/tests/deploys/setup-alt-source-backup.yml
+++ b/tests/deploys/setup-alt-source-backup.yml
@@ -13,14 +13,13 @@
   tasks:
     - name: Ensure packages installed
       yum:
-        name: "{{item}}"
+        name:
+          - mariadb
+          - mariadb-server
+          - mariadb-libs
+          - MySQL-python
+          - perl-DBD-MySQL
         state: installed
-      with_items:
-        - mariadb
-        - mariadb-server
-        - mariadb-libs
-        - MySQL-python
-        - perl-DBD-MySQL
 
     - name: Ensure backups repo in place
       git:


### PR DESCRIPTION
### Changes

* Don't use `with_items` for lists of packages (`yum`, `apt`, `package` modules)
* Remove use of `static`. Instead use `include_tasks` or `import_tasks` accordingly. See [1] and [2].
* Removed use of `result|skipped`. Instead do `result is skipped`
* Cleaned up logic in database role's `replication.yml`

### Issues

* Closes #812
* Closes #1039
* Closes #1071

### Post-merge actions

None

### Refs

[1] https://docs.ansible.com/ansible/2.4/playbooks_reuse_includes.html
[2] https://docs.ansible.com/ansible/2.4/playbooks_reuse.html