### PR TITLE
Change 'state: installed' to 'state: present'

### DIFF
--- a/src/roles/apache-php/tasks/main.yml
+++ b/src/roles/apache-php/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Ensure Apache webserver installed
   package:
     name: "{{ package_apache }}"
-    state: installed
+    state: present
 
 - name: Make apache own htdocs directory
   file:
@@ -50,7 +50,7 @@
     name:
       - mod_ssl
       - mod_proxy_html
-    state: installed
+    state: present
   when: ansible_os_family == 'RedHat'
 
 - name: Ensure Apache modules installed (Debian only)

--- a/src/roles/apache-php/tasks/mssql_driver_for_php.yml
+++ b/src/roles/apache-php/tasks/mssql_driver_for_php.yml
@@ -5,7 +5,7 @@
     name:
       - re2c
       - gcc-c++
-    state: installed
+    state: present
 
 # Install ODBC driver
 - name: install mssql-server repo (CentOS, RedHat)

--- a/src/roles/apache-php/tasks/php-redhat.yml
+++ b/src/roles/apache-php/tasks/php-redhat.yml
@@ -101,4 +101,4 @@
       # Get alternative method of accessing SQL Server:
       # https://docs.microsoft.com/en-us/sql/connect/php/installation-tutorial-linux-mac?view=sql-server-2017#installing-the-drivers-on-red-hat-7
       # - php56u-mssql
-    state: installed
+    state: present

--- a/src/roles/apache-php/tasks/php.yml
+++ b/src/roles/apache-php/tasks/php.yml
@@ -2,7 +2,7 @@
 - name: Install php dependency packages
   package:
     name: "{{ package_php_apache_deps }}"
-    state: installed
+    state: present
 
 - name: Install PHP (RedHat/CentOS only)
   include: php-redhat.yml

--- a/src/roles/apache-php/tasks/profiling.yml
+++ b/src/roles/apache-php/tasks/profiling.yml
@@ -12,7 +12,7 @@
 - name: Install mongodb-org package
   yum:
     name: mongodb-org
-    state: installed
+    state: present
   run_once: yes
 
 - name: Ensure MongoDB conf file in place

--- a/src/roles/base-extras/tasks/main.yml
+++ b/src/roles/base-extras/tasks/main.yml
@@ -2,4 +2,4 @@
 - name: Install base-extras packages
   package:
     name: "{{ package_base_extras }}"
-    state: installed
+    state: present

--- a/src/roles/base/tasks/main.yml
+++ b/src/roles/base/tasks/main.yml
@@ -63,7 +63,7 @@
 - name: Ensure aptitude installed in order to use Ansible 'package' (Debian only)
   apt:
     name: aptitude
-    state: installed
+    state: present
     force_apt_get: yes
   when: ansible_os_family == "Debian"
 
@@ -81,7 +81,7 @@
 - name: Ensure EPEL installed via epel-release package (CentOS only)
   yum:
     name: epel-release
-    state: installed
+    state: present
   when: ansible_distribution == "CentOS"
   tags:
   - latest
@@ -144,7 +144,7 @@
       - tree
       - "{{ package_cron }}"
       - rsync
-    state: installed
+    state: present
   tags:
   - latest
 

--- a/src/roles/cron/tasks/main.yml
+++ b/src/roles/cron/tasks/main.yml
@@ -4,7 +4,7 @@
 # - name: Ensure cron installed
 #   yum:
 #     name: cronie
-#     state: installed
+#     state: present
 
 - name: Ensure cron is running (and enable it at boot)
   service:

--- a/src/roles/database/tasks/setup-Debian.yml
+++ b/src/roles/database/tasks/setup-Debian.yml
@@ -13,7 +13,7 @@
 - name: Ensure MySQL packages are installed.
   apt:
     name: "{{ mysql_packages }}"
-    state: installed
+    state: present
   register: deb_mysql_install_packages
 
 # Because Ubuntu starts MySQL as part of the install process, we need to stop

--- a/src/roles/elasticsearch/tasks/main.yml
+++ b/src/roles/elasticsearch/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: Ensure Java 1.8.0 OpenJDK is installed
   yum:
     name: "{{ package_java }}"
-    state: installed
+    state: present
 
 
 # Environment setup.

--- a/src/roles/gluster/tasks/setup-Debian.yml
+++ b/src/roles/gluster/tasks/setup-Debian.yml
@@ -20,5 +20,5 @@
     name:
       - glusterfs-server
       - glusterfs-client
-    state: installed
+    state: present
     default_release: "{{ glusterfs_default_release }}"

--- a/src/roles/imagemagick/tasks/main.yml
+++ b/src/roles/imagemagick/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Ensure ghostscript installed
   package:
     name: ghostscript
-    state: installed
+    state: present
 
 - name: Install Imagemagick from meza repo (RedHat/CentOS only)
   yum:

--- a/tests/deploys/setup-alt-source-backup.yml
+++ b/tests/deploys/setup-alt-source-backup.yml
@@ -19,7 +19,7 @@
           - mariadb-libs
           - MySQL-python
           - perl-DBD-MySQL
-        state: installed
+        state: present
 
     - name: Ensure backups repo in place
       git:


### PR DESCRIPTION
### Changes

Change 'state: installed' to 'state: present' due to possible deprecation. #1071 shows that there's a deprecation warning if `state: installed` is used. This is not showing in current CI builds. There are other repositories (e.g. geerlingguy/ansible-role-firewall#48) that also are reporting this issue, so perhaps it's due to Ansible version. Anyway...switching to `present` won't hurt.

### Issues

* Closes #1071

### Post-merge actions

None