### PR TITLE
Add debug to troubleshoot backup issue

### DIFF
--- a/src/roles/remote-mysqldump/tasks/main.yml
+++ b/src/roles/remote-mysqldump/tasks/main.yml
@@ -69,6 +69,9 @@
   failed_when: False
   run_once: true
 
+- debug:
+    var: source_wiki_exists_check
+
 - name: "{{ wiki_id }} - Set fact if database wiki_{{ wiki_id }} DOES exist ON SOURCE SERVER"
   set_fact:
     source_wiki_exists: True


### PR DESCRIPTION
Add debug to hopefully catch issue with wiki not on production yet but
backup server thinking that the wiki does exist on production, and
attempting to backup from it. This generates a meaningless SQL backup
file and then fails to generate the MediaWiki database.

The check for whether the new wiki's database exists on production is:

`mysqlshow "wiki_{{ wiki_id }}" | grep -v Wildcard | grep -o wiki_{{ wiki_id }}`

This should have a return code of zero if the database exists and
non-zero if it doesn't. When manually entering this on the server it
performs as expected. Hopefully adding this debug will shed some light
onto why it doesn't work in this production case.

### Changes

Add a debug task

### Issues

None

### Post-merge actions

None