### PR TITLE
Make backup a tag so that you can at least skip it

### DIFF
--- a/src/roles/remote-mysqldump/tasks/main.yml
+++ b/src/roles/remote-mysqldump/tasks/main.yml
@@ -119,6 +119,8 @@
   shell: "{{ mysqldump_command }}"
   delegate_to: "{{ target_server }}"
   when: source_wiki_exists
+  tags:
+    - backup
 
 
 #


### PR DESCRIPTION
Addresses Issue #1095

### Changes

* Adds 'backup' as a tag

Backups happen automatically for every `meza deploy`.
You can skip the actual database backup(s) with the deploy option `--skip-tags backup`
This can save considerable time and disk space during repeated failed deploys in development.

### Issues

* Addresses #1095

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Update documentation at https://www.mediawiki.org/wiki/Meza
