### PR TITLE
Gluster 3.5 does not exist (at least not in PPAs)

### DIFF
--- a/src/roles/gluster/defaults/main.yml
+++ b/src/roles/gluster/defaults/main.yml
@@ -2,4 +2,4 @@
 # For Ubuntu.
 glusterfs_default_release: ""
 glusterfs_ppa_use: yes
-glusterfs_ppa_version: "3.5"
+glusterfs_ppa_version: "4.1.6"


### PR DESCRIPTION
so I bumped the version to the latest number in the next major release: [4.1.6](https://github.com/gluster/glusterfs/tree/release-4.1/doc/release-notes) .  This should be reviewed critically because the Gluster project already has a 5.x release series and is planning the 6.x releases to start coming out next month (aka in February 2019).

### Changes

change the version of Gluster installed.

### Issues
* What new features / fixes are available?  
* What (if any) limitations are present in the newer release(s) compared to existing?
* What additional install steps are needed to satisfy installation on Debian? 
* What additional install steps are needed to satisfy installation on Ubuntu?
* Can we / Should we simply integrate the ansible roles produced by the Gluster project? -- or does that create too much glue code?

### Post-merge actions

- [ ] Update documentation at https://www.mediawiki.org/wiki/Meza
