### PR TITLE
allow access to SSH agent (private keys)

### DIFF
--- a/src/roles/base/tasks/main.yml
+++ b/src/roles/base/tasks/main.yml
@@ -326,3 +326,10 @@
     owner: "meza-ansible"
     group: "wheel"
     mode: 0644
+
+- name: Ensure meza-ansible can use the ssh-agent of the deploy user
+  lineinfile:
+    dest: /etc/sudoers
+    insertafter: '^#?\s*Defaults\s+env_keep\b'
+    line: 'Defaults    env_keep += "SSH_AUTH_SOCK"'
+


### PR DESCRIPTION
If the deploy user forwards her ssh agent with
`ssh -A controller.example.com` then make those private keys accessible through the SSH_AUTH_SOCK environment variable in /etc/sudoers

### Changes
Add/ensure a line in the 'Defaults' section of /etc/sudoers

### Issues

It is difficult to deploy private repositories. One current workaround is to add meza-ansible's key to your repository. In GitLab, you can use a "deploy key". But, in GitHub deploy keys are only good for a single repository. With access to the SSH_AUTH_SOCK, meza-ansible has access to the developers existing private keys (already configured for use in private repositories).

### Post-merge actions

- [ ] Update documentation at https://www.mediawiki.org/wiki/Meza
