### PR TITLE
add netdata monitor

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -125,6 +125,14 @@ mysql_performance_schema: "on"
 load_balancer_unmanaged_parsoid_port: 8000
 load_balancer_unmanaged_mediawiki_port: 8080
 
+# Netdata is a monitoring and alerting system 
+m_install_netdata: True
+# we need a certificate to bind to port 20000
+ssl_certificate_file: /etc/haproxy/certs/meza.pem
+# netdata runs on 19999 by default. We'll expose it at 20000
+netdata_internal_port: 19999
+netdata_external_port: 20000
+
 # If false, keep all SQL files on backup servers. If true, only keep the latest
 do_cleanup_sql_backup: False
 

--- a/src/playbooks/site.yml
+++ b/src/playbooks/site.yml
@@ -135,6 +135,14 @@
     - base-extras
     - imagemagick
     - apache-php
+    - role: netdata
+      when: m_install_netdata
+    - role: firewall_port
+      firewall_action: open
+      firewall_port: 19999
+      firewall_protocol: tcp
+      firewall_servers: "{{ load_balancers_all }}"
+      firewall_zone: "{{m_private_networking_zone|default('public')}}"
 
 # Keeping this as a separate play, since at some point it will make sense to
 # configure app-servers as gluster clients and have separate gluster servers
@@ -384,4 +392,3 @@
     - role: cron
       when: docker_skip_tasks is not defined or not docker_skip_tasks
     - umask-unset
-

--- a/src/roles/apache-php/tasks/php-redhat.yml
+++ b/src/roles/apache-php/tasks/php-redhat.yml
@@ -92,7 +92,9 @@
       # Available for php56u and php70u. NOT php71u or php72u
       # - "{{ php_ius_version }}-pear"
       # Post 7.0, use the pear1u package for all versions of PHP
-      - pear1u
+      # PEAR is no longer a requirement for Meza. Mail and Net_SMTP installed with
+      # Composer via MW core (MW 1.32+) or composer.local.json (MW 1.31 and lower)
+      # - pear1u
 
       # Not available for PHP 7, due to being built into PHP 7
       # - php56u-pecl-jsonc

--- a/src/roles/apache-php/tasks/php.yml
+++ b/src/roles/apache-php/tasks/php.yml
@@ -43,13 +43,3 @@
   notify:
     - restart apache
   when: ansible_os_family == "RedHat"
-
-- name: Ensure PEAR Mail and Net_SMTP packages installed
-  pear:
-    name: "{{ item }}"
-    state: latest
-  tags:
-    - latest
-  with_items:
-    - Mail
-    - Net_SMTP

--- a/src/roles/haproxy/tasks/main.yml
+++ b/src/roles/haproxy/tasks/main.yml
@@ -266,7 +266,18 @@
 #    - http
 #    - https
 
-- name: Ensure port 80 and 443 open for haproxy
+- name: Create list of ports to open to the world
+  set_fact:
+    fully_open_ports:
+      - 80
+      - 443
+
+- name: Add port 20000 to world-accessible list if installing netdata
+  set_fact:
+    fully_open_ports: "{{ fully_open_ports }} + [ 20000 ]"
+  when: m_install_netdata
+
+- name: Ensure port {{ fully_open_ports | join(', ') }} open to the world for haproxy
   include_role:
     name: firewall_port
   vars:
@@ -274,15 +285,16 @@
     firewall_port: "{{ item }}"
     firewall_protocol: tcp
     firewall_zone: "{{m_private_networking_zone|default('public')}}"
-  with_items:
-    - 80
-    - 443
+  with_items: "{{ fully_open_ports }}"
   when:
+      # only external load balancers
+    - load_balancer_handle_external
     - (docker_skip_tasks is not defined or not docker_skip_tasks)
     - >
       ('load-balancers' in groups and inventory_hostname in groups['load-balancers'])
       or
       ('load-balancers-meza-external' in groups and inventory_hostname in groups['load-balancers-meza-external'])
+
 
 - name: Ensure firewall port 1936 OPEN when haproxy stats ENABLED
   include_role:

--- a/src/roles/haproxy/templates/haproxy.cfg.j2
+++ b/src/roles/haproxy/templates/haproxy.cfg.j2
@@ -88,6 +88,17 @@ backend www-backend
 	# Note: slight modification for HAProxy 1.6+
 	http-response set-header Strict-Transport-Security max-age=16000000;\ includeSubDomains;\ preload;
 
+    # @FIXME loop w/ index and tie all
+	# app servers together with controller as registry 
+	{% if m_install_netdata %}
+	frontend netdata
+		bind *:20000 ssl crt {{ ssl_certificate_file }}
+		mode http
+		default_backend netdata-back
+	backend netdata-back
+		server nd1 127.0.0.1:19999
+	{% endif %}
+
 {% endif %}
 
 

--- a/src/roles/netdata/handlers/main.yml
+++ b/src/roles/netdata/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+# Handlers for Netdata role
+- name: restart haproxy
+  service:
+    name: haproxy
+    state: restarted

--- a/src/roles/netdata/tasks/main.yml
+++ b/src/roles/netdata/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+## We're called from the site.yml playbook and the haproxy role takes care of front-end and back-end port handling
+##
+## Add test to see if it's already installed and skip if it is
+- name: Check if Netdata is present
+  stat:
+    path: /opt/netdata
+  register: netdata_present
+
+- debug: msg="netdata not installed"
+  when: netdata_present.stat.exists == False
+
+- debug: msg="netdata installed"
+  when: netdata_present.stat.exists == True
+
+## It will be running once installed
+- name: Install Intel/AMD 64bit static build of Netdata
+  shell: bash <(curl -Ss https://my-netdata.io/kickstart-static64.sh) --dont-wait
+  args:
+    executable: /bin/bash
+  become: no
+  when: netdata_present.stat.exists == False


### PR DESCRIPTION
### Changes

Adds new role to install and configure the system monitor Netdata
restarts HAProxy when first installed
uses the static binary for Netdata so there are no dependencies to install or remove 
Once run, netdata should be available at https://example.com:20000 using the Meza self-signed cert

### Issues
I've been unable to test this role because my local ~/src/meza `vagrant up` is broken and I haven't yet setup another checkout / system to test on.

In my trial usage of Netdata prior to writing this role, I've experienced somewhat 'noisy' alerts for tcp_listen_drops More information on handling this at https://wiki.freephile.org/wiki/Netdata

The default install will use 10-15MB of RAM to keep 24 hours worth of data. This can be adjusted in the conf file manually. If it turns out that we want to modify Netdata, this role should be expanded to include configuration.

I thought I read that the installer adds a system cron to update itself however now I've read that it only give an example cron script. TBD how to handle Netdata updates if it needs to be addressed.

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Update documentation at https://www.mediawiki.org/wiki/Meza
