### PR TITLE
Remove PEAR, install net_smtp via composer.local.json

### DIFF
--- a/src/playbooks/delete-elasticsearch.yml
+++ b/src/playbooks/delete-elasticsearch.yml
@@ -14,6 +14,9 @@
     # - name: Verify user wants to delete elasticsearch
     #   pause: prompt='Please confirm you want to delete Elasticsearch! Press return to continue. Press Ctrl+c and then "a" to abort'
 
+    - include_role:
+        name: set-vars
+
     - name: Ensure Elasticsearch is removed
       yum:
         name: elasticsearch

--- a/src/roles/apache-php/tasks/php.yml
+++ b/src/roles/apache-php/tasks/php.yml
@@ -116,7 +116,9 @@
     # Available for php56u and php70u. NOT php71u or php72u
     # - "{{ php_ius_version }}-pear"
     # Post 7.0, use the pear1u package for all versions of PHP
-    - pear1u
+    # PEAR is no longer a requirement for Meza. Mail and Net_SMTP installed with
+    # Composer via MW core (MW 1.32+) or composer.local.json (MW 1.31 and lower)
+    # - pear1u
 
     # Not available for PHP 7, due to being built into PHP 7
     # - php56u-pecl-jsonc
@@ -154,13 +156,3 @@
     dest: /etc/freetds.conf
   notify:
   - restart apache
-
-- name: Ensure PEAR Mail and Net_SMTP packages installed
-  pear:
-    name: "{{ item }}"
-    state: latest
-  tags:
-  - latest
-  with_items:
-  - Mail
-  - Net_SMTP

--- a/src/roles/mediawiki/templates/composer.local.json.j2
+++ b/src/roles/mediawiki/templates/composer.local.json.j2
@@ -17,9 +17,11 @@
 		{%- endfor -%}
 
 		{%- for ext in meza_core_extensions['list'] if ext.composer is defined %}
-		"{{ ext.composer }}": "{{ ext.version }}"
-		{%- if not loop.last -%},{%- endif %}
+		"{{ ext.composer }}": "{{ ext.version }}",
+		{# Note: pear/net_smtp is part of MW core in 1.32+. Need to add conditional comma here when pear/net_smtp is removed below. %}
 		{%- endfor %}
+
+		"pear/net_smtp": "1.8.0"
 
 	},
 	"extra": {

--- a/src/roles/mediawiki/templates/composer.local.json.j2
+++ b/src/roles/mediawiki/templates/composer.local.json.j2
@@ -18,7 +18,7 @@
 
 		{%- for ext in meza_core_extensions['list'] if ext.composer is defined %}
 		"{{ ext.composer }}": "{{ ext.version }}",
-		{# Note: pear/net_smtp is part of MW core in 1.32+. Need to add conditional comma here when pear/net_smtp is removed below. %}
+		{# Note: pear/net_smtp is part of MW core in 1.32+. Need to add conditional comma here when pear/net_smtp is removed below. #}
 		{%- endfor %}
 
 		"pear/net_smtp": "1.8.0"


### PR DESCRIPTION
### Changes

Meza has historically used PEAR to install the `mail` and `net_smtp` packages per the docs at https://www.mediawiki.org/wiki/Manual:$wgSMTP. However, since MW 1.31 `pear/mail` is packaged with MW (in `composer.json`). In MW 1.32 `net_smtp` is also in `composer.json`. This commit is on a version of Meza using MW 1.31, so `pear/net_smtp` needs to be added via `composer.local.json`.

This change initiated by the fact that PEAR has had a security breach and is down. Ref iuscommunity-pkg/pear1u#3. Since PEAR isn't needed anymore we're removing its usage so builds will pass.

Additionally, I accidentally added a fix for `meza delete elasticsearch <environment>` to this commit. Variables were not properly being loaded. Rather than split this fix out and slow down getting builds passing again I'm going to merge as-is.

### Issues

None

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [x] None