### PR TITLE
Fixes for the gluster role on Debian

### DIFF
--- a/src/roles/firewall_service/tasks/main.yml
+++ b/src/roles/firewall_service/tasks/main.yml
@@ -34,6 +34,5 @@
 
   when:
     - ansible_os_family == 'Debian'
-    - firewall_service is defined
+    - "{{ firewall_service }} is defined"
     - (docker_skip_tasks is not defined or not docker_skip_tasks)
-

--- a/src/roles/gluster/tasks/setup-Debian.yml
+++ b/src/roles/gluster/tasks/setup-Debian.yml
@@ -1,11 +1,52 @@
 ---
+- name: Add apt key for Gluster
+  apt_key:
+    url: https://download.gluster.org/pub/gluster/glusterfs/5/rsa.pub
+    state: present
+
+- name: Register ID  (e.g. 9)
+  shell: grep 'VERSION_ID=' /etc/os-release | cut -d '=' -f 2 | tr -d '"'
+  args:
+    executable: /bin/bash
+  register: debid
+
+- debug:
+    msg: "found Debian ID of {{ debid.stdout }}"
+
+- name: Register version (e.g. stretch)
+  shell: grep 'VERSION=' /etc/os-release | grep -Eo '[a-z]+'
+  args:
+    executable: /bin/bash
+  register: debver
+
+- debug:
+    msg: "found Debian version of {{ debver.stdout }}"
+
+- name: Register architecture (e.g. amd64)
+  shell: dpkg --print-architecture
+  register: debarch
+
+- debug:
+    msg: "found architecture of {{ debarch.stdout }}"
+
 - name: Add PPA for GlusterFS.
   apt_repository:
-    repo: 'ppa:gluster/glusterfs-{{ glusterfs_ppa_version }}'
+    repo: "deb https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/{{ debid.stdout }}/{{ debarch.stdout }}/apt {{ debver.stdout }} main"
     state: present
+    filename: gluster
     update_cache: yes
   register: glusterfs_ppa_added
   when: glusterfs_ppa_use
+
+
+# - name: Add PPA for GlusterFS.
+#   apt_repository:
+#     repo: deb https://download.gluster.org/pub/gluster/glusterfs/LATEST/Debian/9/amd64/apt stretch main
+#     state: present
+#     filename: gluster
+#     update_cache: yes
+#   register: glusterfs_ppa_added
+#   when: glusterfs_ppa_use
 
 - name: Ensure GlusterFS will reinstall if the PPA was just added.
   apt:

--- a/src/roles/gluster/vars/Debian.yml
+++ b/src/roles/gluster/vars/Debian.yml
@@ -1,2 +1,2 @@
 ---
-glusterfs_daemon: glusterfs-server
+glusterfs_daemon: glusterd


### PR DESCRIPTION
### Changes

* "quote" firewall_services in curly braces to avoid error
* configure the PPA repository for gluster
* provide name of package to install

### Issues

* provides further support for Meza on Debian
