### PR TITLE
Add a public_html directory for site assets

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -54,6 +54,8 @@ m_cert_private: /etc/pki/tls/private/meza.key
 m_cert_public: /etc/pki/tls/certs/meza.crt
 m_ca_cert: /etc/pki/tls/certs/meza-ca.crt
 
+# name of web accessible directory
+m_public_html: public_html
 
 # app locations
 m_apache: /etc/httpd
@@ -125,7 +127,7 @@ mysql_performance_schema: "on"
 load_balancer_unmanaged_parsoid_port: 8000
 load_balancer_unmanaged_mediawiki_port: 8080
 
-# Netdata is a monitoring and alerting system 
+# Netdata is a monitoring and alerting system
 m_install_netdata: True
 # we need a certificate to bind to port 20000
 ssl_certificate_file: /etc/haproxy/certs/meza.pem

--- a/src/roles/apache-php/tasks/main.yml
+++ b/src/roles/apache-php/tasks/main.yml
@@ -12,6 +12,14 @@
     group: "{{ group_apache }}"
     mode: 0775
 
+- name: Make apache own htdocs/public_html directory
+  file:
+    state: directory
+    path: "{{ m_htdocs }}/{{ m_public_html }}"
+    owner: "{{ user_apache }}"
+    group: "{{ group_apache }}"
+    mode: 0775
+
 - name: Ensure user meza-ansible and alt-meza-ansible in group "apache"
   user:
     name: "{{ item }}"

--- a/src/roles/htdocs/templates/.htaccess.j2
+++ b/src/roles/htdocs/templates/.htaccess.j2
@@ -25,6 +25,9 @@
     # Allow access to ServerPerformance plot page and support files
     RewriteRule ^ServerPerformance(?:/|$)(.*)$ - [L]
 
+    # Allow access to public_html directory for site assets
+    RewriteRule ^{{ m_public_html }}(?:/|$)(.*)$ - [L]
+
     {% if allow_backup_downloads %}
     # Allow access to BackupDownload function
     RewriteRule ^BackupDownload(?:/|$)(.*)$ - [L]


### PR DESCRIPTION
### Changes
This feature creates an Apache-owned directory within the document root (default 'public_html'). The intention is to allow for supplemental site assets such as headers, footers, scripts, and images to be accessible in a web location.

### Issues

This feature touches two roles, but I guess I was too lazy or don't understand how to have two separate roles create and modify the same file.

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Update documentation at https://www.mediawiki.org/wiki/Meza

## Default variables and overrides

A user may specify a value for <code>m_public_html</code> to provide a web-accessible directory where additional site assets such as images or scripts may be loaded.  The default value it 'public_html' which is located at <code>/opt/htdocs/public_html</code>. Any override must not conflict with existing directory names such as WikiBlender.