### PR TITLE
Feature multi domain take2

### DIFF
--- a/config/MezaCoreExtensions.yml
+++ b/config/MezaCoreExtensions.yml
@@ -108,9 +108,9 @@ list:
     repo: https://github.com/wikimedia/mediawiki-extensions-PageForms.git
     # commit includes spreadsheet sorting which didn't make PageForms 4.4.1
     version: "730390a31a56c001af83948af1eefc5174abbe06"
-  - name: DismissableSiteNotice
-    repo: https://github.com/wikimedia/mediawiki-extensions-DismissableSiteNotice.git
-    version: "{{ mediawiki_default_branch }}"
+    #  - name: DismissableSiteNotice
+    #    repo: https://github.com/wikimedia/mediawiki-extensions-DismissableSiteNotice.git
+    #    version: "{{ mediawiki_default_branch }}"
   - name: WikiEditor
     repo: https://github.com/wikimedia/mediawiki-extensions-WikiEditor.git
     version: "{{ mediawiki_default_branch }}"

--- a/config/MezaCoreExtensions.yml
+++ b/config/MezaCoreExtensions.yml
@@ -54,7 +54,7 @@ list:
     repo: https://github.com/wikimedia/mediawiki-extensions-Scribunto.git
     version: "{{ mediawiki_default_branch }}"
     config: |
-      $wgScribuntoDefaultEngine = 'luasandbox';
+      $wgScribuntoDefaultEngine = 'luastandalone';
       $wgScribuntoUseGeSHi = true;
       $wgScribuntoUseCodeEditor = true;
       #  - name: "Semantic Scribunto"
@@ -257,7 +257,7 @@ list:
     version: tags/0.10.0
   - name: Wiretap
     repo: https://github.com/freephile/Wiretap.git
-    version: master 
+    version: master
   - name: ApprovedRevs
     repo: https://github.com/wikimedia/mediawiki-extensions-ApprovedRevs.git
     # Use this commit until a release tag for v1.0 is created

--- a/config/MezaCoreExtensions.yml
+++ b/config/MezaCoreExtensions.yml
@@ -1,55 +1,55 @@
 ---
 list:
 
-  - name: Semantic MediaWiki
-    composer: "mediawiki/semantic-media-wiki"
-    version: "3.0.0"
-    config: |
-      // Enable Semantic MediaWiki semantics
-      enableSemantics( $wikiId );
-
-      // Semantic MediaWiki Settings
-      $smwgQMaxSize = 5000;
-
-      // allows adding semantic properties to Templates themselves
-      // (not just on pages via templates).
-      $smwgNamespacesWithSemanticLinks[NS_TALK] = true;
-      $smwgNamespacesWithSemanticLinks[NS_TEMPLATE] = true;
-
-      // Always use DB_SLAVE for temporary table actions. Need to pick either
-      // DB_SLAVE or DB_MASTER for this, since temporary tables will either not
-      // replicate at all or won't replicate fast enough (or, even if they do
-      // technically replicate, they are only available to the session that
-      // created them, and thus they effectively don't replicate). Picking
-      // DB_SLAVE since temporary tables are effectively a read-action since
-      // they are used only for making more efficient queries.
-      $smwgLocalConnectionConf['mw.db.queryengine'] = [ 'read' => DB_SLAVE, 'write' => DB_SLAVE ];
-
-  - name: Semantic Result Formats
-    composer: "mediawiki/semantic-result-formats"
-    version: "3.0.0"
-    config: |
-      // In SRF 3.0+ you need to do this, too:
-      wfLoadExtension( 'SemanticResultFormats' );
-
-      // SemanticResultFormats formats enabled (beyond defaults)
-      // These are disabled by default because they send data to external
-      // web services for rendering, which may be considered a data leak
-      // $srfgFormats[] = 'googlebar';
-      // $srfgFormats[] = 'googlepie';
-
-      // Disabled until the proper dependencies are added (PHPExcel I think)
-      // $srfgFormats[] = 'excel';
-
-      // Enables the "filtered" format. Where do we use this?
-      $srfgFormats[] = 'filtered';
-
-      // Disabled due to some issue on FOD wikis. Confirm, reenable if possible
-      // $srfgFormats[] = 'exhibit';
-
-  - name: SemanticCompoundQueries
-    composer: "mediawiki/semantic-compound-queries"
-    version: "1.2.0"
+        #  - name: Semantic MediaWiki
+        #    composer: "mediawiki/semantic-media-wiki"
+        #    version: "3.0.0"
+        #    config: |
+        #      // Enable Semantic MediaWiki semantics
+        #      enableSemantics( $wikiId );
+        #
+        #      // Semantic MediaWiki Settings
+        #      $smwgQMaxSize = 5000;
+        #
+        #      // allows adding semantic properties to Templates themselves
+        #      // (not just on pages via templates).
+        #      $smwgNamespacesWithSemanticLinks[NS_TALK] = true;
+        #      $smwgNamespacesWithSemanticLinks[NS_TEMPLATE] = true;
+        #
+        #      // Always use DB_SLAVE for temporary table actions. Need to pick either
+        #      // DB_SLAVE or DB_MASTER for this, since temporary tables will either not
+        #      // replicate at all or won't replicate fast enough (or, even if they do
+        #      // technically replicate, they are only available to the session that
+        #      // created them, and thus they effectively don't replicate). Picking
+        #      // DB_SLAVE since temporary tables are effectively a read-action since
+        #      // they are used only for making more efficient queries.
+        #      $smwgLocalConnectionConf['mw.db.queryengine'] = [ 'read' => DB_SLAVE, 'write' => DB_SLAVE ];
+        #
+        #  - name: Semantic Result Formats
+        #    composer: "mediawiki/semantic-result-formats"
+        #    version: "3.0.0"
+        #    config: |
+        #      // In SRF 3.0+ you need to do this, too:
+        #      wfLoadExtension( 'SemanticResultFormats' );
+        #
+        #      // SemanticResultFormats formats enabled (beyond defaults)
+        #      // These are disabled by default because they send data to external
+        #      // web services for rendering, which may be considered a data leak
+        #      // $srfgFormats[] = 'googlebar';
+        #      // $srfgFormats[] = 'googlepie';
+        #
+        #      // Disabled until the proper dependencies are added (PHPExcel I think)
+        #      // $srfgFormats[] = 'excel';
+        #
+        #      // Enables the "filtered" format. Where do we use this?
+        #      $srfgFormats[] = 'filtered';
+        #
+        #      // Disabled due to some issue on FOD wikis. Confirm, reenable if possible
+        #      // $srfgFormats[] = 'exhibit';
+        #
+        #  - name: SemanticCompoundQueries
+        #    composer: "mediawiki/semantic-compound-queries"
+        #    version: "1.2.0"
   - name: Scribunto
     repo: https://github.com/wikimedia/mediawiki-extensions-Scribunto.git
     version: "{{ mediawiki_default_branch }}"
@@ -57,11 +57,11 @@ list:
       $wgScribuntoDefaultEngine = 'luasandbox';
       $wgScribuntoUseGeSHi = true;
       $wgScribuntoUseCodeEditor = true;
-  - name: "Semantic Scribunto"
-    composer: "mediawiki/semantic-scribunto"
-    version: 2.0.0
-    config: |
-      wfLoadExtension( 'SemanticScribunto' );
+      #  - name: "Semantic Scribunto"
+      #    composer: "mediawiki/semantic-scribunto"
+      #    version: 2.0.0
+      #    config: |
+      #      wfLoadExtension( 'SemanticScribunto' );
   - name: SubPageList
     composer: "mediawiki/sub-page-list"
     version: "1.5.0"
@@ -157,6 +157,7 @@ list:
       // https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods
       // https://www.mediawiki.org/wiki/Extension:UniversalLanguageSelector
       $wgULSIMEEnabled = false;
+      $wgULSLanguageDetection = false;
 
   - name: VisualEditor
     repo: https://github.com/wikimedia/mediawiki-extensions-VisualEditor.git
@@ -185,9 +186,9 @@ list:
   - name: RevisionSlider
     repo: https://github.com/wikimedia/mediawiki-extensions-RevisionSlider.git
     version: "{{ mediawiki_default_branch }}"
-  - name: CollapsibleVector
-    repo: https://github.com/wikimedia/mediawiki-extensions-CollapsibleVector
-    version: "{{ mediawiki_default_branch }}"
+    #  - name: CollapsibleVector
+    #    repo: https://github.com/wikimedia/mediawiki-extensions-CollapsibleVector
+    #    version: "{{ mediawiki_default_branch }}"
   - name: SimpleMathJax
     repo: https://github.com/jamesmontalvo3/SimpleMathJax.git
     version: e94afaffcdde8d926b166fdd166162f9519beaa1
@@ -215,19 +216,19 @@ list:
     repo: https://github.com/wikimedia/mediawiki-extensions-StringFunctionsEscaped.git
     version: "{{ mediawiki_default_branch }}"
     legacy_load: true
-  - name: WhoIsWatching
-    repo: https://github.com/wikimedia/mediawiki-extensions-WhoIsWatching.git
-    version: "{{ mediawiki_default_branch }}"
-    config: |
-      $wgPageShowWatchingUsers = true;
-  - name: SemanticInternalObjects
-    repo: https://github.com/wikimedia/mediawiki-extensions-SemanticInternalObjects.git
-    version: "{{ mediawiki_default_branch }}"
-    legacy_load: true
-  - name: SemanticDrilldown
-    repo: https://github.com/wikimedia/mediawiki-extensions-SemanticDrilldown.git
-    version: "{{ mediawiki_default_branch }}"
-    legacy_load: true
+    #- name: WhoIsWatching
+    #- repo: https://github.com/wikimedia/mediawiki-extensions-WhoIsWatching.git
+    #- version: "{{ mediawiki_default_branch }}"
+    #- config: |
+    #-   $wgPageShowWatchingUsers = true;
+    #- name: SemanticInternalObjects
+    #- repo: https://github.com/wikimedia/mediawiki-extensions-SemanticInternalObjects.git
+    #- version: "{{ mediawiki_default_branch }}"
+    #- legacy_load: true
+    #- name: SemanticDrilldown
+    #- repo: https://github.com/wikimedia/mediawiki-extensions-SemanticDrilldown.git
+    #- version: "{{ mediawiki_default_branch }}"
+    #- legacy_load: true
   - name: Arrays
     repo: https://github.com/wikimedia/mediawiki-extensions-Arrays.git
     version: "2166695159a9a5eb18cb96d4811cdefa0978ab8a"
@@ -255,8 +256,8 @@ list:
     repo: https://github.com/jamesmontalvo3/MediaWiki-CopyWatchers.git
     version: tags/0.10.0
   - name: Wiretap
-    repo: https://github.com/enterprisemediawiki/Wiretap.git
-    version: tags/0.1.0
+    repo: https://github.com/freephile/Wiretap.git
+    version: master 
   - name: ApprovedRevs
     repo: https://github.com/wikimedia/mediawiki-extensions-ApprovedRevs.git
     # Use this commit until a release tag for v1.0 is created
@@ -269,11 +270,11 @@ list:
   - name: MasonryMainPage
     repo: https://github.com/enterprisemediawiki/MasonryMainPage.git
     version: tags/0.3.0
-  - name: WatchAnalytics
-    repo: https://github.com/enterprisemediawiki/WatchAnalytics.git
-    version: tags/2.0.1
-    config: |
-      $egPendingReviewsEmphasizeDays = 10; // makes Pending Reviews shake after X days
+    #  - name: WatchAnalytics
+    #repo: https://github.com/enterprisemediawiki/WatchAnalytics.git
+    #version: tags/2.0.1
+    #config: |
+    #  $egPendingReviewsEmphasizeDays = 10; // makes Pending Reviews shake after X days
   - name: Variables
     repo: https://github.com/wikimedia/mediawiki-extensions-Variables.git
     version: "{{ mediawiki_default_branch }}"
@@ -319,54 +320,54 @@ list:
     version: "{{ mediawiki_default_branch }}"
     config: |
       $wgEchoEmailFooterAddress = $wgPasswordSender;
-  - name: UploadWizard
-    repo: https://github.com/wikimedia/mediawiki-extensions-UploadWizard
-    version: "{{ mediawiki_default_branch }}"
-    config: |
-      // Needed to make UploadWizard work in IE, see bug 39877
-      // See also: https://www.mediawiki.org/wiki/Manual:$wgApiFrameOptions
-      $wgApiFrameOptions = 'SAMEORIGIN';
-
-      // Use UploadWizard by default in navigation bar
-      $wgUploadNavigationUrl = "$wgScriptPath/index.php/Special:UploadWizard";
-      $wgUploadWizardConfig = array(
-        'debug' => false,
-        'autoCategory' => 'Uploaded with UploadWizard',
-        'feedbackPage' => 'Project:UploadWizard/Feedback',
-        'altUploadForm' => 'Special:Upload',
-        'fallbackToAltUploadForm' => false,
-        'enableFormData' => true,  # Should FileAPI uploads be used on supported browsers?
-        'enableMultipleFiles' => true,
-        'enableMultiFileSelect' => true,
-        'tutorial' => array('skip' => true),
-        'fileExtensions' => $wgFileExtensions, //omitting this can cause errors
-        'licensing' => array(
-          // alternatively, use "thirdparty". Set in postLocalSettings.php like:
-          // $wgUploadWizardConfig['licensing']['defaultType'] = 'thirdparty';
-          'defaultType' => 'ownwork',
-
-          'ownWork' => array(
-            'type' => 'or',
-            // Use [[Project:General disclaimer]] instead of default [[Template:Generic]]
-            'template' => 'Project:General disclaimer',
-            'defaults' => array( 'generic' ),
-            'licenses' => array( 'generic' )
-          ),
-
-          'thirdParty' => array(
-            'type' => 'or',
-            'defaults' => array( 'generic' ),
-            'licenseGroups' => array(
-              array(
-                'head' => 'mwe-upwiz-license-generic-head',
-                'template' => 'Project:General disclaimer', // again, use General disclaimer
-                'licenses' => array( 'generic' ),
-              ),
-            )
-          ),
-        ),
-      );
-
+      #  - name: UploadWizard
+      #    repo: https://github.com/wikimedia/mediawiki-extensions-UploadWizard
+      #    version: "{{ mediawiki_default_branch }}"
+      #    config: |
+      #      // Needed to make UploadWizard work in IE, see bug 39877
+      #      // See also: https://www.mediawiki.org/wiki/Manual:$wgApiFrameOptions
+      #      $wgApiFrameOptions = 'SAMEORIGIN';
+      #
+      #      // Use UploadWizard by default in navigation bar
+      #      $wgUploadNavigationUrl = "$wgScriptPath/index.php/Special:UploadWizard";
+      #      $wgUploadWizardConfig = array(
+      #        'debug' => false,
+      #        'autoCategory' => 'Uploaded with UploadWizard',
+      #        'feedbackPage' => 'Project:UploadWizard/Feedback',
+      #        'altUploadForm' => 'Special:Upload',
+      #        'fallbackToAltUploadForm' => false,
+      #        'enableFormData' => true,  # Should FileAPI uploads be used on supported browsers?
+      #        'enableMultipleFiles' => true,
+      #        'enableMultiFileSelect' => true,
+      #        'tutorial' => array('skip' => true),
+      #        'fileExtensions' => $wgFileExtensions, //omitting this can cause errors
+      #        'licensing' => array(
+      #          // alternatively, use "thirdparty". Set in postLocalSettings.php like:
+      #          // $wgUploadWizardConfig['licensing']['defaultType'] = 'thirdparty';
+      #          'defaultType' => 'ownwork',
+      #
+      #          'ownWork' => array(
+      #            'type' => 'or',
+      #            // Use [[Project:General disclaimer]] instead of default [[Template:Generic]]
+      #            'template' => 'Project:General disclaimer',
+      #            'defaults' => array( 'generic' ),
+      #            'licenses' => array( 'generic' )
+      #          ),
+      #
+      #          'thirdParty' => array(
+      #            'type' => 'or',
+      #            'defaults' => array( 'generic' ),
+      #            'licenseGroups' => array(
+      #              array(
+      #                'head' => 'mwe-upwiz-license-generic-head',
+      #                'template' => 'Project:General disclaimer', // again, use General disclaimer
+      #                'licenses' => array( 'generic' ),
+      #              ),
+      #            )
+      #          ),
+      #        ),
+      #      );
+      #
   - name: DataTransfer
     repo: https://github.com/wikimedia/mediawiki-extensions-DataTransfer.git
     version: "{{ mediawiki_default_branch }}"
@@ -374,10 +375,10 @@ list:
     repo: https://github.com/enterprisemediawiki/PageImporter.git
     version: tags/0.1.0
     legacy_load: True
-  - name: SemanticMeetingMinutes
-    repo: https://github.com/enterprisemediawiki/SemanticMeetingMinutes.git
-    version: tags/1.0.0
-    legacy_load: True
+    #  - name: SemanticMeetingMinutes
+    #    repo: https://github.com/enterprisemediawiki/SemanticMeetingMinutes.git
+    #    version: tags/1.0.0
+    #    legacy_load: True
   - name: HeaderFooter
     repo: https://github.com/enterprisemediawiki/HeaderFooter.git
     version: tags/3.0.0

--- a/src/roles/apache-php/tasks/php-redhat.yml
+++ b/src/roles/apache-php/tasks/php-redhat.yml
@@ -92,7 +92,9 @@
       # Available for php56u and php70u. NOT php71u or php72u
       # - "{{ php_ius_version }}-pear"
       # Post 7.0, use the pear1u package for all versions of PHP
-      - pear1u
+      # PEAR is no longer a requirement for Meza. Mail and Net_SMTP installed with
+      # Composer via MW core (MW 1.32+) or composer.local.json (MW 1.31 and lower)
+      # - pear1u
 
       # Not available for PHP 7, due to being built into PHP 7
       # - php56u-pecl-jsonc

--- a/src/roles/apache-php/tasks/php.yml
+++ b/src/roles/apache-php/tasks/php.yml
@@ -43,13 +43,3 @@
   notify:
     - restart apache
   when: ansible_os_family == "RedHat"
-
-- name: Ensure PEAR Mail and Net_SMTP packages installed
-  pear:
-    name: "{{ item }}"
-    state: latest
-  tags:
-    - latest
-  with_items:
-    - Mail
-    - Net_SMTP

--- a/src/roles/apache-php/templates/httpd.conf.j2
+++ b/src/roles/apache-php/templates/httpd.conf.j2
@@ -210,6 +210,19 @@ ErrorLog ${APACHE_LOG_DIR}/error.log
 #
 LogLevel warn
 
+
+## Add compression
+AddOutputFilterByType DEFLATE text/plain
+AddOutputFilterByType DEFLATE text/html
+AddOutputFilterByType DEFLATE text/xml
+AddOutputFilterByType DEFLATE text/css
+AddOutputFilterByType DEFLATE application/xml
+AddOutputFilterByType DEFLATE application/xhtml+xml
+AddOutputFilterByType DEFLATE application/rss+xml
+AddOutputFilterByType DEFLATE application/javascript
+AddOutputFilterByType DEFLATE application/x-javascript
+
+
 <IfModule log_config_module>
 
 	# Logging format:

--- a/src/roles/htdocs/templates/.htaccess.j2
+++ b/src/roles/htdocs/templates/.htaccess.j2
@@ -30,9 +30,9 @@
     RewriteRule ^BackupDownload(?:/|$)(.*)$ - [L]
     {% endif %}
 
-
-	RewriteRule ^/?wiki/{{ wiki_id }}(/.*)?$ %{DOCUMENT_ROOT}/{{ wiki_id }}/index.php [L]
-	RewriteRule ^/?$ %{DOCUMENT_ROOT}/{{ wiki_id }}/index.php [L]
+	RewriteRule ^/?wiki/{{ wiki_id }}(/.*)?$ %{DOCUMENT_ROOT}/w/index.php [env=WIKI:{{wiki_id}},L]
+#	RewriteRule ^/?wiki/{{ wiki_id }}(/.*)?$ %{DOCUMENT_ROOT}/{{ wiki_id }}/index.php [L]
+	RewriteRule ^/?$ %{DOCUMENT_ROOT}/w/index.php [L]
 
 	RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI} !-f
 	RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI} !-d

--- a/src/roles/htdocs/templates/.htaccess.j2
+++ b/src/roles/htdocs/templates/.htaccess.j2
@@ -29,18 +29,13 @@
     # Allow access to BackupDownload function
     RewriteRule ^BackupDownload(?:/|$)(.*)$ - [L]
     {% endif %}
+{% for wiki in list_of_wikis %}
 
-	RewriteRule ^/?wiki/{{ wiki_id }}(/.*)?$ %{DOCUMENT_ROOT}/w/index.php [env=WIKI:{{wiki_id}},L]
-#	RewriteRule ^/?wiki/{{ wiki_id }}(/.*)?$ %{DOCUMENT_ROOT}/{{ wiki_id }}/index.php [L]
+	RewriteRule ^/?wiki/{{ wiki }}(/.*)?$ %{DOCUMENT_ROOT}/w/index.php [env=WIKI:{{wiki}},L]
+#	RewriteRule ^/?wiki/{{ wiki }}(/.*)?$ %{DOCUMENT_ROOT}/{{ wiki }}/index.php [L]
+{% endfor %}
 	RewriteRule ^/?$ %{DOCUMENT_ROOT}/w/index.php [L]
 
-	RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI} !-f
-	RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI} !-d
-	RewriteRule ^/?{{ wiki_id }}/images/thumb/[0-9a-f]/[0-9a-f][0-9a-f]/([^/]+)/([0-9]+)px-.*$ %{DOCUMENT_ROOT}/{{ wiki_id }}/thumb.php?f=$1&width=$2 [L,QSA,B]
-
-	RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI} !-f
-	RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI} !-d
-	RewriteRule ^/?{{ wiki_id }}/images/thumb/archive/[0-9a-f]/[0-9a-f][0-9a-f]/([^/]+)/([0-9]+)px-.*$ %{DOCUMENT_ROOT}/{{ wiki_id }}/thumb.php?f=$1&width=$2&archived=1 [L,QSA,B]
 
 
 </IfModule>

--- a/src/roles/htdocs/templates/.htaccess.j2
+++ b/src/roles/htdocs/templates/.htaccess.j2
@@ -30,10 +30,17 @@
     RewriteRule ^BackupDownload(?:/|$)(.*)$ - [L]
     {% endif %}
 
-    # Taken from MediaWiki.org [[Extension:Simple Farm]]
-    #
-    # Redirect virtual wiki path to physical wiki path. There
-    # can be no wiki accessible using this path.
-    RewriteRule ^(?!mediawiki(?:/|$))[^/]+(?:/(.*))?$ mediawiki/$1
+
+	RewriteRule ^/?wiki/{{ wiki_id }}(/.*)?$ %{DOCUMENT_ROOT}/{{ wiki_id }}/index.php [L]
+	RewriteRule ^/?$ %{DOCUMENT_ROOT}/{{ wiki_id }}/index.php [L]
+
+	RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI} !-f
+	RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI} !-d
+	RewriteRule ^/?{{ wiki_id }}/images/thumb/[0-9a-f]/[0-9a-f][0-9a-f]/([^/]+)/([0-9]+)px-.*$ %{DOCUMENT_ROOT}/{{ wiki_id }}/thumb.php?f=$1&width=$2 [L,QSA,B]
+
+	RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI} !-f
+	RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI} !-d
+	RewriteRule ^/?{{ wiki_id }}/images/thumb/archive/[0-9a-f]/[0-9a-f][0-9a-f]/([^/]+)/([0-9]+)px-.*$ %{DOCUMENT_ROOT}/{{ wiki_id }}/thumb.php?f=$1&width=$2&archived=1 [L,QSA,B]
+
 
 </IfModule>

--- a/src/roles/htdocs/templates/.htaccess.j2
+++ b/src/roles/htdocs/templates/.htaccess.j2
@@ -29,12 +29,19 @@
     # Allow access to BackupDownload function
     RewriteRule ^BackupDownload(?:/|$)(.*)$ - [L]
     {% endif %}
-{% for wiki in list_of_wikis %}
 
-	RewriteRule ^/?wiki/{{ wiki }}(/.*)?$ %{DOCUMENT_ROOT}/w/index.php [env=WIKI:{{wiki}},L]
-#	RewriteRule ^/?wiki/{{ wiki }}(/.*)?$ %{DOCUMENT_ROOT}/{{ wiki }}/index.php [L]
-{% endfor %}
-	RewriteRule ^/?$ %{DOCUMENT_ROOT}/w/index.php [L]
+
+# If the request is not for a valid directory, file, link
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-l
+RewriteRule ^/?(?:wiki)?/(de|en|es|fr|it|ja|ko|pt|ru|sv|zh)/(.*)?$ %{DOCUMENT_ROOT}/wiki/mediawiki/ [env=WIKI:$1,L]
+
+RewriteRule ^/?wiki/public_html(/.*)?$ - [L]
+
+RewriteRule ^/?$ %{DOCUMENT_ROOT}/wiki/en/Main_Page [env=WIKI:en,L]
+
+
 
 
 

--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -480,7 +480,7 @@
 
 
 - name: Verify metastore index upgraded
-  shell: WIKI={{ list_of_wikis[0] }} php /opt/htdocs/mediawiki/extensions/CirrusSearch/maintenance/metastore.php --upgrade
+  shell: WIKI={{ list_of_wikis[0] }} php /opt/htdocs/wiki/mediawiki/extensions/CirrusSearch/maintenance/metastore.php --upgrade
   run_once: true
 
 # Wikis are totally built at this point, but SMW and search need rebuilding

--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -105,8 +105,8 @@
 # tag it latest, so that the symlink gets created whenever core is downloaded
 - name: Link {{ wiki_id }} to core, to enable short urls
   file:
-    src: "{{ wiki_id }}"
-    dest: "{{ m_htdocs }}/w"
+    src: "{{ m_htdocs }}/w"
+    dest: "{{ m_htdocs }}/{{ wiki_id }}"
     state: link
   tags:
     - latest

--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -103,11 +103,13 @@
 
 # create symlink to wiki for short urls
 # tag it latest, so that the symlink gets created whenever core is downloaded
-- name: Link {{ wiki_id }} to core, to enable short urls
+- name: Link wikis to core, to enable short urls
   file:
     src: "{{ m_htdocs }}/w"
-    dest: "{{ m_htdocs }}/{{ wiki_id }}"
+    dest: "{{ m_htdocs }}/{{ item }}"
     state: link
+  with_items:
+    - "{{ list_of_wikis }}"
   tags:
     - latest
 

--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -91,6 +91,26 @@
   tags:
     - mediawiki-core
 
+# create symlink to core for short urls
+# tag it latest, so that the symlink gets created whenever core is downloaded
+- name: Create symlink to core, to enable short urls
+  file:
+    src: "{{ m_mediawiki }}"
+    dest: "{{ m_htdocs }}/w"
+    state: link
+  tags:
+    - latest
+
+# create symlink to wiki for short urls
+# tag it latest, so that the symlink gets created whenever core is downloaded
+- name: Link {{ wiki_id }} to core, to enable short urls
+  file:
+    src: "{{ wiki_id }}"
+    dest: "{{ m_htdocs }}/w"
+    state: link
+  tags:
+    - latest
+
 #
 # EXTENSIONS AND SKINS
 #
@@ -525,4 +545,3 @@
     group: root
     mode: 0755
   when: ansible_os_family == 'RedHat'
-

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -404,7 +404,7 @@ foreach( $mezaDatabaseServers as $databaseServer ) {
 
 # MySQL specific settings
 $wgDBprefix = "";
-$wgSharedDB = "wiki_en";
+// $wgSharedDB = "wiki_en";
 // $wgSharedTables =
 
 # MySQL table options to use during installation or update

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -673,7 +673,7 @@ $wgULSGeoService = false;
 
 $wgNamespacesWithSubpages[NS_MAIN] = true;
 
-$wgUseRCPatrol = false;
+$wgUseRCPatrol = true;
 
 
 

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -69,7 +69,7 @@ if( $wgCommandLineMode ) {
 	} elseif ( in_array( $uriParts[1], ['de','en','es','fr','it','ja','ko','pt','sv','ru','zh'] ) ) {
 		$wikiId = $uriParts[1];
 	} else {
-	  $wikiId = 'en'; // default
+	  // $wikiId = 'en'; // default
 	}
 }
 
@@ -261,6 +261,11 @@ else {
  *
  *
  **/
+ if (isset($_SERVER["REQUEST_SCHEME"])) {
+   define('WIKI_HOST', $_SERVER["REQUEST_SCHEME"] . '://' . $_SERVER["HTTP_HOST"]);
+ } else { // probably commandline invocation
+   define('WIKI_HOST', 'http://127.0.0.1');
+ }
 
 // ref: https://www.mediawiki.org/wiki/Manual:$wgServer
 //   From section #Autodetection:
@@ -271,7 +276,7 @@ else {
 // Depending on proxy setup (particularly for Varnish/Squid caching) may need
 // to set $wgInternalServer:
 // ref: https://www.mediawiki.org/wiki/Manual:$wgInternalServer
-$wgServer = 'https://{{ wiki_app_fqdn }}';
+$wgServer = WIKI_HOST;
 
 // https://www.mediawiki.org/wiki/Manual:$wgScriptPath
 $wgScriptPath = "/$wikiId";
@@ -526,7 +531,7 @@ $wgShellLocale = "en_US.utf8";
 $wgHashedUploadDirectory = true;
 
 # Site language code, should be one of the list in ./languages/Names.php
-$wgLanguageCode = "en";
+$wgLanguageCode = $wikiId;
 
 # https://www.mediawiki.org/wiki/Manual:$wgSecretKey
 $wgSecretKey = "{{ wg_secret_key }}";

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -264,8 +264,8 @@ else {
  *
  *
  **/
- if (isset($_SERVER["REQUEST_SCHEME"])) {
-   define('WIKI_HOST', $_SERVER["REQUEST_SCHEME"] . '://' . $_SERVER["HTTP_HOST"]);
+ if (isset($_SERVER["HTTP_HOST"])) {
+   define('WIKI_HOST', 'https://' . $_SERVER["HTTP_HOST"]);
  } else { // probably commandline invocation
    define('WIKI_HOST', 'http://127.0.0.1');
  }

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -281,7 +281,7 @@ $wgArticlePath = "/wiki/$wikiId/$1";
 $wgUploadPath = "$wgScriptPath/img_auth.php";
 
 // https://www.mediawiki.org/wiki/Manual:$wgUploadDirectory
-$wgUploadDirectory = "{{ m_uploads_dir }}/$wikiId";
+$wgUploadDirectory = "{{ m_uploads_dir }}/en";
 
 // https://www.mediawiki.org/wiki/Manual:$wgLogo
 $wgLogo = "/wikis/$wikiId/config/logo.png";

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -52,7 +52,11 @@ if( $wgCommandLineMode ) {
 else {
 	// get $wikiId from URI
 	$uriParts = explode( '/', $_SERVER['REQUEST_URI'] );
-	$wikiId = strtolower( $uriParts[2] ); // URI has leading slash, so $uriParts[0] is empty string
+        foreach ($uriParts as $k => $v) {
+                if ( 2 == strlen($v) ) {
+                        $wikiId = $v;
+                }
+        }
 }
 
 
@@ -90,9 +94,8 @@ if ( ! in_array( $wikiId, $wikis ) ) {
     // get $wikiId from environment variable
 	$wikiId = getenv( $mezaWikiEnvVarName );
     if (!$wikiId) {
-		$wikiId = 'demo';
 		// handle invalid wiki
-		// die( "No sir, I ain't heard'a no wiki that goes by the name \"$wikiId\"\n" );
+		die( "No sir, I ain't heard'a no wiki that goes by the name \"$wikiId\"\n" );
 	}
 }
 

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -43,20 +43,16 @@ require "{{ m_deploy }}/samlLocalSettings.php";
 
 require '/opt/.deploy-meza/config.php';
 
+
+$mezaWikiEnvVarName='WIKI';
 if( $wgCommandLineMode ) {
-
-	$mezaWikiEnvVarName='WIKI';
-
 	// get $wikiId from environment variable
 	$wikiId = getenv( $mezaWikiEnvVarName );
-
 }
 else {
-
 	// get $wikiId from URI
 	$uriParts = explode( '/', $_SERVER['REQUEST_URI'] );
-	$wikiId = strtolower( $uriParts[1] ); // URI has leading slash, so $uriParts[0] is empty string
-
+	$wikiId = strtolower( $uriParts[2] ); // URI has leading slash, so $uriParts[0] is empty string
 }
 
 
@@ -94,8 +90,9 @@ if ( ! in_array( $wikiId, $wikis ) ) {
     // get $wikiId from environment variable
 	$wikiId = getenv( $mezaWikiEnvVarName );
     if (!$wikiId) {
+		$wikiId = 'demo';
 		// handle invalid wiki
-		die( "No sir, I ain't heard'a no wiki that goes by the name \"$wikiId\"\n" );
+		// die( "No sir, I ain't heard'a no wiki that goes by the name \"$wikiId\"\n" );
 	}
 }
 
@@ -260,6 +257,7 @@ $wgServer = 'https://{{ wiki_app_fqdn }}';
 
 // https://www.mediawiki.org/wiki/Manual:$wgScriptPath
 $wgScriptPath = "/$wikiId";
+$wgArticlePath = "/wiki/$wikiId/$1";
 
 // https://www.mediawiki.org/wiki/Manual:$wgUploadPath
 $wgUploadPath = "$wgScriptPath/img_auth.php";

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -70,6 +70,9 @@ if( $wgCommandLineMode ) {
 		$wikiId = $uriParts[1];
 	} else {
 	  // $wikiId = 'en'; // default
+	  print 'Can not find wiki id';
+	  print_r ($uriParts);
+	  die();
 	}
 }
 
@@ -105,7 +108,7 @@ if ( isset( $wikiIdRedirects[ $wikiId ] ) ) {
 $wikis = array_slice( scandir( "$m_htdocs/wikis" ), 2 );
 
 
-if ( ! in_array( $wikiId, $wikis ) ) {
+if ( ! in_array( $wikiId, $wikis ) && empty ( $wikiId ) ) {
     // get $wikiId from environment variable
 	$wikiId = getenv( $mezaWikiEnvVarName );
     if (!$wikiId) {
@@ -279,7 +282,7 @@ else {
 $wgServer = WIKI_HOST;
 
 // https://www.mediawiki.org/wiki/Manual:$wgScriptPath
-$wgScriptPath = "/$wikiId";
+$wgScriptPath = "/wiki/$wikiId";
 $wgArticlePath = "/wiki/$wikiId/$1";
 
 // https://www.mediawiki.org/wiki/Manual:$wgUploadPath
@@ -289,10 +292,10 @@ $wgUploadPath = "$wgScriptPath/img_auth.php";
 $wgUploadDirectory = "{{ m_uploads_dir }}/en";
 
 // https://www.mediawiki.org/wiki/Manual:$wgLogo
-$wgLogo = "/wikis/$wikiId/config/logo.png";
+$wgLogo = "/wiki/wikis/$wikiId/config/logo.png";
 
 // https://www.mediawiki.org/wiki/Manual:$wgFavicon
-$wgFavicon = "/wikis/$wikiId/config/favicon.ico";
+$wgFavicon = "/wiki/wikis/$wikiId/config/favicon.ico";
 
 
 // https://www.mediawiki.org/wiki/Manual:$wgMetaNamespace
@@ -401,6 +404,8 @@ foreach( $mezaDatabaseServers as $databaseServer ) {
 
 # MySQL specific settings
 $wgDBprefix = "";
+$wgSharedDB = "wiki_en";
+// $wgSharedTables =
 
 # MySQL table options to use during installation or update
 $wgDBTableOptions = "ENGINE=InnoDB, DEFAULT CHARSET=binary";

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -267,7 +267,7 @@ else {
  if (isset($_SERVER["HTTP_HOST"])) {
    define('WIKI_HOST', 'https://' . $_SERVER["HTTP_HOST"]);
  } else { // probably commandline invocation
-   define('WIKI_HOST', 'http://127.0.0.1');
+   define('WIKI_HOST', 'https://integration.familysearch.org');
  }
 
 // ref: https://www.mediawiki.org/wiki/Manual:$wgServer

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -91,10 +91,12 @@ $wikis = array_slice( scandir( "$m_htdocs/wikis" ), 2 );
 
 
 if ( ! in_array( $wikiId, $wikis ) ) {
-
-	// handle invalid wiki
-	die( "No sir, I ain't heard'a no wiki that goes by the name \"$wikiId\"\n" );
-
+    // get $wikiId from environment variable
+	$wikiId = getenv( $mezaWikiEnvVarName );
+    if (!$wikiId) {
+		// handle invalid wiki
+		die( "No sir, I ain't heard'a no wiki that goes by the name \"$wikiId\"\n" );
+	}
 }
 
 {% if meza_auth_type is defined %}

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -43,21 +43,36 @@ require "{{ m_deploy }}/samlLocalSettings.php";
 
 require '/opt/.deploy-meza/config.php';
 
+/*
+ * Fix ENV vars getting prepended with 'REDIRECT_' by Apache
+ */
+function fixApacheEnv () {
+	foreach ($_ENV as $key => $value) {
+	    if (substr($key, 0, 9) === 'REDIRECT_') {
+	        $_ENV[str_replace('REDIRECT_', '', $key)] = $value;
+	        putenv(str_replace('REDIRECT_', '', $key) . '=' . $value);
+	    }
+	}
+}
+fixApacheEnv();
 
 $mezaWikiEnvVarName='WIKI';
+
 if( $wgCommandLineMode ) {
 	// get $wikiId from environment variable
 	$wikiId = getenv( $mezaWikiEnvVarName );
-}
-else {
-	// get $wikiId from URI
+} elseif (empty($wikiId)) {
+
 	$uriParts = explode( '/', $_SERVER['REQUEST_URI'] );
-        foreach ($uriParts as $k => $v) {
-                if ( 2 == strlen($v) ) {
-                        $wikiId = $v;
-                }
-        }
+	if ($uriParts[1] == 'wiki') {
+		$wikiId = strtolower( $uriParts[2] );
+	} elseif ( in_array( $uriParts[1], ['de','en','es','fr','it','ja','ko','pt','sv','ru','zh'] ) ) {
+		$wikiId = $uriParts[1];
+	} else {
+	  $wikiId = 'en'; // default
+	}
 }
+
 
 
 {% if wiki_id_redirects is defined and wiki_id_redirects|length > 0 %}

--- a/src/roles/parsoid-settings/templates/config.yaml.j2
+++ b/src/roles/parsoid-settings/templates/config.yaml.j2
@@ -46,7 +46,7 @@ services:
 
           {% if groups['app-servers']|length|int == 1 and groups['parsoid-servers']|length|int == 1 and groups['app-servers'][0] == groups['parsoid-servers'][0] -%}
 
-          uri: 'http://127.0.0.1:8080/{{ wiki }}/api.php'
+          uri: 'https://{{wiki_app_fqdn}}/wiki/{{ wiki }}/api.php'
 
           {%- elif 'load-balancers' not in groups or groups['load-balancers']|length|int == 0 -%}
 


### PR DESCRIPTION
### Changes

* By making changes to a live site, and then working backwards to make those changes into ansible tasks, I thought I had a working solution. It worked on the manually editted site. However, I must have missed something in translation to Ansible* because the deploy doesn't achieve the desired results. In my case, I'm trying to create a URL like wiki.example.com/wiki/en/Main_Page.

 * for example, I needed to specify `wiki_id` as an `--extra-var` because during the .htaccess step in role 'htdocs' I don't think the variable was defined.  So here's a deploy:
`meza deploy production --extra-vars 'wiki_id=en' --skip-tags gluster,backup,update.php && cd /etc/haproxy/certs && mv meza.pem meza.pem.backup && ln -s fswiki.familysearch.org.pem meza.pem && systemctl reload haproxy && cd /opt/meza`  The parts at the end are to 're-install' the LetsEncrypt certificate for the domain.

### Issues

* Attempts to solve #336 

