### PR TITLE
new variable to effect crawling mode

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -49,6 +49,8 @@ m_backups: /opt/data-meza/backups
 
 # webserver variables
 m_htdocs: /opt/htdocs
+# crawl for default or nocrawl to disallow all
+m_robots_rules: nocrawl
 m_mediawiki: /opt/htdocs/mediawiki
 m_cert_private: /etc/pki/tls/private/meza.key
 m_cert_public: /etc/pki/tls/certs/meza.crt
@@ -125,7 +127,7 @@ mysql_performance_schema: "on"
 load_balancer_unmanaged_parsoid_port: 8000
 load_balancer_unmanaged_mediawiki_port: 8080
 
-# Netdata is a monitoring and alerting system 
+# Netdata is a monitoring and alerting system
 m_install_netdata: True
 # we need a certificate to bind to port 20000
 ssl_certificate_file: /etc/haproxy/certs/meza.pem

--- a/src/roles/htdocs/templates/robots.txt.j2
+++ b/src/roles/htdocs/templates/robots.txt.j2
@@ -13,6 +13,14 @@
 # that go _way_ too fast. If you're irresponsible, your access to the site may be blocked.
 #
 
+{% if {{ m_robots_rules }} == "nocrawl" %}
+
+User-agent: *
+Disallow /
+
+{% else %}
+
+
 # advertising-related bots:
 User-agent: Mediapartners-Google*
 Disallow: /
@@ -163,3 +171,5 @@ Disallow: /w/
 Disallow: /api/
 Disallow: /trap/
 #
+
+{%  endif %}

--- a/src/roles/htdocs/templates/robots.txt.j2
+++ b/src/roles/htdocs/templates/robots.txt.j2
@@ -13,7 +13,7 @@
 # that go _way_ too fast. If you're irresponsible, your access to the site may be blocked.
 #
 
-{% if {{ m_robots_rules }} == "nocrawl" %}
+{% if m_robots_rules == 'nocrawl' %}
 
 User-agent: *
 Disallow /


### PR DESCRIPTION
### Changes

Introduction of new variable **`m_robots_rules`** which defaults to 'nocrawl' 
when m_robots_rules is equal to "nocrawl" then the simple robots.txt file will be
```
UserAgent: *
Disallow /
```
Any other value (such as 'crawl') will give the full "public" robots.txt file that we harvested from MediaWiki.org

### Issues

Site owners need control over whether or not their site is indexed by search engines. While most public sites want to be indexed, some do not.  Even public sites may not want to be crawled until fully developed. Or a public 'staging' site will be 'nocrawl' while the production site will be 'crawl'. Obviously private wikis do not need to be crawled.

