### PR TITLE
Bump WatchAnalytics to 3.1.1

### DIFF
--- a/config/core/MezaCoreExtensions.yml
+++ b/config/core/MezaCoreExtensions.yml
@@ -253,7 +253,7 @@ list:
     version: tags/0.3.0
   - name: WatchAnalytics
     repo: https://github.com/enterprisemediawiki/WatchAnalytics.git
-    version: tags/3.1.0
+    version: tags/3.1.1
     config: |
       $egPendingReviewsEmphasizeDays = 10; // makes Pending Reviews shake after X days
   - name: Variables

--- a/config/core/MezaCoreExtensions.yml
+++ b/config/core/MezaCoreExtensions.yml
@@ -253,7 +253,7 @@ list:
     version: tags/0.3.0
   - name: WatchAnalytics
     repo: https://github.com/enterprisemediawiki/WatchAnalytics.git
-    version: tags/3.0.0
+    version: tags/3.1.0
     config: |
       $egPendingReviewsEmphasizeDays = 10; // makes Pending Reviews shake after X days
   - name: Variables


### PR DESCRIPTION
### Changes

* Upgrades to WatchAnalytics 3.1.1

### Issues

* None

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] create new release