### PR TITLE
Create script to partially automate Meza release process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 
 .vagrant/*
 vagrantconf.yml
+
+# file used by src/scripts/do-release.sh
+.release-notes.tmp

--- a/src/scripts/do-release.sh
+++ b/src/scripts/do-release.sh
@@ -84,15 +84,6 @@ ${COMMITS}
 
 ${CONTRIBUTORS}
 
-### Mediawiki.org pages updated
-
-* TBD
-
-### What still isn't documented?
-
-* TBD
-* See [list of issues and pull requests indicating missing docs](https://github.com/enterprisemediawiki/meza/pulls?utf8=%E2%9C%93&q=label%3A%22open+post-merge+actions%22+)
-
 # How to upgrade
 
 \`\`\`bash
@@ -116,6 +107,16 @@ EOM
 sed -i -e '/=============/r.release-notes.tmp' ./RELEASE-NOTES.md
 sed -i "s/=============/\0\n\n## Meza $NEW_VERSION/" ./RELEASE-NOTES.md
 
+#
+# COMMIT CHANGE
+#
+git add RELEASE-NOTES.md
+# Set current branch as base branch
+BASE_BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
+RELEASE_BRANCH="${NEW_VERSION}-release"
+git checkout -b "${RELEASE_BRANCH}"
+git commit -m "${NEW_VERSION} release"
+git push origin "$BASE_BRANCH"
 
 #
 # OUTPUT DIRECTIONS FOR COMPLETING RELEASE
@@ -127,10 +128,10 @@ echo "*           Release process started           *"
 echo "*                                             *"
 echo "* * * * * * * * * * * * * * * * * * * * * * * *"
 echo
-echo    "Release notes generated. To complete the release do the following:"
+echo    "Release notes generated, committed, and pushed. "
 echo
-echo -e "1. Check changes to RELEASE-NOTES.md with ${RED}git diff${NC}"
-echo    "2. Commit changes and submit a pull request"
+echo -e "1. Check what you pushed with ${RED}git diff HEAD~1..HEAD${NC}"
+echo -e "2. Open a pull request at ${GREEN}https://github.com/enterprisemediawiki/meza/compare/${BASE_BRANCH}...${RELEASE_BRANCH}?expand=1${NC}"
 echo    "3. After the PR is merged create a new release of Meza with these details:"
 echo    "   * Tag: $NEW_VERSION"
 echo    "   * Title: Meza $NEW_VERSION"
@@ -141,6 +142,8 @@ echo    "   git merge $GIT_HASH --ff-only"
 echo -e "   git push origin $RELEASE_BRANCH${NC}"
 echo -e "5. Update ${GREEN}https://www.mediawiki.org/wiki/Meza/Version_history${NC}"
 echo -e "6. Announce on ${GREEN}https://riot.im/app/#/room/#mwstake-MEZA:matrix.org${NC}"
+echo -e "7. Update pages on ${GREEN}https://mediawiki.org/wiki/Meza${NC}"
 echo
 
 rm ${RELEASE_NOTES_FILE}
+

--- a/src/scripts/do-release.sh
+++ b/src/scripts/do-release.sh
@@ -116,7 +116,7 @@ BASE_BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
 RELEASE_BRANCH="${NEW_VERSION}-release"
 git checkout -b "${RELEASE_BRANCH}"
 git commit -m "${NEW_VERSION} release"
-git push origin "$BASE_BRANCH"
+# git push origin "$BASE_BRANCH"
 
 #
 # OUTPUT DIRECTIONS FOR COMPLETING RELEASE
@@ -130,7 +130,7 @@ echo "* * * * * * * * * * * * * * * * * * * * * * * *"
 echo
 echo    "Release notes generated, committed, and pushed. "
 echo
-echo -e "1. Check what you pushed with ${RED}git diff HEAD~1..HEAD${NC}"
+echo -e "1. Check what you committed with ${RED}git diff HEAD~1..HEAD${NC}, then push"
 echo -e "2. Open a pull request at ${GREEN}https://github.com/enterprisemediawiki/meza/compare/${BASE_BRANCH}...${RELEASE_BRANCH}?expand=1${NC}"
 echo    "3. After the PR is merged create a new release of Meza with these details:"
 echo    "   * Tag: $NEW_VERSION"

--- a/src/scripts/do-release.sh
+++ b/src/scripts/do-release.sh
@@ -18,28 +18,54 @@ LATEST="${PREVIOUS_RELEASES##*$'\n'}"
 GIT_HASH=$(git rev-parse HEAD | cut -c1-8)
 
 #
-# READ IN USER INPUTS
+# WELCOME MESSAGE
 #
-read -p "Add optional single line of overview text: " OVERVIEW
+echo
+echo "* * * * * * * * * * * * * * * * * * * * * * * *"
+echo "*                                             *"
+echo "*           Meza Release Generator            *"
+echo "*                                             *"
+echo "* * * * * * * * * * * * * * * * * * * * * * * *"
 
-echo -e "${BLUE}"
+#
+# USER INPUT: CHOOSE OLD VERSION NUMBER TO BASE FROM
+#
+echo -e "${GREEN}"
 echo "${PREVIOUS_RELEASES}"
 echo -e "${NC}"
 
 while [ -z "$OLD_VERSION" ]; do
-	read -p "Enter previous release number (options in blue above): " -i "$LATEST" -e OLD_VERSION
+	read -p "Enter previous release number (options in green above): " -i "$LATEST" -e OLD_VERSION
 done;
 
+#
+# SETUP LIST OF COMMITS FOR DISPLAY NOW AND INCLUSION IN RELEASE-NOTES.MD
+#
+COMMITS=$(git log --oneline --no-merges "${OLD_VERSION}..HEAD" | while read line; do echo "* $line"; done)
+
+echo
+echo -e "From ${GREEN}${OLD_VERSION}${NC} to ${GREEN}HEAD${NC}, these are the non-merge commits:"
+echo -e "${GREEN}"
+echo "${COMMITS}"
+echo -e "${NC}"
+
+#
+# USER INPUT: CHOOSE NEW VERSION NUMBER
+#
 while [ -z "$NEW_VERSION" ]; do
 	read -p "Enter new version number in form X.Y.Z: " NEW_VERSION
 done;
 
 #
+# USER INPUT: OVERVIEW TEXT
+#
+read -p "Based upon commits above, choose optional 1-line overview: " OVERVIEW
+
+#
 # SETUP VARS BASED UPON USER INPUT
 #
-MAJOR_VERSION=$(echo "$OLD_VERSION" | cut -f1 -d".")
+MAJOR_VERSION=$(echo "$NEW_VERSION" | cut -f1 -d".")
 RELEASE_BRANCH="${MAJOR_VERSION}.x"
-COMMITS=$(git log --oneline --no-merges "${OLD_VERSION}..HEAD" | while read line; do echo "* $line"; done)
 CONTRIBUTORS=$(git shortlog -sn "${OLD_VERSION}..HEAD" | while read line; do echo "* $line"; done)
 
 #
@@ -94,6 +120,12 @@ sed -i "s/=============/\0\n\n## Meza $NEW_VERSION/" ./RELEASE-NOTES.md
 #
 # OUTPUT DIRECTIONS FOR COMPLETING RELEASE
 #
+echo
+echo "* * * * * * * * * * * * * * * * * * * * * * * *"
+echo "*                                             *"
+echo "*           Release process started           *"
+echo "*                                             *"
+echo "* * * * * * * * * * * * * * * * * * * * * * * *"
 echo
 echo    "Release notes generated. To complete the release do the following:"
 echo

--- a/src/scripts/do-release.sh
+++ b/src/scripts/do-release.sh
@@ -47,6 +47,7 @@ CONTRIBUTORS=$(git shortlog -sn "${OLD_VERSION}..HEAD" | while read line; do ech
 #
 RELEASE_NOTES_FILE=./.release-notes.tmp
 cat > ${RELEASE_NOTES_FILE} <<- EOM
+
 ${OVERVIEW}
 
 ### Commits since $OLD_VERSION
@@ -77,33 +78,37 @@ EOM
 #
 # OUTPUT RELEASE NOTES IN GREEN ON COMMAND LINE
 #
-echo -e "${GREEN}"
-cat "${RELEASE_NOTES_FILE}"
-echo -e "${NC}"
+# I think preferable not to output this here
+# echo -e "${GREEN}"
+# cat "${RELEASE_NOTES_FILE}"
+# echo -e "${NC}"
+
 
 #
 # TO-DO: Automate edit of release notes
 #
-# sed -e '1,/=============/r.release-notes.tmp' ./RELEASE-NOTES.md
+sed -i -e '/=============/r.release-notes.tmp' ./RELEASE-NOTES.md
+sed -i "s/=============/\0\n\n## Meza $NEW_VERSION/" ./RELEASE-NOTES.md
+
 
 #
 # OUTPUT DIRECTIONS FOR COMPLETING RELEASE
 #
 echo
-echo    "1. Edit RELEASE-NOTES.md"
-echo -e "   * Copy the ${GREEN}green text${NC} from above and add it under the title ${GREEN}## Meza $NEW_VERSION${NC}"
-echo    "   * Edit the text as required"
-echo    "2. Commit your changes and submit a pull request"
+echo    "Release notes generated. To complete the release do the following:"
+echo
+echo -e "1. Check changes to RELEASE-NOTES.md with ${RED}git diff${NC}"
+echo    "2. Commit changes and submit a pull request"
 echo    "3. After the PR is merged create a new release of Meza with these details:"
 echo    "   * Tag: $NEW_VERSION"
 echo    "   * Title: Meza $NEW_VERSION"
-echo -e "   * Description: ${GREEN}green text${NC} from above (edits as required)"
-echo    "4. Bump the release branch $RELEASE_BRANCH to this release:"
+echo -e "   * Description: the ${GREEN}Meza $NEW_VERSION${NC} section from RELEASE-NOTES.md"
+echo -e "4. Move the ${GREEN}$RELEASE_BRANCH${NC} branch to the same point as the ${GREEN}${NEW_VERSION}${NC} release:"
 echo -e "   ${RED}git checkout $RELEASE_BRANCH"
 echo    "   git merge $GIT_HASH --ff-only"
 echo -e "   git push origin $RELEASE_BRANCH${NC}"
-echo -e "5. Update ${BLUE}https://www.mediawiki.org/wiki/Meza/Version_history${NC}"
-echo -e "6. Announce on ${BLUE}https://riot.im/app/#/room/#mwstake-MEZA:matrix.org${NC}"
+echo -e "5. Update ${GREEN}https://www.mediawiki.org/wiki/Meza/Version_history${NC}"
+echo -e "6. Announce on ${GREEN}https://riot.im/app/#/room/#mwstake-MEZA:matrix.org${NC}"
 echo
 
 rm ${RELEASE_NOTES_FILE}

--- a/src/scripts/do-release.sh
+++ b/src/scripts/do-release.sh
@@ -1,0 +1,109 @@
+#!/bin/sh
+#
+# Generate release notes for Meza
+
+#
+# SET VARIABLES FOR COLORIZING BASH OUTPUT
+#
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+#
+# SETUP KNOWN VARS PRIOR TO USER INPUT
+#
+PREVIOUS_RELEASES=$(git tag -l | sed '/^v0/ d' | sed '/^v1/ d')
+LATEST="${PREVIOUS_RELEASES##*$'\n'}"
+GIT_HASH=$(git rev-parse HEAD | cut -c1-8)
+
+#
+# READ IN USER INPUTS
+#
+read -p "Add optional single line of overview text: " OVERVIEW
+
+echo -e "${BLUE}"
+echo "${PREVIOUS_RELEASES}"
+echo -e "${NC}"
+
+while [ -z "$OLD_VERSION" ]; do
+	read -p "Enter previous release number (options in blue above): " -i "$LATEST" -e OLD_VERSION
+done;
+
+while [ -z "$NEW_VERSION" ]; do
+	read -p "Enter new version number in form X.Y.Z: " NEW_VERSION
+done;
+
+#
+# SETUP VARS BASED UPON USER INPUT
+#
+MAJOR_VERSION=$(echo "$OLD_VERSION" | cut -f1 -d".")
+RELEASE_BRANCH="${MAJOR_VERSION}.x"
+COMMITS=$(git log --oneline --no-merges "${OLD_VERSION}..HEAD" | while read line; do echo "* $line"; done)
+CONTRIBUTORS=$(git shortlog -sn "${OLD_VERSION}..HEAD" | while read line; do echo "* $line"; done)
+
+#
+# GENERATE RELEASE NOTES INTO TEMP FILE
+#
+RELEASE_NOTES_FILE=./.release-notes.tmp
+cat > ${RELEASE_NOTES_FILE} <<- EOM
+${OVERVIEW}
+
+### Commits since $OLD_VERSION
+
+${COMMITS}
+
+### Contributors
+
+${CONTRIBUTORS}
+
+### Mediawiki.org pages updated
+
+* TBD
+
+### What still isn't documented?
+
+* TBD
+* See [list of issues and pull requests indicating missing docs](https://github.com/enterprisemediawiki/meza/pulls?utf8=%E2%9C%93&q=label%3A%22open+post-merge+actions%22+)
+
+# How to upgrade
+
+\`\`\`bash
+sudo meza update ${NEW_VERSION}
+sudo meza deploy <insert-your-environment-name>
+\`\`\`
+EOM
+
+#
+# OUTPUT RELEASE NOTES IN GREEN ON COMMAND LINE
+#
+echo -e "${GREEN}"
+cat "${RELEASE_NOTES_FILE}"
+echo -e "${NC}"
+
+#
+# TO-DO: Automate edit of release notes
+#
+# sed -e '1,/=============/r.release-notes.tmp' ./RELEASE-NOTES.md
+
+#
+# OUTPUT DIRECTIONS FOR COMPLETING RELEASE
+#
+echo
+echo    "1. Edit RELEASE-NOTES.md"
+echo -e "   * Copy the ${GREEN}green text${NC} from above and add it under the title ${GREEN}## Meza $NEW_VERSION${NC}"
+echo    "   * Edit the text as required"
+echo    "2. Commit your changes and submit a pull request"
+echo    "3. After the PR is merged create a new release of Meza with these details:"
+echo    "   * Tag: $NEW_VERSION"
+echo    "   * Title: Meza $NEW_VERSION"
+echo -e "   * Description: ${GREEN}green text${NC} from above (edits as required)"
+echo    "4. Bump the release branch $RELEASE_BRANCH to this release:"
+echo -e "   ${RED}git checkout $RELEASE_BRANCH"
+echo    "   git merge $GIT_HASH --ff-only"
+echo -e "   git push origin $RELEASE_BRANCH${NC}"
+echo -e "5. Update ${BLUE}https://www.mediawiki.org/wiki/Meza/Version_history${NC}"
+echo -e "6. Announce on ${BLUE}https://riot.im/app/#/room/#mwstake-MEZA:matrix.org${NC}"
+echo
+
+rm ${RELEASE_NOTES_FILE}


### PR DESCRIPTION
### Changes

Created `src/scripts/do-release.sh` which helps with the release process.

Do `src/scripts/do-release.sh` from within the Meza directory _when you're on the commit you want to use to make a release_. This will prompt for three inputs:

1. The previous release number (which it pre-fills with the last release)
2. The new release number you'd like to create
3. A one-line overview of the changes (list of changes shown to jog your memory)

This then edits `RELEASE-NOTES.md` and provides a list of actions to perform to complete the release. 

### Issues

* None

### Post-merge actions

Post-merge, the following actions need to be addressed:

- None (this doesn't really need to be documented on mw.o since it's just an internal process)