### PR TITLE
31.3.0 release

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,28 @@
 Release Notes
 =============
 
+## Meza 31.3.0
+
+WatchAnalytics to 3.1.2 for diff in PendingReviews, improved on-page banners
+
+### Commits since 31.2.5
+
+* fc22af4 Bump to WatchAnalytics 3.1.2
+* 70b4e2b Bump to WatchAnalytics 3.1.1
+* ce403a5 Bump WatchAnalytics to 3.1.0
+
+### Contributors
+
+* 4	krisfield
+* 1	James Montalvo
+
+# How to upgrade
+
+```bash
+sudo meza update 31.3.0
+sudo meza deploy <insert-your-environment-name>
+```
+
 ## Meza 31.2.4
 
 ### Commits since 31.2.3


### PR DESCRIPTION
### Changes

WatchAnalytics to 3.1.2 for diff in PendingReviews, improved on-page banners

### Issues

None

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [x] Update relevant docs on https://mediawiki.org/wiki/Meza
- [ ] Create a new release of Meza with these details:
  - Tag: 31.3.0
  - Title: Meza 31.3.0
  - Description: the Meza 31.3.0 section from RELEASE-NOTES.md
- [ ] Move the 31.x branch to the same point as the 31.3.0 release:
  - `git fetch`
  - `git checkout 31.x`
  - `git merge tags/31.3.0 --ff-only`
  - `git push origin 31.x`
- [ ] Update https://www.mediawiki.org/wiki/Meza/Version_history with:
  - `* [https://github.com/enterprisemediawiki/meza/releases/tag/31.3.0 31.3.0]: WatchAnalytics to 3.1.2 for diff in PendingReviews, improved on-page banners`
- [ ] Announce on https://riot.im/app/#/room/#mwstake-MEZA:matrix.org:
  - `Meza 31.3.0 released! WatchAnalytics to 3.1.2 for diff in PendingReviews, improved on-page banners. See details at https://github.com/enterprisemediawiki/meza/releases/tag/31.3.0`