### PR TITLE
The SFTP server is in a different location on Debian

### DIFF
--- a/src/roles/base/templates/sshd_config.j2
+++ b/src/roles/base/templates/sshd_config.j2
@@ -143,7 +143,11 @@ AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE
 AcceptEnv XMODIFIERS
 
 # override default of no subsystems
+{% if ansible_os_family == 'Debian' %}
+Subsystem       sftp    /usr/lib/openssh/sftp-server
+{% else %}
 Subsystem       sftp    /usr/libexec/openssh/sftp-server
+{% endif %}
 
 # Example of overriding settings on a per-user basis
 #Match User anoncvs


### PR DESCRIPTION
It's important to have the path correct. This affects, among other things, the ability to use SSHFS with your nodes.

### Changes

Add conditional to vary the path to sftp-server depending on the OS

### Issues
SSHFS and other SFTP-dependent operations fail without the correct path.

### Post-merge actions

Post-merge, the following actions need to be addressed:
None
