### PR TITLE
Use 'remote_src' to copy Foo.xz

### DIFF
--- a/src/roles/nodejs/tasks/main.yml
+++ b/src/roles/nodejs/tasks/main.yml
@@ -72,6 +72,7 @@
   unarchive:
     src: /tmp/node.tar.xz
     dest: /usr/local/lib/node
+    remote_src: yes
     extra_opts: [--strip-components=1]
   when: "node_version.stdout != 'v8.11.1'"
 


### PR DESCRIPTION
When the parsoid host is not the controller, the src file is on the remote. Therefore, use remote_src: yes so that Ansible finds the file to copy.
Otherwise, this fails when the Parsoid host in inventory is not the same host as the controller.  In my example setup, I have two application servers and both are designated as Parsoid servers. One is the controller, the other app server is just an app server.

### Changes

* Please provide
* a list
* of changes

### Issues

* Closes #123456789 ???
* Addresses #987654321 ???

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Update documentation at https://www.mediawiki.org/wiki/Meza
