### PR TITLE
Use base ImageMagick rather than Meza's own RPM

### DIFF
--- a/src/roles/imagemagick/tasks/main.yml
+++ b/src/roles/imagemagick/tasks/main.yml
@@ -1,8 +1,19 @@
 ---
-- name: Ensure ghostscript installed
-  yum: name=ghostscript state=installed
-- name: Install Imagemagick from meza repo
-  yum: name=https://raw.github.com/enterprisemediawiki/meza-packages/master/RPMs/imagemagick_7.0.3_x86_64.rpm
+- name: Ensure old ImageMagick installed from Meza RPM
+  yum:
+    name: imagemagick-7.0.3-1.x86_64
+    state: absent
+
+- name: Ensure ImageMagick at latest version
+  yum:
+    name:
+      - ghostscript
+      - ImageMagick
+      - ImageMagick-devel
+    state: latest
+  tags:
+    - latest
+
 - name: Copy xpdf bin64 files to /usr/local/bin
   copy:
     src: xpdf-3.04-bin64/

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -601,9 +601,6 @@ $wgMaxImageArea = 1.25e10; // Images on [[Snorkel]] fail without this
 ini_set( 'pcre.backtrack_limit', 1000000000 ); //1 billion
 
 
-$wgUseImageMagick = true;
-$wgImageMagickConvertCommand = '/usr/local/bin/convert';
-
 // Allowed file types
 $wgFileExtensions = array(
 	'aac',


### PR DESCRIPTION
This change is being considered due to intermittent failures getting Meza's own RPM with ImageMagick 7.0.3 instead of CentOS's base 6.7.8.9. This change would effectively downgrade ImageMagick for Meza in favor of a more stable version.

### Changes

* Switches to using ImageMagick from CentOS 7 base repo rather than the `enterprisemediawiki/meza-packages` RPM
* Removes redundant `$wgUseImageMagick` and `$wgImageMagickConvertCommand` lines in `LocalSettings.php`

### Issues

* Closes #1140

### Post-merge actions

Post-merge, the following actions need to be addressed:

- None