### PR TITLE
Move vault passwords from meza-ansible home to /opt/conf-meza/vault

### DIFF
--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -14,6 +14,7 @@ m_use_production_settings: True
 m_config_core: /opt/meza/config/core
 m_local_secret: /opt/conf-meza/secret
 m_local_public: /opt/conf-meza/public
+m_config_vault: /opt/conf-meza/vault
 m_home: /opt/conf-meza/users
 
 # Config files written by Ansible which need a place to live on non-controller

--- a/src/playbooks/site.yml
+++ b/src/playbooks/site.yml
@@ -58,7 +58,7 @@
     shell: >
       ansible-vault encrypt
       /opt/conf-meza/secret/{{ env }}/secret.yml
-      --vault-password-file {{ m_home }}/meza-ansible/.vault-pass-{{ env }}.txt
+      --vault-password-file {{ m_config_vault }}/vault-pass-{{ env }}.txt
     failed_when: False
 
   # Note: without this, the encryption above changes mode to 0600 and ownership

--- a/src/playbooks/site.yml
+++ b/src/playbooks/site.yml
@@ -8,6 +8,7 @@
   become: yes
   vars:
     m_home: "/opt/conf-meza/users"
+    m_config_vault: "/opt/conf-meza/vault"
   tasks:
   - name: Ensure no password on meza-ansible user on controller
     shell: passwd --delete meza-ansible

--- a/src/roles/haproxy/tasks/main.yml
+++ b/src/roles/haproxy/tasks/main.yml
@@ -55,7 +55,7 @@
   shell: >
     ansible-vault encrypt
     {{ item }}
-    --vault-password-file {{ m_home }}/meza-ansible/.vault-pass-{{ env }}.txt
+    --vault-password-file {{ m_config_vault }}/vault-pass-{{ env }}.txt
   failed_when: False
   delegate_to: localhost
   run_once: True
@@ -67,7 +67,7 @@
   shell: >
     ansible-vault view
     /opt/conf-meza/secret/{{ env }}/ssl/meza.key
-    --vault-password-file {{ m_home }}/meza-ansible/.vault-pass-{{ env }}.txt
+    --vault-password-file {{ m_config_vault }}/vault-pass-{{ env }}.txt
   register: decrypted_key
   delegate_to: localhost
   run_once: True
@@ -76,7 +76,7 @@
   shell: >
     ansible-vault view
     /opt/conf-meza/secret/{{ env }}/ssl/meza.crt
-    --vault-password-file {{ m_home }}/meza-ansible/.vault-pass-{{ env }}.txt
+    --vault-password-file {{ m_config_vault }}/vault-pass-{{ env }}.txt
   register: decrypted_cert
   delegate_to: localhost
   run_once: True

--- a/src/scripts/meza.py
+++ b/src/scripts/meza.py
@@ -325,7 +325,7 @@ def meza_command_setup_env (argv, return_not_exit=False):
 	print "Please review your host file. Run command:"
 	print "  sudo vi /opt/conf-meza/secret/{}/hosts".format(env)
 	print "Please review your secret config. It is encrypted, so edit by running:"
-	print "  sudo ansible-vault edit /opt/conf-meza/secret/{}/secret.yml --vault-password-file /opt/conf-meza/users/meza-ansible/.vault-pass-{}.txt".format(env,env)
+	print "  sudo ansible-vault edit /opt/conf-meza/secret/{}/secret.yml --vault-password-file {}".format(env,vault_pass_file)
 	if return_not_exit:
 		return rc
 	else:
@@ -680,12 +680,28 @@ def meza_shell_exec_exit( return_code=0 ):
 def get_vault_pass_file ( env ):
 	import pwd
 	import grp
+
 	home_dir = defaults['m_home']
-	vault_pass_file = '{}/meza-ansible/.vault-pass-{}.txt'.format(home_dir,env)
+	legacy_file = '{}/meza-ansible/.vault-pass-{}.txt'.format(home_dir,env)
+
+	vault_dir = defaults['m_config_vault']
+	vault_pass_file = '{}/vault-pass-{}.txt'.format(vault_dir, env)
+
 	if not os.path.isfile( vault_pass_file ):
-		with open( vault_pass_file, 'w' ) as f:
-			f.write( random_string( num_chars=64 ) )
-			f.close()
+		if not os.path.exists( vault_dir ):
+			os.mkdir( vault_dir )
+			meza_chown( vault_dir, 'meza-ansible', 'wheel' )
+			os.chmod( vault_dir, 0o700 )
+
+		# If legacy vault password file exists copy that into new location.
+		# Otherwise, create one in the new location
+		if os.path.isfile( legacy_file ):
+			from shutil import copyfile
+			copyfile(legacy_file, vault_pass_file)
+		else:
+			with open( vault_pass_file, 'w' ) as f:
+				f.write( random_string( num_chars=64 ) )
+				f.close()
 
 	# Run this everytime, since it should be fast and if meza-ansible can't
 	# read this then you're stuck!

--- a/tests/docker/backup-to-remote.setup.sh
+++ b/tests/docker/backup-to-remote.setup.sh
@@ -47,7 +47,7 @@ ${docker_exec_1[@]} bash -c "echo -e 'sshd_config_PasswordAuthentication: \"yes\
 
 # secret.yml is encrypted. decrypt first, make edits, re-encrypt.
 # secret_yml="/opt/conf-meza/secret/$env_name/secret.yml"
-# vault_pass="/opt/conf-meza/users/meza-ansible/.vault-pass-$env_name.txt"
+# vault_pass="/opt/conf-meza/vault/vault-pass-$env_name.txt"
 # ${docker_exec_1[@]} bash -c "ansible-vault decrypt $secret_yml --vault-password-file $vault_pass"
 # ${docker_exec_1[@]} bash -c "echo -e '\n' >> $secret_yml"
 # ${docker_exec_1[@]} bash -c "echo 'mysql_root_password_update: yes' >> $secret_yml"

--- a/tests/docker/import-from-alt-remote.setup.sh
+++ b/tests/docker/import-from-alt-remote.setup.sh
@@ -28,7 +28,7 @@ docker_exec_2=( "${docker_exec[@]}" )
 # Location of secret.yml file, hosts file, and vault pass file
 secret_yml="/opt/conf-meza/secret/$env_name/secret.yml"
 hosts_file="/opt/conf-meza/secret/$env_name/hosts"
-vault_pass="/opt/conf-meza/users/meza-ansible/.vault-pass-$env_name.txt"
+vault_pass="/opt/conf-meza/vault/vault-pass-$env_name.txt"
 
 # CONTAINER 1
 # (1) Get local secret config from repo


### PR DESCRIPTION
### Changes

* Move vault passwords, used for encrypting/decrypting things like `secret.yml`, from `/opt/conf-meza/users/meza-ansible/.vault-pass-<env>.txt` to `/opt/conf-meza/vault/vault-pass-<env>.txt`
* This was done to make it easier to put vault passwords into a repository. Either all environments could be in one repo, or they could each have their own.

```
/opt/conf-meza/vault
    vault-pass-production.txt
    vault-pass-integration.txt
    vault-pass-development.txt
```

### Issues

None

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Update documentation at https://www.mediawiki.org/wiki/Meza
