### PR TITLE
Simplified and sudoless overwrite from source server

### DIFF
--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -215,6 +215,11 @@ m_backups_owner: root
 m_backups_group: root
 
 
+m_config_public_mode: "0755"
+m_config_public_owner: meza-ansible
+m_config_public_group: wheel
+
+
 #
 # PHP config
 #

--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -14,6 +14,7 @@ m_use_production_settings: True
 m_config_core: /opt/meza/config/core
 m_local_secret: /opt/conf-meza/secret
 m_local_public: /opt/conf-meza/public
+m_config_vault: /opt/conf-meza/vault
 m_home: /opt/conf-meza/users
 
 # Config files written by Ansible which need a place to live on non-controller

--- a/src/playbooks/site.yml
+++ b/src/playbooks/site.yml
@@ -284,6 +284,18 @@
       mysql_replication_master: "{{ groups['db-master'][0] }}"
       mysql_replication_role: slave
 
+- hosts: backup-servers
+  become: yes
+  tags: backup-servers
+  roles:
+    - set-vars
+  tasks:
+    - name: Ensure MariaDB client installed on backup servers
+      yum:
+        name: mariadb
+        state: present
+      tags:
+        - latest
 
 - hosts: elastic-servers
   become: yes

--- a/src/playbooks/site.yml
+++ b/src/playbooks/site.yml
@@ -71,6 +71,14 @@
       group: wheel
       mode: "0600"
 
+  - name: Ensure /opt/conf-meza owned by meza-ansible
+    file:
+      path: "/opt/conf-meza"
+      owner: meza-ansible
+      group: wheel
+      mode: "0755"
+
+
 # FIXME 800: Run against localhost
 - hosts: app-servers
   become: yes

--- a/src/playbooks/site.yml
+++ b/src/playbooks/site.yml
@@ -8,6 +8,7 @@
   become: yes
   vars:
     m_home: "/opt/conf-meza/users"
+    m_config_vault: "/opt/conf-meza/vault"
   tasks:
   - name: Ensure no password on meza-ansible user on controller
     shell: passwd --delete meza-ansible
@@ -58,7 +59,7 @@
     shell: >
       ansible-vault encrypt
       /opt/conf-meza/secret/{{ env }}/secret.yml
-      --vault-password-file {{ m_home }}/meza-ansible/.vault-pass-{{ env }}.txt
+      --vault-password-file {{ m_config_vault }}/vault-pass-{{ env }}.txt
     failed_when: False
 
   # Note: without this, the encryption above changes mode to 0600 and ownership

--- a/src/roles/apache-php/tasks/php.yml
+++ b/src/roles/apache-php/tasks/php.yml
@@ -118,7 +118,9 @@
     # Post 7.0, use the pear1u package for all versions of PHP
     # PEAR is no longer a requirement for Meza. Mail and Net_SMTP installed with
     # Composer via MW core (MW 1.32+) or composer.local.json (MW 1.31 and lower)
-    # - pear1u
+    # However, other packages may require it, for example installing sqlsrv and
+    # pdo_sqlsrv PECL packages for MS SQL use.
+    - pear1u
 
     # Not available for PHP 7, due to being built into PHP 7
     # - php56u-pecl-jsonc

--- a/src/roles/haproxy/tasks/main.yml
+++ b/src/roles/haproxy/tasks/main.yml
@@ -55,7 +55,7 @@
   shell: >
     ansible-vault encrypt
     {{ item }}
-    --vault-password-file {{ m_home }}/meza-ansible/.vault-pass-{{ env }}.txt
+    --vault-password-file {{ m_config_vault }}/vault-pass-{{ env }}.txt
   failed_when: False
   delegate_to: localhost
   run_once: True
@@ -67,7 +67,7 @@
   shell: >
     ansible-vault view
     /opt/conf-meza/secret/{{ env }}/ssl/meza.key
-    --vault-password-file {{ m_home }}/meza-ansible/.vault-pass-{{ env }}.txt
+    --vault-password-file {{ m_config_vault }}/vault-pass-{{ env }}.txt
   register: decrypted_key
   delegate_to: localhost
   run_once: True
@@ -76,7 +76,7 @@
   shell: >
     ansible-vault view
     /opt/conf-meza/secret/{{ env }}/ssl/meza.crt
-    --vault-password-file {{ m_home }}/meza-ansible/.vault-pass-{{ env }}.txt
+    --vault-password-file {{ m_config_vault }}/vault-pass-{{ env }}.txt
   register: decrypted_cert
   delegate_to: localhost
   run_once: True

--- a/src/roles/init-controller-config/tasks/main.yml
+++ b/src/roles/init-controller-config/tasks/main.yml
@@ -28,6 +28,8 @@
 
 # If a git repo is defined use that for config
 - name: Get local config repo if set
+  become: yes
+  become_user: "meza-ansible"
   git:
     repo: "{{ local_config_repo.repo }}"
     dest: "{{ m_local_public }}"

--- a/src/roles/init-controller-config/tasks/main.yml
+++ b/src/roles/init-controller-config/tasks/main.yml
@@ -57,9 +57,9 @@
   file:
     path: "{{ m_local_public }}"
     state: directory
-    owner: root
-    group: root
-    mode: 0755
+    owner: "{{ m_config_public_owner }}"
+    group: "{{ m_config_public_group }}"
+    mode: "{{ m_config_public_mode }}"
     recurse: true
   delegate_to: localhost
   run_once: true
@@ -71,20 +71,20 @@
   file:
     path: "{{ m_local_public }}/wikis"
     state: directory
-    owner: root
-    group: root
-    mode: 0755
+    owner: "{{ m_config_public_owner }}"
+    group: "{{ m_config_public_group }}"
+    mode: "{{ m_config_public_mode }}"
   delegate_to: localhost
   run_once: true
 
 
 - name: Ensure pre/post settings directories exists in config
   file:
-    path: "/opt/conf-meza/public/{{ item }}"
+    path: "{{ m_local_public }}/{{ item }}"
     state: directory
-    owner: root
-    group: root
-    mode: 0755
+    owner: "{{ m_config_public_owner }}"
+    group: "{{ m_config_public_group }}"
+    mode: "{{ m_config_public_mode }}"
   delegate_to: localhost
   run_once: true
   with_items:
@@ -96,9 +96,9 @@
   template:
     src: "templates/{{ item }}.j2"
     dest: "{{ m_local_public }}/{{ item }}"
-    owner: root
-    group: root
-    mode: 0755
+    owner: "{{ m_config_public_owner }}"
+    group: "{{ m_config_public_group }}"
+    mode: "{{ m_config_public_mode }}"
     force: no
   delegate_to: localhost
   run_once: true

--- a/src/roles/remote-dir-check/tasks/main.yml
+++ b/src/roles/remote-dir-check/tasks/main.yml
@@ -1,0 +1,61 @@
+---
+# Check if a directory exists on a remote server
+#
+# Inputs:
+#   remote_server:
+#   directory_path:
+#   remote_server_user:
+
+- name: "Initially assume directory does not exist"
+  set_fact:
+    remote_dir_exists: False
+
+#
+# Put meza-ansible's private key and known_hosts on server within /root
+#
+- name: "Grant keys to {{ inventory_hostname }}"
+  include_role:
+    name: key-transfer
+    tasks_from: grant-keys
+  vars:
+    granted_server: "{{ inventory_hostname }}"
+  when:
+    remote_server != inventory_hostname
+
+- name: "Check for existence of {{ directory_path }} on {{ remote_server }}"
+  shell: >
+    ssh
+    -o StrictHostKeyChecking=no
+    -i /root/meza-ansible-id_rsa
+    -o UserKnownHostsFile=/root/meza-ansible-known_hosts
+    {{ remote_server_user }}@{{ remote_server }}
+    '[ -d {{ uploads_backup_dir_path }} ]'
+  failed_when: False
+  register: remote_dir_check
+  run_once: true
+  when: remote_server != inventory_hostname
+
+# If not actually a remote server
+- name: "Check for existence of {{ directory_path }} on {{ inventory_hostname }}"
+  shell: '[ -d {{ uploads_backup_dir_path }} ]'
+  failed_when: False
+  register: local_dir_check
+  run_once: true
+  when: remote_server == inventory_hostname
+
+- debug: { var: remote_dir_check }
+- debug: { var: local_dir_check }
+
+- name: "Set remote_dir_exists to true"
+  set_fact:
+    remote_dir_exists: True
+  when: (not local_dir_check|skipped and local_dir_check.rc == 0) or (not remote_dir_check|skipped and remote_dir_check.rc == 0)
+
+- debug: { var: remote_dir_exists }
+
+- name: "Revoke keys from {{ inventory_hostname }}"
+  include_role:
+    name: key-transfer
+    tasks_from: revoke-keys
+  vars:
+    granted_server: "{{ inventory_hostname }}"

--- a/src/roles/remote-mysqldump/tasks/main.yml
+++ b/src/roles/remote-mysqldump/tasks/main.yml
@@ -62,15 +62,46 @@
 #
 # Verify wiki exists on source server before attempting to dump from it
 #
+
+#
+# If remote_server != target_server, use SSH to run mysqlshow. Else, doit locally
+#
+# FIXME #818: Remove StrictHostKeyChecking=no when tests properly add host keys (users should do so, too, of course)
+- name: remote_server ({{ remote_server }}) != target_server ({{ target_server }}); run mysqlshow over SSH
+  set_fact:
+    mysqlshow_command: >
+      ssh
+      -o StrictHostKeyChecking=no
+      -i /root/meza-ansible-id_rsa
+      -o UserKnownHostsFile=/root/meza-ansible-known_hosts
+      {{ remote_server_ssh_user }}@{{ remote_server }}
+      "mysqlshow
+      {{ user_option }}
+      {{ password_option }}
+      {{ dump_database }}
+      | grep -v Wildcard
+      | grep -o {{ dump_database }}"
+  when: remote_server != target_server
+- name: remote_server == target_server ({{ target_server }}); run mysqlshow locally
+  set_fact:
+    mysqlshow_command: >
+      mysqlshow
+      {{ user_option }}
+      {{ password_option }}
+      {{ dump_database }}
+      | grep -v Wildcard
+      | grep -o {{ dump_database }}
+  when: remote_server == target_server
+- debug: { msg: "{{ mysqlshow_command }}" }
+
 - name: "{{ wiki_id }} - check if wiki database exists ON SOURCE SERVER"
-  shell: 'mysqlshow "wiki_{{ wiki_id }}" | grep -v Wildcard | grep -o wiki_{{ wiki_id }}'
+  shell: "{{ mysqlshow_command }}"
   register: source_wiki_exists_check
-  delegate_to: "{{ target_server }}"
   failed_when: False
   run_once: true
-
 - debug:
     var: source_wiki_exists_check
+
 
 - name: "{{ wiki_id }} - Set fact if database wiki_{{ wiki_id }} DOES exist ON SOURCE SERVER"
   set_fact:

--- a/src/roles/remote-mysqldump/tasks/main.yml
+++ b/src/roles/remote-mysqldump/tasks/main.yml
@@ -32,9 +32,9 @@
   set_fact:
     user_option: "-u {{ remote_server_mysql_user }}"
   when: remote_server_mysql_user is defined
-- name: Set mysql user option to empty string if not defined
+- name: Set mysql user option to use wiki application user if not defined
   set_fact:
-    user_option: ""
+    user_option: "-u {{ wiki_app_db_user.name }}"
   when: remote_server_mysql_user is not defined
 
 #
@@ -44,9 +44,9 @@
   set_fact:
     password_option: "-p{{ remote_server_mysql_pass }}"
   when: remote_server_mysql_pass is defined
-- name: Set mysql password option to empty string if not defined
+- name: Set mysql password option use wiki application user if not defined
   set_fact:
-    password_option: ""
+    password_option: "-p{{ wiki_app_db_user.password }}"
   when: remote_server_mysql_pass is not defined
 
 #

--- a/src/roles/remote-mysqldump/tasks/main.yml
+++ b/src/roles/remote-mysqldump/tasks/main.yml
@@ -99,6 +99,8 @@
   register: source_wiki_exists_check
   failed_when: False
   run_once: true
+  delegate_to: "{{ target_server }}"
+
 - debug:
     var: source_wiki_exists_check
 

--- a/src/roles/verify-wiki/tasks/main.yml
+++ b/src/roles/verify-wiki/tasks/main.yml
@@ -182,6 +182,20 @@
 - debug: { var: wiki_exists }
 - debug: { var: intend_overwrite_from_backup }
 
+- debug:
+    msg: |
+      do_sql_dump:                   "{{ do_sql_dump }}"
+      wiki_exists:                   "{{ wiki_exists }}"
+      intend_overwrite_from_backup:  "{{ intend_overwrite_from_backup }}"
+      wiki_id:                       "{{ wiki_id }}"
+      remote_server:                 "{{ sql_backup_server }}"
+      remote_server_ssh_user:        "{{ db_backup_server_remote_user }}"
+      remote_server_mysql_user:      "{{ backups_server_db_dump.mysql_user }}"
+      remote_server_mysql_pass:      "hidden"
+      dump_database:                 "wiki_{{ wiki_id }}"
+      target_server:                 "{{ groups['db-master'][0] }}"
+      target_server_path:            "{{ m_tmp }}/wiki.sql"
+
 #
 # SECTION: DUMP SQL to DB master
 #
@@ -309,8 +323,12 @@
     remote_server: "{{ uploads_backup_server }}"
     directory_path: "{{ uploads_backup_dir_path }}"
     remote_server_user: "{{ uploads_backup_server_remote_user }}"
+  tags:
+    - verify-wiki-uploads
 
 - debug: { var: remote_dir_exists }
+  tags:
+    - verify-wiki-uploads
 
 
 #
@@ -320,11 +338,15 @@
   set_fact:
     do_overwrite_uploads_from_backup: True
   when: intend_overwrite_from_backup and remote_dir_exists
+  tags:
+    - verify-wiki-uploads
 
 - name: "{{ wiki_id }} - Set fact if SHOULD NOT overwrite uploads data"
   set_fact:
     do_overwrite_uploads_from_backup: False
   when: not intend_overwrite_from_backup or not remote_dir_exists
+  tags:
+    - verify-wiki-uploads
 
 
 #
@@ -343,6 +365,8 @@
   when:
     remote_dir_exists
     and (not wiki_has_uploads or do_overwrite_uploads_from_backup)
+  tags:
+    - verify-wiki-uploads
 
 
 #

--- a/src/roles/verify-wiki/tasks/main.yml
+++ b/src/roles/verify-wiki/tasks/main.yml
@@ -184,17 +184,17 @@
 
 - debug:
     msg: |
-      do_sql_dump:                   "{{ do_sql_dump }}"
-      wiki_exists:                   "{{ wiki_exists }}"
-      intend_overwrite_from_backup:  "{{ intend_overwrite_from_backup }}"
-      wiki_id:                       "{{ wiki_id }}"
-      remote_server:                 "{{ sql_backup_server }}"
-      remote_server_ssh_user:        "{{ db_backup_server_remote_user }}"
-      remote_server_mysql_user:      "{{ backups_server_db_dump.mysql_user }}"
-      remote_server_mysql_pass:      "hidden"
-      dump_database:                 "wiki_{{ wiki_id }}"
-      target_server:                 "{{ groups['db-master'][0] }}"
-      target_server_path:            "{{ m_tmp }}/wiki.sql"
+      do_sql_dump:                   {{ do_sql_dump | default('<undefined>') }}
+      wiki_exists:                   {{ wiki_exists | default('<undefined>') }}
+      intend_overwrite_from_backup:  {{ intend_overwrite_from_backup | default('<undefined>') }}
+      wiki_id:                       {{ wiki_id | default('<undefined>') }}
+      remote_server:                 {{ sql_backup_server | default('<undefined>') }}
+      remote_server_ssh_user:        {{ db_backup_server_remote_user | default('<undefined>') }}
+      remote_server_mysql_user:      {{ backups_server_db_dump.mysql_user | default('<undefined>') }}
+      remote_server_mysql_pass:      <hidden>
+      dump_database:                 wiki_{{ wiki_id | default('<undefined>') }}
+      target_server:                 {{ groups['db-master'][0] }}
+      target_server_path:            {{ m_tmp }}/wiki.sql
 
 #
 # SECTION: DUMP SQL to DB master

--- a/src/roles/verify-wiki/tasks/main.yml
+++ b/src/roles/verify-wiki/tasks/main.yml
@@ -138,6 +138,7 @@
     do_sql_dump: True
     sql_file_match: "wiki_{{ wiki_id }}.sql"
     db_backup_server_remote_user: "{{ backups_server_db_dump.remote_user }}"
+    db_backup_server_mysql_user: "{{ backups_server_db_dump.mysql_user }}"
     sql_backup_server_set: True
   when: "backups_server_db_dump is defined"
 
@@ -190,7 +191,7 @@
       wiki_id:                       {{ wiki_id | default('<undefined>') }}
       remote_server:                 {{ sql_backup_server | default('<undefined>') }}
       remote_server_ssh_user:        {{ db_backup_server_remote_user | default('<undefined>') }}
-      remote_server_mysql_user:      {{ backups_server_db_dump.mysql_user | default('<undefined>') }}
+      remote_server_mysql_user:      {{ db_backup_server_mysql_user | default('<undefined>') }}
       remote_server_mysql_pass:      <hidden>
       dump_database:                 wiki_{{ wiki_id | default('<undefined>') }}
       target_server:                 {{ groups['db-master'][0] }}
@@ -205,7 +206,7 @@
   vars:
     remote_server:            "{{ sql_backup_server }}"
     remote_server_ssh_user:   "{{ db_backup_server_remote_user }}"
-    remote_server_mysql_user: "{{ backups_server_db_dump.mysql_user }}"
+    remote_server_mysql_user: "{{ db_backup_server_mysql_user }}"
     remote_server_mysql_pass: "{{ backups_server_db_dump.mysql_pass }}"
     dump_database:            "wiki_{{ wiki_id }}"
     target_server:            "{{ groups['db-master'][0] }}"

--- a/src/roles/verify-wiki/tasks/main.yml
+++ b/src/roles/verify-wiki/tasks/main.yml
@@ -178,6 +178,9 @@
   run_once: true
   delegate_to: "{{ groups['db-master'][0] }}"
 
+- debug: { var: do_sql_dump }
+- debug: { var: wiki_exists }
+- debug: { var: intend_overwrite_from_backup }
 
 #
 # SECTION: DUMP SQL to DB master
@@ -299,13 +302,15 @@
 #
 # SECTION: Does backup server have uploads?
 #
-- name: "{{ wiki_id }} - Check if wiki's uploads backup dir exists on backups.0"
-  stat:
-    path: "{{ uploads_backup_dir_path }}"
-  register: images_backup_dir
-  delegate_to: "{{ uploads_backup_server }}"
-  remote_user: "{{ uploads_backup_server_remote_user }}"
-  run_once: true
+- name:
+  include_role:
+    name: remote-dir-check
+  vars:
+    remote_server: "{{ uploads_backup_server }}"
+    directory_path: "{{ uploads_backup_dir_path }}"
+    remote_server_user: "{{ uploads_backup_server_remote_user }}"
+
+- debug: { var: remote_dir_exists }
 
 
 #
@@ -314,12 +319,12 @@
 - name: "{{ wiki_id }} - Set fact if SHOULD overwrite uploads data (only possible if backup exists)"
   set_fact:
     do_overwrite_uploads_from_backup: True
-  when: intend_overwrite_from_backup and images_backup_dir.stat.exists
+  when: intend_overwrite_from_backup and remote_dir_exists
 
 - name: "{{ wiki_id }} - Set fact if SHOULD NOT overwrite uploads data"
   set_fact:
     do_overwrite_uploads_from_backup: False
-  when: not intend_overwrite_from_backup or not images_backup_dir.stat.exists
+  when: not intend_overwrite_from_backup or not remote_dir_exists
 
 
 #
@@ -336,7 +341,7 @@
     pulling_from_user:   "{{ uploads_backup_server_remote_user }}"
   run_once: true
   when:
-    images_backup_dir.stat.exists
+    remote_dir_exists
     and (not wiki_has_uploads or do_overwrite_uploads_from_backup)
 
 

--- a/src/scripts/getmeza.sh
+++ b/src/scripts/getmeza.sh
@@ -80,6 +80,7 @@ if $ret; then
 	fi
 fi
 
+chown meza-ansible:wheel /opt/conf-meza
 
 echo
 echo "Add ansible master user"

--- a/src/scripts/meza.py
+++ b/src/scripts/meza.py
@@ -325,7 +325,7 @@ def meza_command_setup_env (argv, return_not_exit=False):
 	print "Please review your host file. Run command:"
 	print "  sudo vi /opt/conf-meza/secret/{}/hosts".format(env)
 	print "Please review your secret config. It is encrypted, so edit by running:"
-	print "  sudo ansible-vault edit /opt/conf-meza/secret/{}/secret.yml --vault-password-file /opt/conf-meza/users/meza-ansible/.vault-pass-{}.txt".format(env,env)
+	print "  sudo ansible-vault edit /opt/conf-meza/secret/{}/secret.yml --vault-password-file {}".format(env,vault_pass_file)
 	if return_not_exit:
 		return rc
 	else:
@@ -680,12 +680,28 @@ def meza_shell_exec_exit( return_code=0 ):
 def get_vault_pass_file ( env ):
 	import pwd
 	import grp
+
 	home_dir = defaults['m_home']
-	vault_pass_file = '{}/meza-ansible/.vault-pass-{}.txt'.format(home_dir,env)
+	legacy_file = '{}/meza-ansible/.vault-pass-{}.txt'.format(home_dir,env)
+
+	vault_dir = defaults['m_config_vault']
+	vault_pass_file = '{}/vault-pass-{}.txt'.format(vault_dir, env)
+
 	if not os.path.isfile( vault_pass_file ):
-		with open( vault_pass_file, 'w' ) as f:
-			f.write( random_string( num_chars=64 ) )
-			f.close()
+		if not os.path.exists( vault_dir ):
+			os.mkdir( vault_dir )
+			meza_chown( vault_dir, 'meza-ansible', 'wheel' )
+			os.chmod( vault_dir, 0o700 )
+
+		# If legacy vault password file exists copy that into new location.
+		# Otherwise, create one in the new location
+		if os.path.isfile( legacy_file ):
+			from shutil import copyfile
+			copyfile(legacy_file, vault_pass_file)
+		else:
+			with open( vault_pass_file, 'w' ) as f:
+				f.write( random_string( num_chars=64 ) )
+				f.close()
 
 	# Run this everytime, since it should be fast and if meza-ansible can't
 	# read this then you're stuck!

--- a/tests/docker/backup-to-remote.setup.sh
+++ b/tests/docker/backup-to-remote.setup.sh
@@ -47,7 +47,7 @@ ${docker_exec_1[@]} bash -c "echo -e 'sshd_config_PasswordAuthentication: \"yes\
 
 # secret.yml is encrypted. decrypt first, make edits, re-encrypt.
 # secret_yml="/opt/conf-meza/secret/$env_name/secret.yml"
-# vault_pass="/opt/conf-meza/users/meza-ansible/.vault-pass-$env_name.txt"
+# vault_pass="/opt/conf-meza/vault/vault-pass-$env_name.txt"
 # ${docker_exec_1[@]} bash -c "ansible-vault decrypt $secret_yml --vault-password-file $vault_pass"
 # ${docker_exec_1[@]} bash -c "echo -e '\n' >> $secret_yml"
 # ${docker_exec_1[@]} bash -c "echo 'mysql_root_password_update: yes' >> $secret_yml"

--- a/tests/docker/import-from-alt-remote.setup.sh
+++ b/tests/docker/import-from-alt-remote.setup.sh
@@ -28,7 +28,7 @@ docker_exec_2=( "${docker_exec[@]}" )
 # Location of secret.yml file, hosts file, and vault pass file
 secret_yml="/opt/conf-meza/secret/$env_name/secret.yml"
 hosts_file="/opt/conf-meza/secret/$env_name/hosts"
-vault_pass="/opt/conf-meza/users/meza-ansible/.vault-pass-$env_name.txt"
+vault_pass="/opt/conf-meza/vault/vault-pass-$env_name.txt"
 
 # CONTAINER 1
 # (1) Get local secret config from repo


### PR DESCRIPTION
### Changes

Many commits in support of simplifying and securing importing data from remote server. Sudo no longer required on remote.

- af9eb52: Move vault pass file from meza-ansible home to /opt/conf-meza/vault
- 51f5e34: Re-enable PEAR package; not used by default, but used by MS SQL
- 527852f: Get public config repo as meza-ansible, not root
- 6ecc855: Create role remote-dir-check to verify if remote uploads dir exists
- 4d56386: Set permissions for /opt/conf-meza and /opt/conf-meza/public  …
- 68ac393: Add tags for rsync-uploads and better debug
- cd79230: Make checks for wiki existence during backup go to right server  …
- db6f805: Give undefined debug vars print vals
- 112317c: Handle undefined backups_server_db_dump
- 84bc0a0: Install mysql client on backup servers for direct mysqldump
- 7ea1f98: Use known user, not no user, when mysqldump user unspecified

### Issues

* Addresses #910 
* Closes #827 

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Update documentation at https://www.mediawiki.org/wiki/Meza
  - [ ] Vault pass location
  - [ ] Cleanup importing docs
  - [ ] Import into vagrant