### PR TITLE
Adds definition for baseURL

### DIFF
--- a/src/roles/saml/templates/config.php.j2
+++ b/src/roles/saml/templates/config.php.j2
@@ -3,6 +3,8 @@
 $config = array(
 	'baseurlpath' => 'https://{{ wiki_app_fqdn }}/simplesaml/',
 
+	'application' => [ 'baseURL' => 'https://{{ wiki_app_fqdn }}' ],
+
 	'certdir' => 'cert/',
 	'loggingdir' => 'log/',
 	'datadir' => 'data/',


### PR DESCRIPTION
When TLS offloading, SSL load balancing, or reverse proxying, the `baseurlpath` value gets changed to only use `http` instead of `https.

Because the wiki auto redirect `http` to `https`, the issue isn't apparent to normal wiki usage. However, the issue arises when loading a wiki in an `iframe`. The `http` redirect by `simplesaml` causes a `Mixed Content` error. 

### Changes

-  Adds `baseURL` to `application` property on config. 