### PR TITLE
Support /tmp mounted with noexec

### DIFF
--- a/src/roles/apache-php/tasks/profiling.yml
+++ b/src/roles/apache-php/tasks/profiling.yml
@@ -38,6 +38,9 @@
     - pecl/mongodb
 
 - name: Ensure XHGui present
+  # Ref #1149 for TMPDIR environment var
+  environment:
+    TMPDIR: "{{ m_tmp }}"
   git:
     repo: https://github.com/perftools/xhgui.git
     dest: "{{ m_profiling_xhgui_directory }}"

--- a/src/roles/init-controller-config/tasks/main.yml
+++ b/src/roles/init-controller-config/tasks/main.yml
@@ -30,6 +30,9 @@
 - name: Get local config repo if set
   become: yes
   become_user: "meza-ansible"
+  # Ref #1149 for TMPDIR environment var
+  environment:
+    TMPDIR: "{{ m_tmp }}"
   git:
     repo: "{{ local_config_repo.repo }}"
     dest: "{{ m_local_public }}"

--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -72,6 +72,9 @@
 - name: Ensure proper MediaWiki git version installed
   become: yes
   become_user: "meza-ansible"
+  # Ref #1149 for TMPDIR environment var
+  environment:
+    TMPDIR: "{{ m_tmp }}"
   git:
     repo: https://github.com/wikimedia/mediawiki.git
     dest: "{{ m_mediawiki }}"
@@ -118,6 +121,9 @@
 - name: Ensure core meza extensions installed (non-Composer)
   become: yes
   become_user: "meza-ansible"
+  # Ref #1149 for TMPDIR environment var
+  environment:
+    TMPDIR: "{{ m_tmp }}"
   git:
     repo: "{{ item.repo }}"
     dest: "{{ m_mediawiki }}/extensions/{{ item.name }}"
@@ -138,6 +144,9 @@
     - always
 
 - name: Ensure core meza skins installed (non-Composer)
+  # Ref #1149 for TMPDIR environment var
+  environment:
+    TMPDIR: "{{ m_tmp }}"
   git:
     repo: "{{ item.repo }}"
     dest: "{{ m_mediawiki }}/skins/{{ item.name }}"
@@ -151,6 +160,9 @@
 - name: Ensure local meza extensions installed (non-Composer)
   become: yes
   become_user: "meza-ansible"
+  # Ref #1149 for TMPDIR environment var
+  environment:
+    TMPDIR: "{{ m_tmp }}"
   git:
     repo: "{{ item.repo }}"
     dest: "{{ m_mediawiki }}/extensions/{{ item.name }}"
@@ -165,6 +177,9 @@
     - latest
 
 - name: Ensure local meza skins installed (non-Composer)
+  # Ref #1149 for TMPDIR environment var
+  environment:
+    TMPDIR: "{{ m_tmp }}"
   git:
     repo: "{{ item.repo }}"
     dest: "{{ m_mediawiki }}/skins/{{ item.name }}"
@@ -287,6 +302,9 @@
 # LANDING PAGE
 #
 - name: Ensure WikiBlender installed
+  # Ref #1149 for TMPDIR environment var
+  environment:
+    TMPDIR: "{{ m_tmp }}"
   git:
     repo: https://github.com/jamesmontalvo3/WikiBlender.git
     dest: "{{ m_htdocs }}/WikiBlender"

--- a/src/roles/parsoid/tasks/main.yml
+++ b/src/roles/parsoid/tasks/main.yml
@@ -7,6 +7,9 @@
 # working directory is wiped out on each run. Then We can immediately patch
 # the repo in the following step (optionally, if we want <img> tags)
 - name: Get Parsoid repository
+  # Ref #1149 for TMPDIR environment var
+  environment:
+    TMPDIR: "{{ m_tmp }}"
   git:
     repo: https://github.com/wikimedia/parsoid.git
     dest: "{{ m_parsoid_path }}"

--- a/src/roles/saml/tasks/main.yml
+++ b/src/roles/saml/tasks/main.yml
@@ -1,6 +1,9 @@
 ---
 
 - name: Ensure SimpleSamlPhp (PHP SAML library) installed
+  # Ref #1149 for TMPDIR environment var
+  environment:
+    TMPDIR: "{{ m_tmp }}"
   git:
     repo: https://github.com/simplesamlphp/simplesamlphp.git
     dest: "{{ m_simplesamlphp_path }}"
@@ -10,6 +13,9 @@
     - latest
 
 - name: Ensure SimpleSamlAuth (MediaWiki extension) installed
+  # Ref #1149 for TMPDIR environment var
+  environment:
+    TMPDIR: "{{ m_tmp }}"
   git:
     # Main version of this extension, jornane/mwSimpleSamlAuth, is slow to
     # update. Use this fork instead, which should stay current with jornane

--- a/tests/deploys/setup-alt-source-backup.yml
+++ b/tests/deploys/setup-alt-source-backup.yml
@@ -9,6 +9,7 @@
   vars:
     alt_source_backups_dir: /opt/alt/backups
     m_home: /opt/conf-meza/users
+    m_tmp: /opt/data-meza/tmp
 
   tasks:
     - name: Ensure packages installed
@@ -23,6 +24,9 @@
         - perl-DBD-MySQL
 
     - name: Ensure backups repo in place
+      # Ref #1149 for TMPDIR environment var
+      environment:
+        TMPDIR: "{{ m_tmp }}"
       git:
         repo: https://github.com/jamesmontalvo3/meza-test-backups.git
         dest: "{{ alt_source_backups_dir }}"


### PR DESCRIPTION
### Changes

* ~Move `ansible.cfg` setting `remote_tmp` out of `/tmp`~ (EDIT: not required, see first comment below)
* Set `TMPDIR` environment variable on Ansible Git module operations

### Issues

* Closes #1149 

### Post-merge actions

Post-merge, the following actions need to be addressed:

- None