### PR TITLE
Fix broken meza-docker-full image

### DIFF
--- a/src/roles/elasticsearch/tasks/main.yml
+++ b/src/roles/elasticsearch/tasks/main.yml
@@ -110,18 +110,29 @@
   register: version_found
   retries: 10
   delay: 10
+  when: docker_skip_tasks is not defined or not docker_skip_tasks
 
 - name: Display current Elasticsearch full version number
   debug:
     var: version_found.json.version.number
+  when: docker_skip_tasks is not defined or not docker_skip_tasks
 
 - name: Display desired Elasticsearch version
   debug:
     var: elasticsearch_major_version
 
-- name: Set the Elasticsearch major version numbers
+- name: Set the Elasticsearch major version found
   set_fact:
     es_version_found: "{{ version_found.json.version.number | list | first }}"
+  when: docker_skip_tasks is not defined or not docker_skip_tasks
+
+- name: "Docker image building only: set found version to desired version"
+  set_fact:
+    es_version_found: "{{ elasticsearch_major_version | list | first }}"
+  when: docker_skip_tasks is defined and docker_skip_tasks
+
+- name: Set the Elasticsearch major version desired
+  set_fact:
     es_version_desired: "{{ elasticsearch_major_version | list | first }}"
 
 # Do false first. Then force_do_elasticsearch_upgrade can override

--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -482,6 +482,7 @@
 - name: Verify metastore index upgraded
   shell: WIKI={{ list_of_wikis[0] }} php /opt/htdocs/mediawiki/extensions/CirrusSearch/maintenance/metastore.php --upgrade
   run_once: true
+  when: docker_skip_tasks is not defined or not docker_skip_tasks
 
 # Wikis are totally built at this point, but SMW and search need rebuilding
 # FIXME #811: Will this work when controller is not an app server?

--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -371,12 +371,16 @@
   vars:
     wiki_id: demo
     wiki_name: Demo Wiki
-  when: "initial_wikis_dirs_check.files|length == 0 and (docker_skip_tasks is not defined or not docker_skip_tasks)"
+  when:
+    - (docker_skip_tasks is not defined or not docker_skip_tasks)
+    - initial_wikis_dirs_check.files|length == 0
 
 - name: Re-sync configuration between controller and app servers if Demo just configured
   include_role:
     name: sync-configs
-  when: "initial_wikis_dirs_check.files|length == 0 and (docker_skip_tasks is not defined or not docker_skip_tasks)"
+  when:
+    - (docker_skip_tasks is not defined or not docker_skip_tasks)
+    - initial_wikis_dirs_check.files|length == 0
 
 
 

--- a/src/roles/parsoid/tasks/main.yml
+++ b/src/roles/parsoid/tasks/main.yml
@@ -62,7 +62,10 @@
   service:
     name: parsoid
     state: stopped
-  when: modify_parsoid_user and parsoid_service_status.stat.exists
+  when:
+    - docker_skip_tasks is not defined or not docker_skip_tasks
+    - modify_parsoid_user
+    - parsoid_service_status.stat.exists
 
 - name: Ensure parsoid user exists
   user:

--- a/src/scripts/getmeza.sh
+++ b/src/scripts/getmeza.sh
@@ -78,14 +78,13 @@ if $ret; then
 	else
 		echo "meza-ansible home-dir in correct location"
 	fi
+else
+	echo
+	echo "Add ansible master user"
+	source "/opt/meza/src/scripts/ssh-users/setup-master-user.sh"
 fi
 
 chown meza-ansible:wheel /opt/conf-meza
-
-echo
-echo "Add ansible master user"
-source "/opt/meza/src/scripts/ssh-users/setup-master-user.sh"
-
 
 # Don't require TTY or visible password for sudo. Ref #769
 sed -r -i "s/^Defaults\\s+requiretty/#Defaults requiretty/g;" /etc/sudoers


### PR DESCRIPTION
### Changes

* Add `when: docker_skip_tasks is not defined or not docker_skip_tasks` to several tasks that can't run when building a docker image (e.g. starting services or any tasks relying upon a service)
* Fix `getmeza.sh` that had non-idempotency added since last docker build (over a year ago)

### Issues

All builds failing

### Post-merge actions

None