### PR TITLE
Prevent simultaneous deploys

### DIFF
--- a/src/scripts/getmeza.sh
+++ b/src/scripts/getmeza.sh
@@ -61,6 +61,9 @@ mkdir -p /opt/conf-meza/secret
 chmod 755 /opt/conf-meza
 chmod 755 /opt/conf-meza/secret
 
+# Required initially for creating lock files
+mkdir -p /opt/data-meza
+
 # If user meza-ansible already exists, make sure home directory is correct
 # (update from old meza versions)
 ret=false

--- a/src/scripts/meza.py
+++ b/src/scripts/meza.py
@@ -128,6 +128,7 @@ def request_lock_for_deploy (env):
 		with open( lock_file, 'w' ) as f:
 			f.write( "deploying" )
 			f.close()
+		return True
 
 def unlock_deploy(env):
 	import os

--- a/src/scripts/meza.py
+++ b/src/scripts/meza.py
@@ -136,7 +136,8 @@ def unlock_deploy(env):
 def get_lock_file_path(env):
 	import os
 	lock_file = os.path.join( defaults['m_meza_data'], "env-{}-deploy.lock".format(env) )
-
+	print "Set lock file to {}".format(lock_file)
+	return lock_file
 
 # env
 # dev

--- a/src/scripts/meza.py
+++ b/src/scripts/meza.py
@@ -122,7 +122,7 @@ def request_lock_for_deploy (env):
 	lock_file = get_lock_file_path(env)
 	if os.path.exists( lock_file ):
 		return False
-	else
+	else:
 		with open( lock_file, 'w' ) as f:
 			f.write( "deploying" )
 			f.close()

--- a/src/scripts/meza.py
+++ b/src/scripts/meza.py
@@ -120,9 +120,11 @@ def meza_command_deploy (argv):
 def request_lock_for_deploy (env):
 	import os
 	lock_file = get_lock_file_path(env)
-	if os.path.exists( lock_file ):
+	if os.path.isfile( lock_file ):
+		print "Deploy lock file already exists at {}".format(lock_file)
 		return False
 	else:
+		print "Create deploy lock file at {}".format(lock_file)
 		with open( lock_file, 'w' ) as f:
 			f.write( "deploying" )
 			f.close()
@@ -136,7 +138,6 @@ def unlock_deploy(env):
 def get_lock_file_path(env):
 	import os
 	lock_file = os.path.join( defaults['m_meza_data'], "env-{}-deploy.lock".format(env) )
-	print "Set lock file to {}".format(lock_file)
 	return lock_file
 
 # env

--- a/src/scripts/meza.py
+++ b/src/scripts/meza.py
@@ -72,6 +72,12 @@ def meza_command_deploy (argv):
 
 	rc = check_environment(env)
 
+	lock_success = request_lock_for_deploy(env)
+
+	if not lock_success:
+		print "Deploy for environment {} in progress. Exiting".format(env)
+		sys.exit(1)
+
 	# return code != 0 means failure
 	if rc != 0:
 		if env == "monolith":
@@ -107,9 +113,29 @@ def meza_command_deploy (argv):
 
 	return_code = meza_shell_exec( shell_cmd )
 
+	unlock_deploy(env)
+
 	meza_shell_exec_exit( return_code )
 
+def request_lock_for_deploy (env):
+	import os
+	lock_file = get_lock_file_path(env)
+	if os.path.exists( lock_file ):
+		return False
+	else
+		with open( lock_file, 'w' ) as f:
+			f.write( "deploying" )
+			f.close()
 
+def unlock_deploy(env):
+	import os
+	lock_file = get_lock_file_path(env)
+	if os.path.exists( lock_file ):
+		os.remove( lock_file )
+
+def get_lock_file_path(env):
+	import os
+	lock_file = os.path.join( defaults['m_meza_data'], "env-{}-deploy.lock".format(env) )
 
 
 # env


### PR DESCRIPTION
### Changes

* Create lock file at start of `meza deploy` to prevent deploys when one is already underway

### Issues

* None

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Update documentation at https://www.mediawiki.org/wiki/Meza
