### PR TITLE
Add several meza deploy-* commands supporting better deploys; add deploy log

### DIFF
--- a/config/core/ansible.cfg
+++ b/config/core/ansible.cfg
@@ -26,3 +26,8 @@ stdout_callback = debug
 ; forks = 1
 
 remote_tmp = /tmp/${USER}/ansible
+
+# Makes deploys write to logs with color info. Puts extra characters into logs
+# which is ugly when viewed in an editor (Vim) but looks better when you do
+# `less -r /path/to/file` or similar commands.
+force_color = 1

--- a/src/roles/autodeployer/templates/check-for-changes.sh.j2
+++ b/src/roles/autodeployer/templates/check-for-changes.sh.j2
@@ -58,6 +58,15 @@ if [ ! -z "$autodeployer_slack_username" ]; then SLACK_USERNAME="$autodeployer_s
 if [ ! -z "$autodeployer_slack_channel"  ]; then  SLACK_CHANNEL="$autodeployer_slack_channel";  fi
 if [ ! -z "$autodeployer_slack_icon_url" ]; then SLACK_ICON_URL="$autodeployer_slack_icon_url"; fi
 
+meza deploy-check "$m_environment"
+if [ $? -eq 0 ]; then
+	echo "Checked if deploy underway. Is not. Placing deploy lock while checking for changes."
+	meza deploy-lock "$m_environment"
+else
+	echo "Deploy is underway. Exiting."
+	exit 1
+fi
+
 # If SLACK_TOKEN is set, send notification via slack. Else, use no-notify script
 if [ ! -z "$SLACK_TOKEN" ]; then
 	NOTIFY="$DIR/slack-notify.sh"
@@ -181,6 +190,7 @@ set -e # end FIXME from above.
 # Neither Meza mor config changed? Exit.
 #
 if [ -z "$PUBLIC_CONFIG_AFTER_HASH$MEZA_AFTER_HASH" ]; then
+	meza deploy-unlock "$m_environment"
 	echo "Nothing to deploy"
 	exit 0;
 fi
@@ -251,5 +261,13 @@ echo "Deploying"
 if [ -z "$DEPLOY_TYPE"       ]; then DEPLOY_TYPE="Deploy";                            fi
 if [ -z "$DEPLOY_ARGS"       ]; then DEPLOY_ARGS="";                                  fi
 if [ -z "$DEPLOY_LOG_PREFIX" ]; then DEPLOY_LOG_PREFIX="deploy-after-config-change-"; fi
+
+# This isn't perfect, as there is still a little that will happen in do-deploy
+# below before the actual deploy starts, and a separate deploy _could_ start
+# in between now and then, but the likelihood is low, and the impact is only
+# this deploy wouldn't happen since it's actual deploy would check for the lock
+# file and would fail/exit.
+meza deploy-unlock "$m_environment"
+
 source "$DIR/do-deploy.sh"
 echo "Done"

--- a/src/scripts/meza.py
+++ b/src/scripts/meza.py
@@ -230,7 +230,13 @@ def get_deploy_info (env):
 def get_deploy_log_path (env):
 	timestamp = get_deploy_info(env)["timestamp"]
 	filename = "{}-{}.log".format( env,timestamp )
-	log_path = os.path.join( defaults['m_logs'], 'deploy-output', filename )
+
+	log_dir = os.path.join( defaults['m_logs'], 'deploy-output' )
+	log_path = os.path.join( log_dir, filename )
+
+	if not os.path.isdir( log_dir ):
+		os.makedirs( log_dir )
+
 	return log_path
 
 def meza_command_deploy_log (argv):

--- a/src/scripts/meza.py
+++ b/src/scripts/meza.py
@@ -135,6 +135,9 @@ def unlock_deploy(env):
 	lock_file = get_lock_file_path(env)
 	if os.path.exists( lock_file ):
 		os.remove( lock_file )
+		return True
+	else:
+		return False
 
 def get_lock_file_path(env):
 	import os
@@ -152,6 +155,26 @@ def meza_command_deploy_check (argv):
 	else:
 		print "Meza environment {} not deploying".format(env)
 		sys.exit(0)
+
+def meza_command_deploy_lock (argv):
+	env = argv[0]
+	success = request_lock_for_deploy(env)
+	if success:
+		print "Environment {} locked for deploy".format(env)
+		sys.exit(0)
+	else:
+		print "Environment {} could not be locked".format(env)
+		sys.exit(1)
+
+def meza_command_deploy_unlock (argv):
+	env = argv[0]
+	success = unlock_deploy(env)
+	if success:
+		print "Environment {} deploy lock removed".format(env)
+		sys.exit(0)
+	else:
+		print "Environment {} is not deploying".format(env)
+		sys.exit(1)
 
 # env
 # dev

--- a/src/scripts/meza.py
+++ b/src/scripts/meza.py
@@ -55,7 +55,7 @@ def main (argv):
 
 
 	command = argv[0]
-	command_fn = "meza_command_{}".format( argv[0] )
+	command_fn = "meza_command_{}".format( argv[0] ).replace("-","_")
 
 	# if command_fn is a valid Python function, pass it all remaining args
 	if command_fn in globals() and callable( globals()[command_fn] ):
@@ -140,6 +140,18 @@ def get_lock_file_path(env):
 	import os
 	lock_file = os.path.join( defaults['m_meza_data'], "env-{}-deploy.lock".format(env) )
 	return lock_file
+
+# "meza deploy-check <ENV>" to return 0 on no deploy, 1 on deploy is active
+def meza_command_deploy_check (argv):
+	import os
+	env = argv[0]
+	lock_file = get_lock_file_path(env)
+	if os.path.isfile( lock_file ):
+		print "Meza environment {} deploying; {} exists".format(env,lock_file)
+		sys.exit(1)
+	else:
+		print "Meza environment {} not deploying".format(env)
+		sys.exit(0)
 
 # env
 # dev

--- a/src/scripts/meza.py
+++ b/src/scripts/meza.py
@@ -794,6 +794,7 @@ def meza_shell_exec ( shell_cmd, log_file=False ):
 		print( line.rstrip() )
 		if log_file:
 			log.write( line )
+	proc.wait()
 
 	rc = proc.returncode
 


### PR DESCRIPTION
### Changes

* Always show ansible colors (without this they don't show when written to a file)
* Add meza commands
  * `meza deploy-check ENV` to check if a deploy is underway
  * `meza deploy-lock ENV` and `meza deploy-unlock ENV` to add and remove lock file
  * `meza deploy-kill ENV` to stop any deploy in progress (by autodeployer or in another terminal)
  * `meza deploy-log ENV` to print the log file path for a deploy underway
  * `meza deploy-tail ENV` to tail (view) the log of a deploy underway
* Autodeployer use `deploy-check`, `deploy-lock`, `deploy-unlock` to make sure a deploy is not running when it starts, and to block other deploys from starting while autodeployer prepares to deploy
* Add handling for SIGINT (ctrl-c pressed by user) since this could cause issues if lock file is not removed, but mostly because sending deploy output to a file _and_ to stdout caused issues with SIGINT
* Make `meza_shell_exec` function use `subprocess.Popen` instead of `os.system`. This allows sending the output of the subprocess to both a log file and the terminal (stdout). Writing to log file is optional, and at present only `deploy` command does it.

### Issues

* TBD

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Update documentation at https://www.mediawiki.org/wiki/Meza
