### PR TITLE
Set ownership of meza and config; fix role:init-controller-config

### DIFF
--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -188,6 +188,13 @@ clean_upload_stash_crontime: "0 18 * * *"
 # FILE MODES, OWNERS, GROUPS
 #
 
+m_meza_owner: meza-ansible
+m_meza_group: wheel
+# Don't set mode for /opt/meza for now. Don't want to impact execute bit which
+# is managed by Git
+# FIXME: Later specify read and write permissions only if Ansible supports
+
+
 # uploads directory. Note: user meza-ansible is in group "apache"
 m_uploads_dir_mode: "0775"
 m_uploads_dir_owner: apache
@@ -223,6 +230,9 @@ m_config_public_mode: "0755"
 m_config_public_owner: meza-ansible
 m_config_public_group: wheel
 
+m_config_secret_mode: "0750"
+m_config_secret_owner: meza-ansible
+m_config_secret_group: wheel
 
 #
 # PHP config

--- a/src/playbooks/site.yml
+++ b/src/playbooks/site.yml
@@ -78,23 +78,23 @@
       group: wheel
       mode: "0755"
 
-
-# FIXME 800: Run against localhost
-- hosts: app-servers
+# Set umask on all servers. Perhaps this should move above localhost steps since
+# it may impact them, and role "umask-set" has no config requirements
+- hosts: all:!exclude-all:!load-balancers-unmanaged
   become: yes
   roles:
-    - set-vars
     - umask-set
-    - init-controller-config
 
 - hosts: localhost
   become: yes
   roles:
     - set-vars
+    - init-controller-config
     - role: autodeployer
       when: force_deploy is defined or autodeployer is defined
   tags:
     - autodeployer
+    - controller
 
 # Ensure proper base setup on all servers in inventory, with the exception of
 # servers in "exclude-all" group. At present, the intent of this group is to
@@ -104,7 +104,6 @@
   become: yes
   roles:
     - set-vars
-    - umask-set
     - base
     - base-config-scripts
   tags: base

--- a/src/roles/init-controller-config/tasks/main.yml
+++ b/src/roles/init-controller-config/tasks/main.yml
@@ -23,8 +23,6 @@
   stat:
     path: "{{ m_local_public }}"
   register: controller_local_config
-  delegate_to: localhost
-  run_once: true
 
 # If a git repo is defined use that for config
 - name: Get local config repo if set
@@ -39,8 +37,6 @@
     version: "{{ local_config_repo.version | default('master') }}"
     force: "{{ local_config_repo.force | default(false) | bool }}"
     umask: "0002"
-  delegate_to: localhost
-  run_once: true
   when:
     not controller_local_config.stat.exists
     and local_config_repo.repo is defined
@@ -51,8 +47,6 @@
   stat:
     path: "{{ m_local_public }}"
   register: recheck_controller
-  delegate_to: localhost
-  run_once: true
 
 # At this point, whether a m_local directory exists on the controller or not,
 # ensure the directory exists and is configured properly
@@ -64,8 +58,8 @@
     group: "{{ m_config_public_group }}"
     mode: "{{ m_config_public_mode }}"
     recurse: true
-  delegate_to: localhost
-  run_once: true
+  tags:
+    - file-perms
 
 
 # Still no config for controller? This must be a new installation. Copy from
@@ -77,9 +71,6 @@
     owner: "{{ m_config_public_owner }}"
     group: "{{ m_config_public_group }}"
     mode: "{{ m_config_public_mode }}"
-  delegate_to: localhost
-  run_once: true
-
 
 - name: Ensure pre/post settings directories exists in config
   file:
@@ -88,8 +79,6 @@
     owner: "{{ m_config_public_owner }}"
     group: "{{ m_config_public_group }}"
     mode: "{{ m_config_public_mode }}"
-  delegate_to: localhost
-  run_once: true
   with_items:
     - preLocalSettings.d
     - postLocalSettings.d
@@ -103,9 +92,28 @@
     group: "{{ m_config_public_group }}"
     mode: "{{ m_config_public_mode }}"
     force: no
-  delegate_to: localhost
-  run_once: true
   with_items:
     - MezaLocalExtensions.yml
     - MezaLocalSkins.yml
     - public.yml
+
+- name: "Ensure {{ m_meza }} properly owned"
+  file:
+    path: "{{ m_meza }}"
+    owner: "{{ m_meza_owner }}"
+    group: "{{ m_meza_group }}"
+    state: directory
+    recurse: Yes
+  tags:
+    - file-perms
+
+- name: "Ensure {{ m_local_secret }} properly owned"
+  file:
+    path: "{{ m_local_secret }}"
+    owner: "{{ m_config_secret_owner }}"
+    group: "{{ m_config_secret_group }}"
+    mode: "{{ m_config_secret_mode }}"
+    state: directory
+    recurse: Yes
+  tags:
+    - file-perms

--- a/src/scripts/getmeza.sh
+++ b/src/scripts/getmeza.sh
@@ -88,6 +88,7 @@ else
 fi
 
 chown meza-ansible:wheel /opt/conf-meza
+chown meza-ansible:wheel /opt/meza
 
 # Don't require TTY or visible password for sudo. Ref #769
 sed -r -i "s/^Defaults\\s+requiretty/#Defaults requiretty/g;" /etc/sudoers


### PR DESCRIPTION
### Changes

* Make sure `/opt/meza` and public and secret configs have good permissions
* init-controller-config was being run on app-servers, but then had delegate:localhost on all tasks. This didn't make sense. Instead just run the play on localhost.

### Issues

* Closes #800 

### Post-merge actions

None