### PR TITLE
Ansible 2.8 fixes

### DIFF
--- a/src/roles/backup-db-wikis/tasks/main.yml
+++ b/src/roles/backup-db-wikis/tasks/main.yml
@@ -25,6 +25,20 @@
     group: "{{ m_backups_group }}"
   with_items: "{{ wiki_dirs.files | map(attribute='path') | map('basename') | list }}"
 
+
+
+
+- name: "Grant keys to {{ pulling_to_server }}"
+  include_role:
+    name: key-transfer
+    tasks_from: grant-keys
+  vars:
+    granted_server: "{{ groups['db-master'][0] }}"
+
+
+
+
+
 # copy from server A (db-master) to server B (backups)
 - name: Copy SQL files to backups
   synchronize:

--- a/src/roles/backup-db-wikis/tasks/main.yml
+++ b/src/roles/backup-db-wikis/tasks/main.yml
@@ -28,52 +28,33 @@
 
 
 
-- name: "Grant keys to {{ inventory_hostname }}"
+
+
+
+
+- name: "Run role:rsync - Copy SQL files to backups"
   include_role:
-    name: key-transfer
-    tasks_from: grant-keys
+    name: rsync
   vars:
-    granted_server: "{{ inventory_hostname }}"
-
-- name: "Grant keys to {{ groups['db-master'][0] }}"
-  include_role:
-    name: key-transfer
-    tasks_from: grant-keys
-  vars:
-    granted_server: "{{ groups['db-master'][0] }}"
-
-
-
-
-
-
-# - name: "Run role:rsync - Copy SQL files to backups"
-#   include_role:
-#     name: rsync
-#   vars:
-#     pulling_to_server:   "{{ inventory_hostname }}"
-#     pulling_to_path:     "{{ m_uploads_dir }}/{{ wiki_id }}"
-#     pulling_from_server: "{{ uploads_backup_server }}"
-#     pulling_from_path:   "{{ uploads_backup_dir_path }}/"
-#     pulling_from_user:   "{{ uploads_backup_server_remote_user }}"
-#   run_once: true
-#   when:
-#     remote_dir_exists
-#     and (not wiki_has_uploads or do_overwrite_uploads_from_backup)
-#   tags:
-#     - verify-wiki-uploads
-
-
-# copy from server A (db-master) to server B (backups)
-- name: Copy SQL files to backups
-  synchronize:
-    # copy from server A
-    src: "{{ m_tmp }}/{{ env }}_{{ item }}.sql"
-    # copy to server B
-    dest: "{{ m_backups }}/{{ env }}/{{ item }}/{{ backup_timestamp }}_wiki.sql"
-  # server A
-  delegate_to: "{{ groups['db-master'][0] }}"
+    pulling_to_server:   "{{ inventory_hostname }}"
+    pulling_to_path:     "{{ m_backups }}/{{ env }}/{{ item }}/{{ backup_timestamp }}_wiki.sql"
+    pulling_from_server: "{{ groups['db-master'][0] }}"
+    pulling_from_path:   "{{ m_tmp }}/{{ env }}_{{ item }}.sql"
+    pulling_from_user:   "meza-ansible"
   with_items: "{{ wiki_dirs.files | map(attribute='path') | map('basename') | list }}"
+
+
+
+#copy from server A (db-master) to server B (backups)
+#- name: Copy SQL files to backups
+#  synchronize:
+#    # copy from server A
+#    src: "{{ m_tmp }}/{{ env }}_{{ item }}.sql"
+#    # copy to server B
+#    dest: "{{ m_backups }}/{{ env }}/{{ item }}/{{ backup_timestamp }}_wiki.sql"
+#  # server A
+#  delegate_to: "{{ groups['db-master'][0] }}"
+#  with_items: "{{ wiki_dirs.files | map(attribute='path') | map('basename') | list }}"
 
 # Remove temp SQL files, only needs to be done on first backup server
 - name: Remove SQL files from DB master {{ m_tmp }}

--- a/src/roles/backup-db-wikis/tasks/main.yml
+++ b/src/roles/backup-db-wikis/tasks/main.yml
@@ -25,13 +25,6 @@
     group: "{{ m_backups_group }}"
   with_items: "{{ wiki_dirs.files | map(attribute='path') | map('basename') | list }}"
 
-
-
-
-
-
-
-
 - name: "Run role:rsync - Copy SQL files to backups"
   include_role:
     name: rsync
@@ -42,19 +35,6 @@
     pulling_from_path:   "{{ m_tmp }}/{{ env }}_{{ item }}.sql"
     pulling_from_user:   "meza-ansible"
   with_items: "{{ wiki_dirs.files | map(attribute='path') | map('basename') | list }}"
-
-
-
-#copy from server A (db-master) to server B (backups)
-#- name: Copy SQL files to backups
-#  synchronize:
-#    # copy from server A
-#    src: "{{ m_tmp }}/{{ env }}_{{ item }}.sql"
-#    # copy to server B
-#    dest: "{{ m_backups }}/{{ env }}/{{ item }}/{{ backup_timestamp }}_wiki.sql"
-#  # server A
-#  delegate_to: "{{ groups['db-master'][0] }}"
-#  with_items: "{{ wiki_dirs.files | map(attribute='path') | map('basename') | list }}"
 
 # Remove temp SQL files, only needs to be done on first backup server
 - name: Remove SQL files from DB master {{ m_tmp }}

--- a/src/roles/backup-db-wikis/tasks/main.yml
+++ b/src/roles/backup-db-wikis/tasks/main.yml
@@ -28,7 +28,14 @@
 
 
 
-- name: "Grant keys to {{ pulling_to_server }}"
+- name: "Grant keys to {{ inventory_hostname }}"
+  include_role:
+    name: key-transfer
+    tasks_from: grant-keys
+  vars:
+    granted_server: "{{ inventory_hostname }}"
+
+- name: "Grant keys to {{ groups['db-master'][0] }}"
   include_role:
     name: key-transfer
     tasks_from: grant-keys
@@ -37,6 +44,24 @@
 
 
 
+
+
+
+# - name: "Run role:rsync - Copy SQL files to backups"
+#   include_role:
+#     name: rsync
+#   vars:
+#     pulling_to_server:   "{{ inventory_hostname }}"
+#     pulling_to_path:     "{{ m_uploads_dir }}/{{ wiki_id }}"
+#     pulling_from_server: "{{ uploads_backup_server }}"
+#     pulling_from_path:   "{{ uploads_backup_dir_path }}/"
+#     pulling_from_user:   "{{ uploads_backup_server_remote_user }}"
+#   run_once: true
+#   when:
+#     remote_dir_exists
+#     and (not wiki_has_uploads or do_overwrite_uploads_from_backup)
+#   tags:
+#     - verify-wiki-uploads
 
 
 # copy from server A (db-master) to server B (backups)

--- a/src/roles/backup-uploads/tasks/main.yml
+++ b/src/roles/backup-uploads/tasks/main.yml
@@ -36,16 +36,27 @@
     group: root
   with_items: "{{ wiki_dirs.files | map(attribute='path') | map('basename') | list }}"
 
-# copy from server A (app.0) to server B (backups)
-- name: Copy uploads directories to backups
-  synchronize:
-    # copy from server A
-    src: "{{ m_uploads_dir }}/{{ item }}/"
-    # copy to server B
-    dest: "{{ m_backups }}/{{ env }}/{{ item }}/uploads"
-    recursive: yes
-  # server A
-  delegate_to: "{{ groups['app-servers'][0] }}"
+- name: "Run role:rsync - Copy uploads directory to backups"
+  include_role:
+    name: rsync
+  vars:
+    pulling_to_server:   "{{ inventory_hostname }}"
+    pulling_to_path:     "{{ m_backups }}/{{ env }}/{{ item }}/uploads"
+    pulling_from_server: "{{ groups['app-servers'][0] }}"
+    pulling_from_path:   "{{ m_uploads_dir }}/{{ item }}/"
+    pulling_from_user:   "meza-ansible”
   with_items: "{{ wiki_dirs.files | map(attribute='path') | map('basename') | list }}"
 
+
+# copy from server A (app.0) to server B (backups)
+#- name: Copy uploads directories to backups
+#  synchronize:
+#    # copy from server A
+#    src: "{{ m_uploads_dir }}/{{ item }}/"
+#    # copy to server B
+#    dest: "{{ m_backups }}/{{ env }}/{{ item }}/uploads"
+#    recursive: yes
+#  # server A
+#  delegate_to: "{{ groups['app-servers'][0] }}"
+#  with_items: "{{ wiki_dirs.files | map(attribute='path') | map('basename') | list }}"
 

--- a/src/roles/backup-uploads/tasks/main.yml
+++ b/src/roles/backup-uploads/tasks/main.yml
@@ -46,17 +46,3 @@
     pulling_from_path:   "{{ m_uploads_dir }}/{{ item }}/"
     pulling_from_user:   "meza-ansible"
   with_items: "{{ wiki_dirs.files | map(attribute='path') | map('basename') | list }}"
-
-
-# copy from server A (app.0) to server B (backups)
-#- name: Copy uploads directories to backups
-#  synchronize:
-#    # copy from server A
-#    src: "{{ m_uploads_dir }}/{{ item }}/"
-#    # copy to server B
-#    dest: "{{ m_backups }}/{{ env }}/{{ item }}/uploads"
-#    recursive: yes
-#  # server A
-#  delegate_to: "{{ groups['app-servers'][0] }}"
-#  with_items: "{{ wiki_dirs.files | map(attribute='path') | map('basename') | list }}"
-

--- a/src/roles/backup-uploads/tasks/main.yml
+++ b/src/roles/backup-uploads/tasks/main.yml
@@ -44,7 +44,7 @@
     pulling_to_path:     "{{ m_backups }}/{{ env }}/{{ item }}/uploads"
     pulling_from_server: "{{ groups['app-servers'][0] }}"
     pulling_from_path:   "{{ m_uploads_dir }}/{{ item }}/"
-    pulling_from_user:   "meza-ansible”
+    pulling_from_user:   "meza-ansible"
   with_items: "{{ wiki_dirs.files | map(attribute='path') | map('basename') | list }}"
 
 

--- a/src/roles/nodejs/tasks/main.yml
+++ b/src/roles/nodejs/tasks/main.yml
@@ -15,11 +15,19 @@
 #   https://bugs.centos.org/view.php?id=13669&nbn=8
 #   https://bugzilla.redhat.com/show_bug.cgi?id=1481008
 #   https://bugzilla.redhat.com/show_bug.cgi?id=1481470
+- name: Get OS minor version (EL-only)
+  shell: cat /etc/redhat-release | grep -Eo '[0-9]+' | sed -n 2p
+  register: rhel_os_minor_version
+  when: ansible_os_family == 'RedHat'
+- debug:
+    var: rhel_os_minor_version
 - name: Ensure http-parser installed from RPM for {{ ansible_distribution_version }}
   yum:
     name: https://kojipkgs.fedoraproject.org//packages/http-parser/2.7.1/3.el7/x86_64/http-parser-2.7.1-3.el7.x86_64.rpm
     state: present
-  when: ansible_distribution_version.split('.')[1] | int <= 3
+  when:
+    - ansible_os_family == 'RedHat'
+    - rhel_os_minor_version.stdout | int <= 3
 
 # - name: Ensure Node.js and npm are installed.
 #   yum:


### PR DESCRIPTION
### Changes

* `ansible_distribution_version` no longer an ansible variable, get RedHat/CentOS version from `/etc/redhat-release`
* Ansible Synchronize module not working, use Meza rsync role

### Issues

* None

### Post-merge actions

Post-merge, the following actions need to be addressed:

- none