### PR TITLE
Add PIP for Python 2 and 3

### DIFF
--- a/src/roles/base/tasks/main.yml
+++ b/src/roles/base/tasks/main.yml
@@ -130,6 +130,7 @@
     - tree
     - cronie
     - rsync
+    - python-pip
   tags:
   - latest
 

--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -533,7 +533,9 @@
 # MediaWiki 1.31+.
 - name: Ensure Python3 present
   yum:
-    name: python35u
+    name:
+      - python35u
+      - python35u-pip
     state: latest
   tags:
   - latest

--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -547,3 +547,15 @@
     owner: root
     group: root
     mode: 0755
+  when: ansible_os_family == 'RedHat'
+
+- name: "Ensure pip3 symlink in place"
+  file:
+    # dest = symlink, src = dir linked to
+    src: "/usr/bin/pip3.5"
+    dest: "/usr/bin/pip3"
+    state: link
+    owner: root
+    group: root
+    mode: 0755
+  when: ansible_os_family == 'RedHat'


### PR DESCRIPTION
### Changes

* Add EPEL repo package `python-pip` for PIP for Python 2.7
* Add IUS repo package `python35u-pip` for PIP for Python 3.5
* Add symlink for `pip3` so you don't have to do `pip3.5`

### Issues

* Helps #809

### Post-merge actions

Post-merge, the following actions need to be addressed:

- None