### PR TITLE
Remove yum:PackageKit to remove error

### DIFF
--- a/src/roles/base/tasks/main.yml
+++ b/src/roles/base/tasks/main.yml
@@ -49,6 +49,13 @@
     line: 'alt-meza-ansible ALL=(ALL) NOPASSWD: ALL'
     validate: 'visudo -cf %s'
 
+# Without this get error "yum lockfile is held by another process" occasionally
+- name: Ensure PackageKit is removed so it doesn't try to upgrade packages on its own
+  yum:
+    name: PackageKit
+    state: absent
+  when: ansible_os_family == 'RedHat'
+
 - name: ensure deltarpm is installed and latest
   yum: name=deltarpm state=latest
   tags:


### PR DESCRIPTION
Error was "yum lockfile is held by another process"

### Changes

* Ensure `PackageKit` absent on RedHat

### Issues

* None

### Post-merge actions

Post-merge, the following actions need to be addressed:

- None