### PR TITLE
Make net adapter select statement break on newlines

### DIFF
--- a/src/scripts/create-vm.sh
+++ b/src/scripts/create-vm.sh
@@ -129,12 +129,16 @@ if (( $(grep -c . <<<"$hostonlyadapter") > 1 )); then
 	echo "You have multiple Host-Only adapters. Their info is above. Choose which to use below."
 	echo
 
+	OLD_IFS=$IFS
+	IFS=$'\n'
 	select adapter in $hostonlyadapter;
 	do
 		echo "You chose: $adapter"
 		hostonlyadapter=$adapter
 		break
 	done
+	IFS=${OLD_IFS}
+
 
 #
 # If Host-Only adapter is blank, create one


### PR DESCRIPTION
### Changes

Use newline Internal Field Separator temporarily for selecting network adapter, then switch it back to spaces.

### Issues

* Closes #1133

