### PR TITLE
Add option to recursively set perms on uploads dir

### DIFF
--- a/src/roles/verify-wiki/tasks/main.yml
+++ b/src/roles/verify-wiki/tasks/main.yml
@@ -370,6 +370,11 @@
     - verify-wiki-uploads
 
 
+- name: "{{ wiki_id }} - Force m_recursively_set_uploads_permissions = True"
+  set_fact:
+    m_recursively_set_uploads_permissions: True
+  when: intend_overwrite_from_backup
+
 #
 # SECTION: Ensure backups still in good config
 #
@@ -380,4 +385,4 @@
     mode: "{{ m_uploads_dir_mode }}"
     owner: "{{ m_uploads_dir_owner }}"
     group: "{{ m_uploads_dir_group }}"
-    # recursive?
+    recurse: "{{ m_recursively_set_uploads_permissions | default(False) }}"


### PR DESCRIPTION
### Changes

* Add `m_recursively_set_uploads_permissions` to do `chmod` and `chown` on `/opt/data-meza/uploads`. This can take a long time if you have lots of uploads, so generally speaking you don't want to do it. But the option exists in case something causes permissions to get improperly set. Generally this will only happen if using `meza push-backup <env>` to push uploads onto the server, so:
* Always do recursive permissions set when doing overwrite (in case pulling/pushing data changes permissions)

### Issues

None

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Update documentation at https://www.mediawiki.org/wiki/Meza
