### PR TITLE
Make push-backup cron configurable; simplify push-backup settings

### DIFF
--- a/src/playbooks/push-backup.yml
+++ b/src/playbooks/push-backup.yml
@@ -24,7 +24,7 @@
     - name: Notify push backup is starting
       slack:
         token: "{{ autodeployer.slack_token }}"
-        msg: "Push backup starting"
+        msg: "Push backup to {{ push_backup.short_name | default('remote server') }} starting"
         channel: "{{ autodeployer.slack_channel }}"
         username: "{{ autodeployer.slack_username }}"
         icon_url: "{{ autodeployer_slack_icon_url }}"
@@ -74,7 +74,7 @@
     - name: Notify push backup is complete
       slack:
         token: "{{ autodeployer.slack_token }}"
-        msg: "Push backup complete"
+        msg: "Push backup to {{ push_backup.short_name | default('remote server') }} complete"
         channel: "{{ autodeployer.slack_channel }}"
         username: "{{ autodeployer.slack_username }}"
         icon_url: "{{ autodeployer_slack_icon_url }}"

--- a/src/playbooks/push-backup.yml
+++ b/src/playbooks/push-backup.yml
@@ -6,6 +6,38 @@
     - set_fact:
         backup_timestamp: "{{lookup('pipe','date +%Y%m%d%H%M%S')}}"
 
+- hosts: localhost
+  become: yes
+  roles:
+    - set-vars
+  tags:
+    # only run this if notify specified
+    - never
+    - notify
+  tasks:
+
+    - name:
+      set_fact:
+        autodeployer_slack_icon_url: "{{ autodeployer.slack_icon_url | default('https://github.com/enterprisemediawiki/meza/raw/master/src/roles/configure-wiki/files/logo.png') }}"
+      when: autodeployer is defined
+
+    - name: Notify push backup is starting
+      slack:
+        token: "{{ autodeployer.slack_token }}"
+        msg: "Push backup starting"
+        channel: "{{ autodeployer.slack_channel }}"
+        username: "{{ autodeployer.slack_username }}"
+        icon_url: "{{ autodeployer_slack_icon_url }}"
+        color: "good"
+        link_names: 1
+      when:
+        - autodeployer is defined
+        - autodeployer.slack_token is defined
+        - autodeployer.slack_channel is defined
+        - autodeployer.slack_username is defined
+        - autodeployer_slack_icon_url is defined
+
+
 # FIXME #803: If a slave is available, maybe pull from there
 - hosts: db-master
   become: yes
@@ -23,3 +55,35 @@
   tags:
     - uploads
     - upload
+
+- hosts: localhost
+  become: yes
+  roles:
+    - set-vars
+  tags:
+    # only run this if notify specified
+    - never
+    - notify
+  tasks:
+
+    - name:
+      set_fact:
+        autodeployer_slack_icon_url: "{{ autodeployer.slack_icon_url | default('https://github.com/enterprisemediawiki/meza/raw/master/src/roles/configure-wiki/files/logo.png') }}"
+      when: autodeployer is defined
+
+    - name: Notify push backup is complete
+      slack:
+        token: "{{ autodeployer.slack_token }}"
+        msg: "Push backup complete"
+        channel: "{{ autodeployer.slack_channel }}"
+        username: "{{ autodeployer.slack_username }}"
+        icon_url: "{{ autodeployer_slack_icon_url }}"
+        color: "good"
+        link_names: 1
+      when:
+        - autodeployer is defined
+        - autodeployer.slack_token is defined
+        - autodeployer.slack_channel is defined
+        - autodeployer.slack_username is defined
+        - autodeployer_slack_icon_url is defined
+

--- a/src/roles/autodeployer/templates/meza-autodeployer-cron.j2
+++ b/src/roles/autodeployer/templates/meza-autodeployer-cron.j2
@@ -6,10 +6,6 @@ MAILTO=root
 {% if force_deploy is defined and force_deploy.crontime is defined %}
 #
 # Force deploy
-# FIXME: At present this extracts environment from /opt/.deploy-meza/config.sh.
-#        This works fine if the controller is used for only one environment, but
-#        will get confused if multiple environments are used. Environment should
-#        be explicitly passed into this script.
 #
 {{ force_deploy.crontime }} root meza deploy-notify "{{ env }}" "{{ _force_deploy_notify_prefix }}" "{{ _force_deploy_options }}"
 {% endif %}
@@ -18,10 +14,13 @@ MAILTO=root
 {% if autodeployer is defined and autodeployer.crontime is defined %}
 #
 # Auto-deploy on config and Meza changes
-# FIXME: At present this extracts environment from /opt/.deploy-meza/config.sh.
-#        This works fine if the controller is used for only one environment, but
-#        will get confused if multiple environments are used. Environment should
-#        be explicitly passed into this script.
 #
 {{ autodeployer.crontime }} root meza autodeploy "{{ env }}" "Deploy" "" >> {{ m_logs }}/deploy/check-for-changes-`date "+\%Y\%m\%d"`.log 2>&1
+
+
+{% if push_backup is defined and push_backup.crontime is defined %}
+#
+# Push backup (db and uploads) to another server periodically
+#
+{{ push_backup.crontime }} root meza push-backup "{{ env }}" "--tags notify" >> {{ m_logs }}/deploy/push-backup-`date "+\%Y\%m\%d"`.log 2>&1
 {% endif %}

--- a/src/roles/autodeployer/templates/meza-autodeployer-cron.j2
+++ b/src/roles/autodeployer/templates/meza-autodeployer-cron.j2
@@ -24,3 +24,4 @@ MAILTO=root
 #
 {{ push_backup.crontime }} root meza push-backup "{{ env }}" "--tags notify" >> {{ m_logs }}/deploy/push-backup-`date "+\%Y\%m\%d"`.log 2>&1
 {% endif %}
+{% endif %}

--- a/src/roles/backup-db-wikis-push/tasks/main.yml
+++ b/src/roles/backup-db-wikis-push/tasks/main.yml
@@ -14,29 +14,29 @@
 
 - name: Set remote_server_base_path if set in configuration
   set_fact:
-    remote_server_base_path: "{{ backups_server_db_push.sql_files_path }}"
+    remote_server_base_path: "{{ push_backup.db.path }}"
   when:
-    - backups_server_db_push.sql_files_path is defined
+    - push_backup.db.path is defined
 
 - name: Set remote_server_base_path if NOT set in configuration
   set_fact:
     remote_server_base_path: "{{ m_backups }}/{{ env }}/<id>/"
   when:
-    - backups_server_db_push.sql_files_path is not defined
+    - push_backup.db.path is not defined
 
 - name: Output value of remote_server_base_path (<id> will be replaced by each wiki_id)
   debug: { var: remote_server_base_path }
 
-- name: "Run role:rsync-push - Copy SQL files to {{ backups_server_db_push.addr }}"
+- name: "Run role:rsync-push - Copy SQL files to {{ push_backup.db.addr }}"
   include_role:
     name: rsync-push
   vars:
     pushing_from_server: "{{ inventory_hostname }}"
     pushing_from_path: "{{ m_tmp }}/{{ env }}_{{ item }}.sql"
-    pushing_to_server: "{{ backups_server_db_push.addr }}"
+    pushing_to_server: "{{ push_backup.db.addr }}"
     # remote_server_base_path + backup_timestamp + _wiki.sql, but replace <id> with wiki_id (item)
     pushing_to_path: "{{ remote_server_base_path | regex_replace('<id>', item) }}{{ backup_timestamp }}_wiki.sql"
-    pushing_to_user: "{{ backups_server_db_push.remote_user }}"
+    pushing_to_user: "{{ push_backup.remote_user }}"
   with_items: "{{ wiki_dirs.files | map(attribute='path') | map('basename') | list }}"
 
 # Remove temp SQL files, only needs to be done on first backup server

--- a/src/roles/backup-uploads-push/tasks/main.yml
+++ b/src/roles/backup-uploads-push/tasks/main.yml
@@ -20,9 +20,9 @@
   set_fact:
     # Likely path if pushing to a live Meza uploads directory:
     #                        /opt/data-meza/uploads/<wiki_id>/
-    remote_server_base_path: "{{ backups_server_uploads_push.uploads_dir_path }}"
+    remote_server_base_path: "{{ push_backup.uploads.path }}"
   when:
-    - backups_server_uploads_push.uploads_dir_path is defined
+    - push_backup.uploads.path is defined
 
 - name: Set remote_server_base_path if NOT set in configuration
   set_fact:
@@ -30,19 +30,19 @@
     #                        /opt/data-meza/backups/<env>/<wiki_id>/uploads/
     remote_server_base_path: "{{ m_backups }}/{{ env }}/<id>/uploads/"
   when:
-    - backups_server_uploads_push.uploads_dir_path is not defined
+    - push_backup.uploads.path is not defined
 
 - name: Output value of remote_server_base_path (<id> will be replaced by each wiki_id)
   debug: { var: remote_server_base_path }
 
-- name: "Run role:rsync-push - Copy uploads directory to {{ backups_server_uploads_push.addr }}"
+- name: "Run role:rsync-push - Copy uploads directory to {{ push_backup.uploads.addr }}"
   include_role:
     name: rsync-push
   vars:
     pushing_from_server: "{{ inventory_hostname }}"
     pushing_from_path: "{{ m_uploads_dir }}/{{ item }}/"
-    pushing_to_server: "{{ backups_server_uploads_push.addr }}"
+    pushing_to_server: "{{ push_backup.uploads.addr }}"
     # remote_server_base_path + backup_timestamp, but replace <id> with wiki_id (item)
     pushing_to_path: "{{ remote_server_base_path | regex_replace('<id>', item) }}"
-    pushing_to_user: "{{ backups_server_uploads_push.remote_user }}"
+    pushing_to_user: "{{ push_backup.remote_user }}"
   with_items: "{{ wiki_dirs.files | map(attribute='path') | map('basename') | list }}"


### PR DESCRIPTION
### Changes

Change settings for `meza push-backup <env>` from:

```yaml
backups_server_db_push:
  addr: example.com
  remote_user: meza-push-user
  sql_files_path: /opt/data-meza/backups/YOURENVIRONMENT/<id>/

backups_server_uploads_push:
  addr: example.com
  remote_user: meza-push-user
  uploads_dir_path: /opt/data-meza/uploads/<id>
```

to:

```yaml
push_backup:
  crontime: "50 10 * * *"
  remote_user: meza-push-user
  short_name: "SOME NICE NAME"
  db:
    addr: example.com
    path: /opt/data-meza/backups/vagrant/<id>/
  uploads:
    addr: example.com
    path: /opt/data-meza/uploads/<id>
```

By adding `push_backup.crontime` this will automatically setup a cron job to run `meza push-backup <env>` periodically. This relies upon `autodeployer` also being setup.

### Issues

None

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Update documentation at https://www.mediawiki.org/wiki/Meza
