### PR TITLE
Standardize secret config permissions

### DIFF
--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -236,9 +236,12 @@ m_config_public_mode: "0755"
 m_config_public_owner: meza-ansible
 m_config_public_group: wheel
 
-m_config_secret_mode: "0750"
+m_config_secret_file_mode: "0660"
+m_config_secret_dir_mode: "0770"
 m_config_secret_owner: meza-ansible
 m_config_secret_group: wheel
+
+
 
 #
 # PHP config

--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -237,7 +237,7 @@ m_config_public_owner: meza-ansible
 m_config_public_group: wheel
 
 m_config_secret_file_mode: "0660"
-m_config_secret_dir_mode: "0770"
+m_config_secret_dir_mode: "0775"
 m_config_secret_owner: meza-ansible
 m_config_secret_group: wheel
 

--- a/src/playbooks/site.yml
+++ b/src/playbooks/site.yml
@@ -63,7 +63,7 @@
       path: "/opt/conf-meza/secret/{{ env }}/secret.yml"
       owner: meza-ansible
       group: wheel
-      mode: "0600"
+      mode: "0660"
 
   - name: Ensure /opt/conf-meza owned by meza-ansible
     file:

--- a/src/roles/haproxy/tasks/main.yml
+++ b/src/roles/haproxy/tasks/main.yml
@@ -35,9 +35,9 @@
   file:
     path: "{{ m_local_secret }}/{{ env }}/ssl"
     state: directory
-    owner: root
-    group: root
-    mode: 0755
+    owner: "{{ m_config_secret_owner }}"
+    group: "{{ m_config_secret_group }}"
+    mode: "{{ m_config_secret_dir_mode }}"
   delegate_to: localhost
   run_once: True
 

--- a/src/roles/init-controller-config/tasks/main.yml
+++ b/src/roles/init-controller-config/tasks/main.yml
@@ -107,13 +107,28 @@
   tags:
     - file-perms
 
-- name: "Ensure {{ m_local_secret }} properly owned"
+- name: "Ensure {{ m_local_secret }} directories properly owned/moded"
   file:
-    path: "{{ m_local_secret }}"
+    path: "{{ item }}"
     owner: "{{ m_config_secret_owner }}"
     group: "{{ m_config_secret_group }}"
-    mode: "{{ m_config_secret_mode }}"
+    mode: "{{ m_config_secret_dir_mode }}"
     state: directory
-    recurse: Yes
   tags:
     - file-perms
+  with_items:
+    - "{{ m_local_secret }}"
+    - "{{ m_local_secret }}/{{ env }}"
+
+- name: "Ensure {{ m_local_secret }} files properly owned/moded"
+  file:
+    path: "{{ item }}"
+    owner: "{{ m_config_secret_owner }}"
+    group: "{{ m_config_secret_group }}"
+    mode: "{{ m_config_secret_file_mode }}"
+    state: directory
+  tags:
+    - file-perms
+  with_items:
+    - "{{ m_local_secret }}/{{ env }}/secret.yml"
+    - "{{ m_local_secret }}/{{ env }}/hosts"

--- a/src/roles/init-controller-config/tasks/main.yml
+++ b/src/roles/init-controller-config/tasks/main.yml
@@ -126,8 +126,7 @@
     owner: "{{ m_config_secret_owner }}"
     group: "{{ m_config_secret_group }}"
     mode: "{{ m_config_secret_file_mode }}"
-    state: directory
-    force: no
+    state: file
   tags:
     - file-perms
   with_items:

--- a/src/roles/init-controller-config/tasks/main.yml
+++ b/src/roles/init-controller-config/tasks/main.yml
@@ -127,6 +127,7 @@
     group: "{{ m_config_secret_group }}"
     mode: "{{ m_config_secret_file_mode }}"
     state: directory
+    force: no
   tags:
     - file-perms
   with_items:

--- a/src/roles/setup-env/tasks/main.yml
+++ b/src/roles/setup-env/tasks/main.yml
@@ -4,26 +4,26 @@
   file:
     path: "{{ m_local_secret }}"
     state: directory
-    owner: meza-ansible
-    group: wheel
-    mode: 0750
+    owner: "{{ m_config_secret_owner }}"
+    group: "{{ m_config_secret_group }}"
+    mode: "{{ m_config_secret_dir_mode }}"
 
 - name: Ensure secret config environment directory exists
   file:
     path: "{{ m_local_secret }}/{{ env }}"
     state: directory
-    owner: meza-ansible
-    group: wheel
-    mode: 0750
+    owner: "{{ m_config_secret_owner }}"
+    group: "{{ m_config_secret_group }}"
+    mode: "{{ m_config_secret_dir_mode }}"
 
 # Ansible writing Ansible
 - name: Ensure hosts file configured
   template:
     src: hosts.j2
     dest: "{{ m_local_secret }}/{{ env }}/hosts"
-    owner: meza-ansible
-    group: wheel
-    mode: 0640
+    owner: "{{ m_config_secret_owner }}"
+    group: "{{ m_config_secret_group }}"
+    mode: "{{ m_config_secret_file_mode }}"
 
     # We don't want to overwrite an existing hosts file with the default
     force: no
@@ -32,9 +32,9 @@
   template:
     src: secret.yml.j2
     dest: "{{ m_local_secret }}/{{ env }}/secret.yml"
-    owner: meza-ansible
-    group: wheel
-    mode: 0640
+    owner: "{{ m_config_secret_owner }}"
+    group: "{{ m_config_secret_group }}"
+    mode: "{{ m_config_secret_file_mode }}"
 
     # don't overwrite existing
     force: no

--- a/src/scripts/getmeza.sh
+++ b/src/scripts/getmeza.sh
@@ -88,6 +88,7 @@ else
 fi
 
 chown meza-ansible:wheel /opt/conf-meza
+chown meza-ansible:wheel /opt/conf-meza/secret
 chown meza-ansible:wheel /opt/meza
 
 # Don't require TTY or visible password for sudo. Ref #769

--- a/src/scripts/getmeza.sh
+++ b/src/scripts/getmeza.sh
@@ -59,7 +59,7 @@ fi
 # make sure conf-meza exists and has good permissions
 mkdir -p /opt/conf-meza/secret
 chmod 755 /opt/conf-meza
-chmod 770 /opt/conf-meza/secret
+chmod 775 /opt/conf-meza/secret
 
 # Required initially for creating lock files
 mkdir -p /opt/data-meza

--- a/src/scripts/getmeza.sh
+++ b/src/scripts/getmeza.sh
@@ -59,7 +59,7 @@ fi
 # make sure conf-meza exists and has good permissions
 mkdir -p /opt/conf-meza/secret
 chmod 755 /opt/conf-meza
-chmod 755 /opt/conf-meza/secret
+chmod 770 /opt/conf-meza/secret
 
 # Required initially for creating lock files
 mkdir -p /opt/data-meza

--- a/src/scripts/meza.py
+++ b/src/scripts/meza.py
@@ -520,7 +520,7 @@ def meza_command_setup_env (argv, return_not_exit=False):
 	# are not written to command line. Putting in secret should make
 	# permissions acceptable since this dir will hold secret info, though it's
 	# sort of an odd place for a temporary file. Perhaps /root instead?
-	extra_vars_file = "/opt/conf-meza/secret/temp_vars.json"
+	extra_vars_file = os.path.join( defaults['m_local_secret'], "temp_vars.json" )
 	if os.path.isfile(extra_vars_file):
 		os.remove(extra_vars_file)
 	f = open(extra_vars_file, 'w')
@@ -530,6 +530,7 @@ def meza_command_setup_env (argv, return_not_exit=False):
 	# Make sure temp_vars.json is accessible. On the first run of deploy it is
 	# possible that user meza-ansible will not be able to reach this file,
 	# specifically if the system has a restrictive umask set (e.g 077).
+	meza_chown( defaults['m_local_secret'], 'meza-ansible', 'wheel' )
 	meza_chown( extra_vars_file, 'meza-ansible', 'wheel' )
 	os.chmod(extra_vars_file, 0664)
 

--- a/src/scripts/meza.py
+++ b/src/scripts/meza.py
@@ -530,6 +530,7 @@ def meza_command_setup_env (argv, return_not_exit=False):
 	# Make sure temp_vars.json is accessible. On the first run of deploy it is
 	# possible that user meza-ansible will not be able to reach this file,
 	# specifically if the system has a restrictive umask set (e.g 077).
+	meza_chown( extra_vars_file, 'meza-ansible', 'wheel' )
 	os.chmod(extra_vars_file, 0664)
 
 	shell_cmd = playbook_cmd( "setup-env" ) + ["--extra-vars", '@'+extra_vars_file]


### PR DESCRIPTION
### Changes

* Set `/opt/conf-meza/secret` and `/opt/conf-meza/secret/<env>` directory permissions to `775`. 
* Set `ssl/` directory to `775` as well, if it exists
* Set `secret.yml` and `hosts` files to `660`

### Issues

N/A

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Update documentation at https://www.mediawiki.org/wiki/Meza
