### PR TITLE
Don't use 'meza' command for dev-networking

### DIFF
--- a/src/scripts/meza.py
+++ b/src/scripts/meza.py
@@ -576,10 +576,11 @@ def meza_command_setup_dev (argv):
 	print "https://wbond.net/sublime_packages/sftp/settings#Remote_Server_Settings"
 	sys.exit()
 
-
+# Remove in 32.x
 def meza_command_setup_dev_networking (argv):
-	rc = meza_shell_exec(["bash","/opt/meza/src/scripts/dev-networking.sh"])
-	sys.exit(rc)
+	print "Function removed. Instead do:"
+	print "  sudo bash /opt/meza/src/scripts/dev-networking.sh"
+	sys.exit(1)
 
 def meza_command_setup_docker (argv):
 	shell_cmd = playbook_cmd( "getdocker" )


### PR DESCRIPTION
### Changes

No reason to have `meza setup dev-networking`. Just run `dev-networking.sh` directly to avoid issues with user input. 

### Issues

* Closes #1169 

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [x] Update documentation at https://www.mediawiki.org/wiki/Meza
