### PR TITLE
Add lock_timeout to yum/package modules to fix Ansible 2.8 issue

### DIFF
--- a/src/playbooks/delete-elasticsearch.yml
+++ b/src/playbooks/delete-elasticsearch.yml
@@ -19,6 +19,7 @@
 
     - name: Ensure Elasticsearch is removed
       yum:
+        lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
         name: elasticsearch
         state: absent
       when: seriously_delete_elasticsearch == "yes"

--- a/src/playbooks/getdocker.yml
+++ b/src/playbooks/getdocker.yml
@@ -15,6 +15,7 @@
   tasks:
     - name: Ensure CentOS-provided Docker repos are removed
       yum:
+        lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
         name: "{{ item }}"
         state: absent
       with_items:
@@ -26,6 +27,7 @@
 
     - name: Ensure yum-utils present
       yum:
+        lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
         name: yum-utils
         state: present
 
@@ -47,6 +49,7 @@
     # or specify docker-ce-{{ docker_version }}
     - name: Ensure docker-ce package installed
       yum:
+        lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
         name: "docker-ce"
         state: latest
       notify: Restart Docker

--- a/src/roles/apache-php/tasks/ius.yml
+++ b/src/roles/apache-php/tasks/ius.yml
@@ -1,11 +1,13 @@
 ---
 - name: Install IUS (CentOS) repo.
   yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
     name: "https://centos{{ ansible_distribution_major_version }}.iuscommunity.org/ius-release.rpm"
   when: ansible_distribution == "CentOS"
 
 - name: Install IUS (RHEL) repo.
   yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
     name: "https://rhel{{ ansible_distribution_major_version }}.iuscommunity.org/ius-release.rpm"
   when: ansible_distribution == "RedHat"
 

--- a/src/roles/apache-php/tasks/main.yml
+++ b/src/roles/apache-php/tasks/main.yml
@@ -1,6 +1,9 @@
 ---
 - name: Install apache packages
-  yum: name={{item}} state=installed
+  yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
+    name: "{{ item }}"
+    state: installed
   with_items:
     - httpd-devel
     - mod_ssl

--- a/src/roles/apache-php/tasks/mssql_driver_for_php.yml
+++ b/src/roles/apache-php/tasks/mssql_driver_for_php.yml
@@ -2,6 +2,7 @@
 
 - name: Ensure prerequisites for sqlsrv in place
   yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
     name: "{{item}}"
     state: installed
   with_items:
@@ -17,6 +18,7 @@
 
 - name: Ensure conflicting ODBC drivers removed
   yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
     name: "{{item}}"
     state: absent
   with_items:
@@ -25,6 +27,7 @@
 
 - name: install MS ODBC driver package
   yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
     name: msodbcsql17
     state: latest
   environment:
@@ -34,6 +37,7 @@
 
 - name: install ODBC driver devel package
   yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
     name: unixODBC-devel
     state: latest
 

--- a/src/roles/apache-php/tasks/php.yml
+++ b/src/roles/apache-php/tasks/php.yml
@@ -1,6 +1,7 @@
 ---
 - name: Install php dependency packages
   yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
     name: "{{ item }}"
     state: installed
   with_items:
@@ -36,6 +37,7 @@
 
 - name: Ensure PHP 5.6 packages removed
   yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
     name: "{{item}}"
     state: absent
   with_items:
@@ -68,6 +70,7 @@
 # other versions of PHP are not installed
 - name: "Check if {{ php_ius_version}} package is installed"
   yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
     list: "{{ php_ius_version }}"
   register: correct_php
 
@@ -76,6 +79,7 @@
 
 - name: Remove any other PHP packages from IUS repo if correct PHP is not installed
   package:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
     name: "php*u*"
     state: absent
   when: ansible_os_family == 'RedHat' and
@@ -83,6 +87,7 @@
 
 - name: Ensure PHP IUS packages installed
   yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
     name: "{{item}}"
     state: installed
   with_items:

--- a/src/roles/apache-php/tasks/profiling.yml
+++ b/src/roles/apache-php/tasks/profiling.yml
@@ -11,6 +11,7 @@
 
 - name: Install mongodb-org package
   yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
     name: mongodb-org
     state: installed
   run_once: yes

--- a/src/roles/backup-config/tasks/main.yml
+++ b/src/roles/backup-config/tasks/main.yml
@@ -2,6 +2,7 @@
 
 - name: Ensure MariaDB client installed on backup servers
   yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
     name: mariadb
     state: present
   tags:

--- a/src/roles/base-extras/tasks/main.yml
+++ b/src/roles/base-extras/tasks/main.yml
@@ -1,6 +1,9 @@
 ---
 - name: Install base-extras packages
-  yum: name={{item}} state=installed
+  yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
+    name: "{{ item }}"
+    state: installed
   with_items:
     - expect
     - expectk

--- a/src/roles/base/tasks/main.yml
+++ b/src/roles/base/tasks/main.yml
@@ -52,17 +52,24 @@
 # Without this get error "yum lockfile is held by another process" occasionally
 - name: Ensure PackageKit is removed so it doesn't try to upgrade packages on its own
   yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
     name: PackageKit
     state: absent
   when: ansible_os_family == 'RedHat'
 
 - name: ensure deltarpm is installed and latest
-  yum: name=deltarpm state=latest
+  yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
+    name: deltarpm
+    state: latest
   tags:
   - latest
 
 - name: upgrade all packages
-  yum: name=* state=latest
+  yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
+    name: "*"
+    state: latest
   environment:
     # If `install_ms_sql_driver: True` is set in config, MS SQL drivers will be
     # installed. When these drivers are updated they require accepting end user
@@ -74,6 +81,7 @@
 # FIXME #807: for RedHat may need to enable "Optional RPMs"
 - name: ensure EPEL installed
   yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
     name: epel-release
     state: installed
   when: ansible_distribution == "CentOS"
@@ -89,6 +97,7 @@
 
 - name: Install EPEL repo.
   yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
     name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
     state: present
   register: result
@@ -115,12 +124,18 @@
   - latest
 
 - name: ensure libselinux-python installed prior to SELinux
-  yum: name=libselinux-python state=installed
+  yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
+    name: libselinux-python
+    state: installed
   tags:
   - latest
 
 - name: Install base packages
-  yum: name={{item}} state=installed
+  yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
+    name: "{{ item }}"
+    state: installed
   with_items:
     - ntp
     - ntpdate
@@ -187,7 +202,10 @@
 # ntpdate pool.ntp.org # Synchronize the system clock with 0.pool.ntp.org server
 # service ntpd start # Start service
 - name: Install NTP
-  yum: name=ntp state=installed
+  yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
+    name: ntp
+    state: installed
   tags:
   - latest
 

--- a/src/roles/database/tasks/setup-RedHat.yml
+++ b/src/roles/database/tasks/setup-RedHat.yml
@@ -1,6 +1,7 @@
 ---
 - name: Ensure MySQL packages are installed.
   yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
     name: "{{ mysql_packages }}"
     state: present
     enablerepo: "{{ mysql_enablerepo | default(omit, true) }}"
@@ -8,6 +9,7 @@
 
 - name: Ensure MySQL Python libraries are installed.
   yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
     name: MySQL-python
     state: present
     enablerepo: "{{ mysql_enablerepo | default(omit, true) }}"

--- a/src/roles/elasticsearch/tasks/es_upgrade.yml
+++ b/src/roles/elasticsearch/tasks/es_upgrade.yml
@@ -82,6 +82,7 @@
 
 - name: Ensure Elasticsearch is latest version
   yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
     name: elasticsearch
     state: latest
 

--- a/src/roles/elasticsearch/tasks/main.yml
+++ b/src/roles/elasticsearch/tasks/main.yml
@@ -4,10 +4,12 @@
 #
 - name: Ensure Java 1.7.0 OpenJDK is absent
   yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
     name: java-1.7.0-openjdk
     state: absent
 - name: Ensure Java 1.8.0 OpenJDK is installed
   yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
     name: java-1.8.0-openjdk
     state: installed
 
@@ -31,6 +33,7 @@
     mode: 0644
 - name: Install Elasticsearch.
   yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
     name: elasticsearch
     state: installed
 

--- a/src/roles/gluster/tasks/setup-RedHat.yml
+++ b/src/roles/gluster/tasks/setup-RedHat.yml
@@ -10,6 +10,7 @@
 
 - name: Ensure CentOS prerequisites in place
   yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
     name: "{{ item }}"
     state: present
   with_items:
@@ -19,6 +20,7 @@
 
 - name: Install Packages
   yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
     name: "{{ item }}"
     state: present
   with_items:

--- a/src/roles/haproxy/tasks/main.yml
+++ b/src/roles/haproxy/tasks/main.yml
@@ -7,7 +7,10 @@
 #     https://www.unixmen.com/configure-high-available-load-balancer-haproxy-keepalived/
 
 - name: Install haproxy packages
-  yum: name={{item}} state=installed
+  yum:
+    name: "{{ item }}"
+    state: installed
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
   with_items:
     - haproxy
     - openssl

--- a/src/roles/imagemagick/tasks/main.yml
+++ b/src/roles/imagemagick/tasks/main.yml
@@ -1,11 +1,13 @@
 ---
 - name: Ensure old ImageMagick installed from Meza RPM
   yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
     name: imagemagick-7.0.3-1.x86_64
     state: absent
 
 - name: Ensure ImageMagick at latest version
   yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
     name:
       - ghostscript
       - ImageMagick

--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -533,6 +533,7 @@
 # MediaWiki 1.31+.
 - name: Ensure Python3 present
   yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
     name:
       - python35u
       - python35u-pip

--- a/src/roles/memcached/tasks/main.yml
+++ b/src/roles/memcached/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 - name: Ensure memcached and netcat packages latest
   yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
     name: "{{ item }}"
     state: latest
   tags:

--- a/src/roles/nodejs/tasks/main.yml
+++ b/src/roles/nodejs/tasks/main.yml
@@ -23,6 +23,7 @@
     var: rhel_os_minor_version
 - name: Ensure http-parser installed from RPM for {{ ansible_distribution_version }}
   yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
     name: https://kojipkgs.fedoraproject.org//packages/http-parser/2.7.1/3.el7/x86_64/http-parser-2.7.1-3.el7.x86_64.rpm
     state: present
   when:
@@ -40,6 +41,7 @@
 
 - name: Ensure Node.js and npm from yum are REMOVED
   yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
     name: "{{ item }}"
     state: absent
   with_items:

--- a/src/roles/nodejs/tasks/setup-RedHat.yml
+++ b/src/roles/nodejs/tasks/setup-RedHat.yml
@@ -23,12 +23,14 @@
 
 - name: Add Nodesource repositories for Node.js (CentOS < 7).
   yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
     name: "http://rpm.nodesource.com/{{ nodejs_rhel_rpm_dir }}/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm"
     state: present
   when: ansible_distribution_major_version|int < 7
 
 - name: Add Nodesource repositories for Node.js (CentOS 7+).
   yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
     name: "https://rpm.nodesource.com/{{ nodejs_rhel_rpm_dir }}/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm"
     state: present
   when: ansible_distribution_major_version|int >= 7
@@ -45,9 +47,14 @@
 #   https://bugzilla.redhat.com/show_bug.cgi?id=1481470
 - name: Ensure http-parser installed from RPM for {{ ansible_distribution_version }}
   yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
     name: https://kojipkgs.fedoraproject.org//packages/http-parser/2.7.1/3.el7/x86_64/http-parser-2.7.1-3.el7.x86_64.rpm
     state: present
   when: ansible_distribution_version.split('.')[1] | int <= 3
 
 - name: Ensure Node.js and npm are installed.
-  yum: "name=nodejs-{{ nodejs_version[0] }}.* state=present enablerepo='epel,nodesource'"
+  yum:
+    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
+    name: "nodejs-{{ nodejs_version[0] }}.*"
+    state: present
+    enablerepo: 'epel,nodesource'"

--- a/tests/deploys/setup-alt-source-backup.yml
+++ b/tests/deploys/setup-alt-source-backup.yml
@@ -14,6 +14,7 @@
   tasks:
     - name: Ensure packages installed
       yum:
+        lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
         name: "{{item}}"
         state: installed
       with_items:


### PR DESCRIPTION
### Changes

* set `lock_timeout` on all `yum` and `package` tasks to avoid intermittent `yum lockfile is held by another process` failures, due to change in Ansible 2.8.

### Issues

* Closes #1165 
* ansible/ansible#57189

### Post-merge actions

Post-merge, the following actions need to be addressed:

- N/A