### PR TITLE
push-backup: Fix bad use of 'notify' tag; Add servers to exclude

### DIFF
--- a/src/playbooks/push-backup.yml
+++ b/src/playbooks/push-backup.yml
@@ -1,7 +1,7 @@
 ---
 
 # Define a timestamp fact to persist throughout this playbook
-- hosts: all:!exclude-all:!load-balancers-nonmeza:!load-balancers-nonmeza-external:!load-balancers-nonmeza-internal
+- hosts: all:!exclude-all:!load-balancers-unmanaged:!load-balancers-nonmeza:!load-balancers-nonmeza-external:!load-balancers-nonmeza-internal
   tasks:
     - set_fact:
         backup_timestamp: "{{lookup('pipe','date +%Y%m%d%H%M%S')}}"
@@ -11,8 +11,6 @@
   roles:
     - set-vars
   tags:
-    # only run this if notify specified
-    - never
     - notify
   tasks:
 
@@ -61,8 +59,6 @@
   roles:
     - set-vars
   tags:
-    # only run this if notify specified
-    - never
     - notify
   tasks:
 

--- a/src/roles/autodeployer/templates/meza-autodeployer-cron.j2
+++ b/src/roles/autodeployer/templates/meza-autodeployer-cron.j2
@@ -22,6 +22,6 @@ MAILTO=root
 #
 # Push backup (db and uploads) to another server periodically
 #
-{{ push_backup.crontime }} root meza push-backup "{{ env }}" "--tags notify" >> {{ m_logs }}/deploy/push-backup-`date "+\%Y\%m\%d"`.log 2>&1
+{{ push_backup.crontime }} root meza push-backup "{{ env }}" >> {{ m_logs }}/deploy/push-backup-`date "+\%Y\%m\%d"`.log 2>&1
 {% endif %}
 {% endif %}


### PR DESCRIPTION
### Changes

* 'notify' tag was mixed with 'never' tag, such that it seemed to make sense to do '--tags notify' to get it to notify. However, this would then skip over other things not tagged 'notify' like 'uploads' and 'db'. Instead you'd have to do '--tags db,uploads,anything-else-required'. Maybe '--tags all,notify' would work, but that's also confusing. Instead this commit removes the 'never' tag so notification will always happen. If a user wants to prevent notification they can do '--skip-tags notify'
* For some reason the list of servers to exclude on the push-backup playbook took the 32.x form with server groups like load-balancers-nonmeza. This missed load-balancers-unmanaged, the 31.x group naming.

### Issues

None

### Post-merge actions

None