### PR TITLE
Fixes for some servers setting zero "others" permissions

### DIFF
--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -241,6 +241,9 @@ m_config_secret_dir_mode: "0775"
 m_config_secret_owner: meza-ansible
 m_config_secret_group: wheel
 
+m_simplesamlphp_mode: "u=rwX,g=rwX,o=rX"
+m_simplesamlphp_owner: meza-ansible
+m_simplesamlphp_group: wheel
 
 
 #

--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -200,6 +200,13 @@ m_data_owner: meza-ansible
 m_data_group: wheel
 
 
+#
+# Used for many things within htdocs that don't require apache to manipulate
+#
+m_htdocs_mode: "u=rwX,g=rwX,o=rX"
+m_htdocs_owner: meza-ansible
+m_htdocs_group: wheel
+
 
 # uploads directory. Note: user meza-ansible is in group "apache"
 m_uploads_dir_mode: "0775"

--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -63,8 +63,9 @@
 - name: Ensure MediaWiki core owned by meza-ansible
   file:
     path: "{{ m_mediawiki }}"
-    owner: meza-ansible
-    group: wheel
+    mode: "{{ m_htdocs_mode }}"
+    owner: "{{ m_htdocs_owner }}"
+    group: "{{ m_htdocs_group }}"
     state: directory
     recurse: yes
   tags:
@@ -93,6 +94,7 @@
           ignoreSubmodules = all
   tags:
     - mediawiki-core
+
 
 #
 # EXTENSIONS AND SKINS
@@ -196,8 +198,9 @@
   template:
     src: Extensions.php.j2
     dest: "{{ m_deploy }}/Extensions.php"
-    owner: meza-ansible
-    group: wheel
+    mode: "{{ m_htdocs_mode }}"
+    owner: "{{ m_htdocs_owner }}"
+    group: "{{ m_htdocs_group }}"
 
 # Adds extensions with composer param from MezaCoreExtensions.yml,
 # MezaLocalExtensions.yml, MezaCoreSkins.yml, and MezaLocalSkins.yml
@@ -205,8 +208,9 @@
   template:
     src: composer.local.json.j2
     dest: "{{ m_mediawiki }}/composer.local.json"
-    owner: meza-ansible
-    group: wheel
+    mode: "{{ m_htdocs_mode }}"
+    owner: "{{ m_htdocs_owner }}"
+    group: "{{ m_htdocs_group }}"
 
 - name: Run composer install on MediaWiki for dependencies
   become: yes
@@ -293,8 +297,9 @@
     src: LocalSettings.php.j2
     dest: "{{ m_mediawiki }}/LocalSettings.php"
     backup: yes
-    owner: meza-ansible
-    group: wheel
+    mode: "{{ m_htdocs_mode }}"
+    owner: "{{ m_htdocs_owner }}"
+    group: "{{ m_htdocs_group }}"
 
 
 

--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -301,6 +301,17 @@
     owner: "{{ m_htdocs_owner }}"
     group: "{{ m_htdocs_group }}"
 
+- name: Ensure MediaWiki still properly owned
+  file:
+    path: "{{ m_mediawiki }}"
+    mode: "{{ m_htdocs_mode }}"
+    owner: "{{ m_htdocs_owner }}"
+    group: "{{ m_htdocs_group }}"
+    state: directory
+    recurse: yes
+  tags:
+    - mediawiki-core
+    - file-perms
 
 
 #
@@ -320,7 +331,18 @@
   template:
     src: BlenderSettings.php.j2
     dest: "{{ m_htdocs }}/WikiBlender/BlenderSettings.php"
+    mode: "{{ m_htdocs_mode }}"
+    owner: "{{ m_htdocs_owner }}"
+    group: "{{ m_htdocs_group }}"
 
+- name: Ensure WikiBlender properly owned
+  file:
+    path: "{{ m_htdocs }}/WikiBlender"
+    mode: "{{ m_htdocs_mode }}"
+    owner: "{{ m_htdocs_owner }}"
+    group: "{{ m_htdocs_group }}"
+    state: directory
+    recurse: yes
 
 
 #

--- a/src/roles/saml/tasks/main.yml
+++ b/src/roles/saml/tasks/main.yml
@@ -1,6 +1,35 @@
 ---
+- name: "Check if {{ m_simplesamlphp_path }} exists"
+  stat:
+    path: "{{ m_simplesamlphp_path }}"
+  register: simplesamlphp_exists
+
+- name: "Check if {{ m_simplesamlphp_path }} exists"
+  stat:
+    path: "{{ m_mediawiki }}/extensions/SimpleSamlAuth"
+  register: simplesamlextension_exists
+
+- name: Ensure good permissions on simplesamlphp directory and subs (if dir exists)
+  file:
+    path: "{{ m_simplesamlphp_path }}"
+    owner: "{{ m_simplesamlphp_owner }}"
+    group: "{{ m_simplesamlphp_group }}"
+    mode: "{{ m_simplesamlphp_mode }}"
+    recurse: yes
+  when: simplesamlphp_exists.stat.exists and simplesamlphp_exists.stat.isdir
+
+- name: Ensure good permissions on Extension:SimpleSamlAuth directory and subs (if dir exists)
+  file:
+    path: "{{ m_mediawiki }}/extensions/SimpleSamlAuth"
+    mode: "{{ m_htdocs_mode }}"
+    owner: "{{ m_htdocs_owner }}"
+    group: "{{ m_htdocs_group }}"
+    recurse: yes
+  when: simplesamlphp_exists.stat.exists and simplesamlphp_exists.stat.isdir
 
 - name: Ensure SimpleSamlPhp (PHP SAML library) installed
+  become: yes
+  become_user: "meza-ansible"
   # Ref #1149 for TMPDIR environment var
   environment:
     TMPDIR: "{{ m_tmp }}"
@@ -13,6 +42,8 @@
     - latest
 
 - name: Ensure SimpleSamlAuth (MediaWiki extension) installed
+  become: yes
+  become_user: "meza-ansible"
   # Ref #1149 for TMPDIR environment var
   environment:
     TMPDIR: "{{ m_tmp }}"
@@ -57,12 +88,20 @@
     - filename: "SAMLConfig.php"
       dest_path: "{{ m_deploy }}"
 
-- name: Ensure good permissions on simplesamlphp directory and subs
+- name: Ensure _still_ good permissions on simplesamlphp directory and subs
   file:
     path: "{{ m_simplesamlphp_path }}"
     owner: "{{ m_simplesamlphp_owner }}"
     group: "{{ m_simplesamlphp_group }}"
     mode: "{{ m_simplesamlphp_mode }}"
+    recurse: yes
+
+- name: Ensure _still_ good permissions on Extension:SimpleSamlAuth directory and subs
+  file:
+    path: "{{ m_mediawiki }}/extensions/SimpleSamlAuth"
+    mode: "{{ m_htdocs_mode }}"
+    owner: "{{ m_htdocs_owner }}"
+    group: "{{ m_htdocs_group }}"
     recurse: yes
 
 - name: Ensure NonMediaWikiSimpleSamlAuth.php in place

--- a/src/roles/saml/tasks/main.yml
+++ b/src/roles/saml/tasks/main.yml
@@ -28,6 +28,8 @@
     - latest
 
 - name: Ensure simplesamlphp dependencies in place
+  become: yes
+  become_user: "meza-ansible"
   composer:
     command: install
     working_dir: "{{ m_simplesamlphp_path }}"
@@ -55,10 +57,18 @@
     - filename: "SAMLConfig.php"
       dest_path: "{{ m_deploy }}"
 
+- name: Ensure good permissions on simplesamlphp directory and subs
+  file:
+    path: "{{ m_simplesamlphp_path }}"
+    owner: "{{ m_simplesamlphp_owner }}"
+    group: "{{ m_simplesamlphp_group }}"
+    mode: "{{ m_simplesamlphp_mode }}"
+    recurse: yes
+
 - name: Ensure NonMediaWikiSimpleSamlAuth.php in place
   copy:
     src: files/NonMediaWikiSimpleSamlAuth.php
     dest: "{{ m_htdocs }}/NonMediaWikiSimpleSamlAuth.php"
-    owner: root
-    group: root
+    owner: meza-ansible
+    group: apache
     mode: 0755

--- a/src/roles/verify-wiki/tasks/import-wiki-sql.yml
+++ b/src/roles/verify-wiki/tasks/import-wiki-sql.yml
@@ -12,6 +12,8 @@
   delegate_to: "{{ groups['db-master'][0] }}"
   run_once: true
 
+- debug:
+    var: imported_wiki_sql_on_db_master
 
 #
 # Set facts to clarify if overwriting data should actually occur


### PR DESCRIPTION
### Changes

On a recent installation several directories associated with Git or Composer installs were getting `750` or `640` permissions (zero for "others"). On previous installs these would get `755` or `644`. Umask is an obvious culprit but Meza should handle this. This pull request explicitly sets user/group/mode for various directories to remove the problem.

### Issues

None

### Post-merge actions

Post-merge, the following actions need to be addressed:

None