### PR TITLE
Make pushed backups in form *push.sql and use them first; more debug

### DIFF
--- a/src/roles/backup-db-wikis-push/tasks/main.yml
+++ b/src/roles/backup-db-wikis-push/tasks/main.yml
@@ -35,7 +35,7 @@
     pushing_from_path: "{{ m_tmp }}/{{ env }}_{{ item }}.sql"
     pushing_to_server: "{{ push_backup.db.addr }}"
     # remote_server_base_path + backup_timestamp + _wiki.sql, but replace <id> with wiki_id (item)
-    pushing_to_path: "{{ remote_server_base_path | regex_replace('<id>', item) }}{{ backup_timestamp }}_wiki.sql"
+    pushing_to_path: "{{ remote_server_base_path | regex_replace('<id>', item) }}{{ backup_timestamp }}_wiki_push.sql"
     pushing_to_user: "{{ push_backup.remote_user }}"
   with_items: "{{ wiki_dirs.files | map(attribute='path') | map('basename') | list }}"
 

--- a/src/roles/verify-wiki/tasks/main.yml
+++ b/src/roles/verify-wiki/tasks/main.yml
@@ -137,6 +137,7 @@
     sql_backup_server: "{{ backups_server_db_dump.addr }}"
     do_sql_dump: True
     sql_file_match: "wiki_{{ wiki_id }}.sql"
+    sql_file_push_match: "wiki_{{ wiki_id }}.sql"
     db_backup_server_remote_user: "{{ backups_server_db_dump.remote_user }}"
     db_backup_server_mysql_user: "{{ backups_server_db_dump.mysql_user }}"
     sql_backup_server_set: True
@@ -148,6 +149,7 @@
     do_sql_dump: False
     sql_dir_path: "{{ backups_server_alt_source.sql_dir_path | regex_replace('<id>', wiki_id) }}"
     sql_file_match: "{{ backups_server_alt_source.sql_file_match | default('*.sql') | regex_replace('<id>', wiki_id) }}"
+    sql_file_push_match: "{{ backups_server_alt_source.sql_file_match | default('*push.sql') | regex_replace('<id>', wiki_id) }}"
     db_backup_server_remote_user: "{{ backups_server_alt_source.remote_user }}"
     sql_backup_server_set: True
   when: "not sql_backup_server_set and backups_server_alt_source is defined"
@@ -158,6 +160,7 @@
     do_sql_dump: False
     sql_dir_path: "{{ m_backups }}/{{ env }}/{{ wiki_id }}"
     sql_file_match: "*.sql"
+    sql_file_push_match: "*push.sql"
     sql_backup_server_set: True
   when: "not sql_backup_server_set and 'backup-servers' in groups and groups['backup-servers']|length|int > 0"
 
@@ -178,10 +181,6 @@
     state: absent
   run_once: true
   delegate_to: "{{ groups['db-master'][0] }}"
-
-- debug: { var: do_sql_dump }
-- debug: { var: wiki_exists }
-- debug: { var: intend_overwrite_from_backup }
 
 - debug:
     msg: |

--- a/src/roles/verify-wiki/tasks/transfer-backup-to-db-master.yml
+++ b/src/roles/verify-wiki/tasks/transfer-backup-to-db-master.yml
@@ -1,6 +1,15 @@
 ---
 # Transfer SQL to DB master
 
+- debug:
+    msg: |
+      wiki_id:                       {{ wiki_id | default('<undefined>') }}
+      sql_dir_path:                  {{ sql_dir_path | default('<undefined>') }}
+      sql_file_match:                {{ sql_file_match | default('<undefined>') }}
+      sql_file_push_match:           {{ sql_file_push_match | default('<undefined>') }}
+      sql_backup_server:             {{ sql_backup_server | default('<undefined>') }}
+      db_backup_server_remote_user:  {{ db_backup_server_remote_user | default('<undefined>') }}
+
 
 #
 # Check for backups directory
@@ -27,8 +36,8 @@
 
 # This will find the latest sql file by name, or wiki.sql over any timestamped one
 # assuming timestamp-named files like 20170220000002_wiki.sql
-- name: "{{ wiki_id }} - Find SQL file if it exists"
-  shell: 'find {{ sql_dir_path }} -maxdepth 1 -type f -iname "{{ sql_file_match }}" | sort -r | head -n +1'
+- name: "{{ wiki_id }} - Find _PUSHED_ SQL file if it exists"
+  shell: 'find {{ sql_dir_path }} -maxdepth 1 -type f -iname "{{ sql_file_push_match }}" | sort -r | head -n +1'
   register: wiki_sql_file
   delegate_to: "{{ sql_backup_server }}"
   run_once: true
@@ -36,16 +45,53 @@
   failed_when: False
   when: backup_dir_exists and (not wiki_exists or intend_overwrite_from_backup)
 
-- name: "{{ wiki_id }} - Set fact if SQL file DOES exist"
+- name: "{{ wiki_id }} - Set fact if _PUSHED_ SQL file DOES exist"
   set_fact:
     sql_file_exists: True
+    sql_file_pushed_exists: True
   when: wiki_sql_file is defined and wiki_sql_file.rc is defined and wiki_sql_file.rc == 0
 
-- name: "{{ wiki_id }} - Set fact if SQL file DOES NOT exist"
+- name: "{{ wiki_id }} - Set fact if _PUSHED_ SQL file DOES NOT exist"
   set_fact:
     sql_file_exists: False
+    sql_file_pushed_exists: False
   when: wiki_sql_file is not defined or wiki_sql_file.rc is not defined or wiki_sql_file.rc != 0
 
+- debug:
+    msg: |
+      sql file: {{ wiki_sql_file.stdout | default('<undefined>') }}
+
+- name: "{{ wiki_id }} - If no pushed SQL file, find any SQL file if it exists"
+  shell: 'find {{ sql_dir_path }} -maxdepth 1 -type f -iname "{{ sql_file_match }}" | sort -r | head -n +1'
+  register: wiki_sql_file
+  delegate_to: "{{ sql_backup_server }}"
+  run_once: true
+  remote_user: "{{ db_backup_server_remote_user }}"
+  failed_when: False
+  when:
+    - not sql_file_pushed_exists
+    - backup_dir_exists
+    - (not wiki_exists or intend_overwrite_from_backup)
+
+- name: "{{ wiki_id }} - If no pushed SQL file, set fact if any SQL file DOES exist"
+  set_fact:
+    sql_file_exists: True
+  when:
+    - not sql_file_pushed_exists
+    - wiki_sql_file is defined
+    - wiki_sql_file.rc is defined
+    - wiki_sql_file.rc == 0
+
+- name: "{{ wiki_id }} - If no pushed SQL file, set fact if any other SQL file DOES NOT exist"
+  set_fact:
+    sql_file_exists: False
+  when:
+    - not sql_file_pushed_exists
+    - wiki_sql_file is not defined or wiki_sql_file.rc is not defined or wiki_sql_file.rc != 0
+
+- debug:
+    msg: |
+      sql file: {{ wiki_sql_file.stdout | default('<undefined>') }}
 
 #
 # Do the rsync transfer of SQL file from backup server to DB master
@@ -60,5 +106,4 @@
     pulling_from_path:   "{{ wiki_sql_file.stdout }}"
     pulling_from_user:   "{{ db_backup_server_remote_user }}"
   run_once: true
-  when:
-    sql_file_exists
+  when: sql_file_exists

--- a/src/roles/verify-wiki/tasks/transfer-backup-to-db-master.yml
+++ b/src/roles/verify-wiki/tasks/transfer-backup-to-db-master.yml
@@ -38,7 +38,7 @@
 # assuming timestamp-named files like 20170220000002_wiki.sql
 - name: "{{ wiki_id }} - Find _PUSHED_ SQL file if it exists"
   shell: 'find {{ sql_dir_path }} -maxdepth 1 -type f -iname "{{ sql_file_push_match }}" | sort -r | head -n +1'
-  register: wiki_sql_file
+  register: wiki_sql_push_file
   delegate_to: "{{ sql_backup_server }}"
   run_once: true
   remote_user: "{{ db_backup_server_remote_user }}"
@@ -47,19 +47,27 @@
 
 - name: "{{ wiki_id }} - Set fact if _PUSHED_ SQL file DOES exist"
   set_fact:
-    sql_file_exists: True
     sql_file_pushed_exists: True
-  when: wiki_sql_file is defined and wiki_sql_file.rc is defined and wiki_sql_file.rc == 0
+  when:
+    - wiki_sql_push_file is defined
+    - wiki_sql_push_file.rc is defined
+    - wiki_sql_push_file.rc == 0
+    - wiki_sql_push_file.stdout != ""
 
 - name: "{{ wiki_id }} - Set fact if _PUSHED_ SQL file DOES NOT exist"
   set_fact:
-    sql_file_exists: False
     sql_file_pushed_exists: False
-  when: wiki_sql_file is not defined or wiki_sql_file.rc is not defined or wiki_sql_file.rc != 0
+  when: >
+    (
+      wiki_sql_push_file is not defined
+      or wiki_sql_push_file.rc is not defined
+      or wiki_sql_push_file.rc != 0
+      or wiki_sql_push_file.stdout == ""
+    )
 
-- debug:
-    msg: |
-      sql file: {{ wiki_sql_file.stdout | default('<undefined>') }}
+- name: Debug var wiki_sql_push_file
+  debug:
+    var: wiki_sql_push_file
 
 - name: "{{ wiki_id }} - If no pushed SQL file, find any SQL file if it exists"
   shell: 'find {{ sql_dir_path }} -maxdepth 1 -type f -iname "{{ sql_file_match }}" | sort -r | head -n +1'
@@ -81,17 +89,37 @@
     - wiki_sql_file is defined
     - wiki_sql_file.rc is defined
     - wiki_sql_file.rc == 0
+    - wiki_sql_file.stdout != ""
 
 - name: "{{ wiki_id }} - If no pushed SQL file, set fact if any other SQL file DOES NOT exist"
   set_fact:
     sql_file_exists: False
   when:
     - not sql_file_pushed_exists
-    - wiki_sql_file is not defined or wiki_sql_file.rc is not defined or wiki_sql_file.rc != 0
+    - >
+      (
+        wiki_sql_file is not defined
+        or wiki_sql_file.rc is not defined
+        or wiki_sql_file.rc != 0
+        or wiki_sql_file.stdout == ""
+      )
+
+
+- name: Set path to pushed SQL file
+  set_fact:
+    wiki_sql_file_path: "{{ wiki_sql_push_file.stdout }}"
+  when: sql_file_pushed_exists
+
+- name: Set path to any SQL file
+  set_fact:
+    wiki_sql_file_path: "{{ wiki_sql_file.stdout }}"
+  when:
+    - not sql_file_pushed_exists
+    - sql_file_exists
 
 - debug:
     msg: |
-      sql file: {{ wiki_sql_file.stdout | default('<undefined>') }}
+      sql file: {{ wiki_sql_file_path | default('<undefined>') }}
 
 #
 # Do the rsync transfer of SQL file from backup server to DB master
@@ -106,4 +134,6 @@
     pulling_from_path:   "{{ wiki_sql_file.stdout }}"
     pulling_from_user:   "{{ db_backup_server_remote_user }}"
   run_once: true
-  when: sql_file_exists
+  when:
+    - wiki_sql_file_path is defined
+    - wiki_sql_file_path != ""


### PR DESCRIPTION
### Changes

Pushing backups from one server, then running deploy and trying to pick up those backups at a later time inevitably gets out of sync. For clarity, say PROD pushes to DEV. If PROD pushes, then another deploy happens on DEV, that deploy will _probably_ generate `.sql` files on DEV with a newer timestamp than those pushed from PROD. When a later deploy with `--overwrite` occurs it will not choose to use the one that was pushed, but instead choose the latest timestamp. This means DEV won't get the freshest data. In an even worse case, if DEV's database gets corrupted (as may happen on a dev server) then it may cause a situation where DEV can never get good data.

This change does three things:
1. Make `meza push-backup` write SQL files that look like `20190611120004_wiki_push.sql` instead of `20190611120004_wiki.sql`
2. Make `transfer-backup-to-db-master.yml` first look for files matching `*push.sql` before looking for `*.sql`
3. Add more debug

Additionally, tests for valid sql file now also include `wiki_sql_file.stdout != ""` (and `wiki_sql_push_file.stdout != ""`) instead of just looking for return code of zero. This may have been causing issues when no backup files were present, since Meza may have been incorrectly saying that files were present but passing along an empty file path.

### Issues

Internal problems with getting servers pushing and deploying nicely

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Update documentation at https://www.mediawiki.org/wiki/Meza
