### PR TITLE
Allow specifying rules for what to gzip in backups-cleanup

### DIFF
--- a/src/roles/backups-cleanup/templates/backups-cleanup.sh.j2
+++ b/src/roles/backups-cleanup/templates/backups-cleanup.sh.j2
@@ -4,11 +4,17 @@
 cd {{ m_backups }}/{{ env }}
 
 # remove all odd-numbered days (keep only even-numbered days)
+{% if backups_cleanup.removal_rules is defined %}
 {% for removal_rule in backups_cleanup.removal_rules %}
 rm {{ removal_rule }} -f
 {% endfor %}
+{% endif %}
 
 # compress all SQL files
+{% if backups_cleanup.gzip_rules is defined %}
 echo "gzip start time: $(date +\"%T\")"
-gzip -9 ./*/*.sql
+{% for gzip_rule in backups_cleanup.gzip_rules %}
+gzip -9 {{ gzip_rule }}
+{% endfor %}
 echo "gzip end time: $(date +\"%T\")"
+{% endif %}


### PR DESCRIPTION
### Changes

Previously backups-cleanup gzipped all SQL backup files present. You don't always want this, particularly if you're sourcing from those backups. This PR allows specifying what should be gzipped. If no `backups_cleanup.gzip_rules` are specified, then nothing will be gzipped.

Previously you've been able to specify backups cleanup like:

```yaml
backups_cleanup:
  crontime: "30 19 * * *"
  removal_rules:

    # Remove SQL files from 2, 3, and 4 days ago
    - "./*/$(date --date=\"2 days ago\" +\"%Y%m%d\")*.sql*"
    - "./*/$(date --date=\"3 days ago\" +\"%Y%m%d\")*.sql*"
    - "./*/$(date --date=\"4 days ago\" +\"%Y%m%d\")*.sql*"
```

Now you can add gzip rules:

```yaml
backups_cleanup:
  crontime: "30 19 * * *"
  removal_rules:
    - "./*/$(date --date=\"4 days ago\" +\"%Y%m%d\")*.sql*"
    - "./*/$(date --date=\"5 days ago\" +\"%Y%m%d\")*.sql*"
    - "./*/$(date --date=\"6 days ago\" +\"%Y%m%d\")*.sql*"
  gzip_rules:
    - "./*/$(date --date=\"2 days ago\" +\"%Y%m%d\")*.sql*"
    - "./*/$(date --date=\"3 days ago\" +\"%Y%m%d\")*.sql*"
```

This would delete files from 4-6 days old, and gzip those 2-3 days old. Files 1 day old or newer would be kept and not gzipped.

### Issues

None

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Update documentation at https://www.mediawiki.org/wiki/Meza
