### PR TITLE
Add --no-dev to MW composer commands

### DIFF
--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -212,26 +212,47 @@
     owner: "{{ m_htdocs_owner }}"
     group: "{{ m_htdocs_group }}"
 
-- name: Remove composer.lock
-  become: yes
-  become_user: "meza-ansible"
-  file:
-    path: "{{ m_mediawiki }}/composer.lock"
-    state: absent
-  tags:
-    - composer-extensions
-    - latest
-    - skins
+# - name: Remove composer.lock
+#   become: yes
+#   become_user: "meza-ansible"
+#   file:
+#     path: "{{ m_mediawiki }}/composer.lock"
+#     state: absent
+#   tags:
+#     - composer-extensions
+#     - latest
+#     - skins
+
+# - name: Run composer install on MediaWiki for dependencies
+#   become: yes
+#   become_user: "meza-ansible"
+#   composer:
+#     command: install
+#     working_dir: "{{ m_mediawiki }}"
+#     no_dev: yes
+#   tags:
+#     - composer-extensions
+#     - latest
+#     - skins
+
+# # install doesn't appear to do extensions
+# - name: Run composer update on MediaWiki for extensions
+#   become: yes
+#   become_user: "meza-ansible"
+#   composer:
+#     command: update
+#     working_dir: "{{ m_mediawiki }}"
+#     no_dev: yes
+#   tags:
+#     - composer-extensions
+#     - latest
+#     - skins
+
 
 - name: Run composer install on MediaWiki for dependencies
   become: yes
   become_user: "meza-ansible"
-  composer:
-    command: install
-    working_dir: "{{ m_mediawiki }}"
-    no_dev: yes
-  # FIXME #317: need ignore_errors because composer throws an error when running as root.
-  # failed_when: False
+  shell: "cd {{ m_mediawiki }} && composer install --no-dev"
   tags:
     - composer-extensions
     - latest
@@ -241,12 +262,7 @@
 - name: Run composer update on MediaWiki for extensions
   become: yes
   become_user: "meza-ansible"
-  composer:
-    command: update
-    working_dir: "{{ m_mediawiki }}"
-    no_dev: yes
-  # FIXME #317: need ignore_errors because composer throws an error when running as root.
-  # failed_when: False
+  composer: "cd {{ m_mediawiki }} && composer update --no-dev"
   tags:
     - composer-extensions
     - latest

--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -212,6 +212,17 @@
     owner: "{{ m_htdocs_owner }}"
     group: "{{ m_htdocs_group }}"
 
+- name: Remove composer.lock
+  become: yes
+  become_user: "meza-ansible"
+  file:
+    path: "{{ m_mediawiki }}/composer.lock"
+    state: absent
+  tags:
+    - composer-extensions
+    - latest
+    - skins
+
 - name: Run composer install on MediaWiki for dependencies
   become: yes
   become_user: "meza-ansible"

--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -262,7 +262,7 @@
 - name: Run composer update on MediaWiki for extensions
   become: yes
   become_user: "meza-ansible"
-  composer: "cd {{ m_mediawiki }} && composer update --no-dev"
+  shell: "cd {{ m_mediawiki }} && composer update --no-dev"
   tags:
     - composer-extensions
     - latest

--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -218,7 +218,7 @@
   composer:
     command: install
     working_dir: "{{ m_mediawiki }}"
-    no_dev: no
+    no_dev: yes
   # FIXME #317: need ignore_errors because composer throws an error when running as root.
   # failed_when: False
   tags:
@@ -233,7 +233,7 @@
   composer:
     command: update
     working_dir: "{{ m_mediawiki }}"
-    no_dev: no
+    no_dev: yes
   # FIXME #317: need ignore_errors because composer throws an error when running as root.
   # failed_when: False
   tags:

--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -237,25 +237,6 @@
     - latest
     - skins
 
-# - name: Run composer install on MediaWiki for dependencies
-#   become: yes
-#   become_user: "meza-ansible"
-#   shell: "cd {{ m_mediawiki }} && composer install --no-dev"
-#   tags:
-#     - composer-extensions
-#     - latest
-#     - skins
-
-# # install doesn't appear to do extensions
-# - name: Run composer update on MediaWiki for extensions
-#   become: yes
-#   become_user: "meza-ansible"
-#   shell: "cd {{ m_mediawiki }} && composer update --no-dev"
-#   tags:
-#     - composer-extensions
-#     - latest
-#     - skins
-
 - name: Ensure Git submodule requirements met for core meza extensions
   become: yes
   become_user: "meza-ansible"

--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -212,47 +212,13 @@
     owner: "{{ m_htdocs_owner }}"
     group: "{{ m_htdocs_group }}"
 
-# - name: Remove composer.lock
-#   become: yes
-#   become_user: "meza-ansible"
-#   file:
-#     path: "{{ m_mediawiki }}/composer.lock"
-#     state: absent
-#   tags:
-#     - composer-extensions
-#     - latest
-#     - skins
-
-# - name: Run composer install on MediaWiki for dependencies
-#   become: yes
-#   become_user: "meza-ansible"
-#   composer:
-#     command: install
-#     working_dir: "{{ m_mediawiki }}"
-#     no_dev: yes
-#   tags:
-#     - composer-extensions
-#     - latest
-#     - skins
-
-# # install doesn't appear to do extensions
-# - name: Run composer update on MediaWiki for extensions
-#   become: yes
-#   become_user: "meza-ansible"
-#   composer:
-#     command: update
-#     working_dir: "{{ m_mediawiki }}"
-#     no_dev: yes
-#   tags:
-#     - composer-extensions
-#     - latest
-#     - skins
-
-
 - name: Run composer install on MediaWiki for dependencies
   become: yes
   become_user: "meza-ansible"
-  shell: "cd {{ m_mediawiki }} && composer install --no-dev"
+  composer:
+    command: install
+    working_dir: "{{ m_mediawiki }}"
+    no_dev: yes
   tags:
     - composer-extensions
     - latest
@@ -262,11 +228,33 @@
 - name: Run composer update on MediaWiki for extensions
   become: yes
   become_user: "meza-ansible"
-  shell: "cd {{ m_mediawiki }} && composer update --no-dev"
+  composer:
+    command: update
+    working_dir: "{{ m_mediawiki }}"
+    no_dev: yes
   tags:
     - composer-extensions
     - latest
     - skins
+
+# - name: Run composer install on MediaWiki for dependencies
+#   become: yes
+#   become_user: "meza-ansible"
+#   shell: "cd {{ m_mediawiki }} && composer install --no-dev"
+#   tags:
+#     - composer-extensions
+#     - latest
+#     - skins
+
+# # install doesn't appear to do extensions
+# - name: Run composer update on MediaWiki for extensions
+#   become: yes
+#   become_user: "meza-ansible"
+#   shell: "cd {{ m_mediawiki }} && composer update --no-dev"
+#   tags:
+#     - composer-extensions
+#     - latest
+#     - skins
 
 - name: Ensure Git submodule requirements met for core meza extensions
   become: yes

--- a/src/roles/update.php/tasks/main.yml
+++ b/src/roles/update.php/tasks/main.yml
@@ -50,10 +50,35 @@
     owner: "{{ m_logs_owner }}"
     group: "{{ m_logs_group }}"
 
-- name: Run update.php on this wiki
-  shell: >
-    WIKI="{{ wiki_id }}" php "{{ m_mediawiki }}/maintenance/update.php" --quick >> {{ m_logs }}/update.php/{{ wiki_id }}.`date "+\%Y\%m\%d"`.log 2>&1
-  # run_once see [1]
-  run_once: true
+- set_fact:
+    update_php_log: "{{ m_logs }}/update.php/{{ wiki_id }}.{{ lookup('pipe','date +%Y%m%d%H%M%S') }}.log"
+
+- name: Try update.php
+  block:
+
+    - name: Run update.php on this wiki
+      shell: >
+        WIKI="{{ wiki_id }}" php "{{ m_mediawiki }}/maintenance/update.php" --quick >> {{ update_php_log }} 2>&1
+      # run_once see [1]
+      run_once: true
+
+  rescue:
+
+    - name: Get update.php log file
+      shell: "cat {{ update_php_log }}"
+      register: update_php_log_output
+
+    - debug:
+        var: update_php_log_output
+
+    - name: Get php error log
+      shell: "tail -n 50 {{ m_logs }}/php/php_errors.log"
+      register: php_error_log_output
+
+    - debug:
+        var: php_error_log_output
+
+    - name: Force failure after reporting
+      command: /bin/false
   tags:
     - update.php

--- a/tests/docker/init-controller.sh
+++ b/tests/docker/init-controller.sh
@@ -5,16 +5,16 @@
 
 # Initiate container
 docker_repo="jamesmontalvo3/meza-docker-full:latest"
-source "$m_meza_host/tests/docker/init-container.sh" "none"
+source "$m_meza_host/tests/docker/init-container.sh" "${m_meza_host}" "mount"
 
 
 # Checkout the correct version of meza on the container
 # What's present on the pre-built container is not the latest. Need to pull
 # master in case the docker image doesn't have the correct git-setup.sh script
 # yet
-${docker_exec[@]} bash -c "cd /opt/meza && git fetch origin && git reset --hard origin/master"
-${docker_exec[@]} bash /opt/meza/tests/travis/git-setup.sh "$TRAVIS_EVENT_TYPE" \
-	"$TRAVIS_COMMIT" "$TRAVIS_PULL_REQUEST_SHA" "$TRAVIS_BRANCH" "$TRAVIS_PULL_REQUEST_BRANCH"
+# ${docker_exec[@]} bash -c "cd /opt/meza && git fetch origin && git reset --hard origin/master"
+# ${docker_exec[@]} bash /opt/meza/tests/travis/git-setup.sh "$TRAVIS_EVENT_TYPE" \
+# 	"$TRAVIS_COMMIT" "$TRAVIS_PULL_REQUEST_SHA" "$TRAVIS_BRANCH" "$TRAVIS_PULL_REQUEST_BRANCH"
 
 
 # FIXME #728: Test band-aid. This is run in init-container.sh above, but at


### PR DESCRIPTION
### Changes

1. Do `composer install` and `composer update` of MW with `--no-dev` (via Ansible Composer module)
2. In CI tests 3 through 5 the `init-controller.sh` script is used. This was not mounting the Meza directory to the container, but was attempting to check out the the right version of Meza from this repository. This had two issues which were resolved by mounting:
  1. It made it impossible to do local testing of that particular job without pushing the changes to this repository.
  2. On travis PR jobs were getting the wrong version and thus were not getting necessary updates.
3. Not directly required for this PR but used in troubleshooting and generally useful: Make `update.php` role output update.php log and php error log on update.php failure

### Issues

- Closes #1207 

### Post-merge actions

None