### PR TITLE
Make meza-ansible:apache own deploy lock file, not root

### DIFF
--- a/src/scripts/meza.py
+++ b/src/scripts/meza.py
@@ -242,6 +242,9 @@ def request_lock_for_deploy (env):
 		with open( lock_file, 'w' ) as f:
 			f.write( "{}\n{}".format(pid,timestamp) )
 			f.close()
+		meza_chown( lock_file, 'meza-ansible', 'apache' )
+		os.chmod( lock_file, 0664 )
+
 		return { "pid": pid, "timestamp": timestamp }
 
 def unlock_deploy(env):


### PR DESCRIPTION
### Changes

Ultimately the web interface should allow admins to unlock the deploy lock file. This sets it up for the apache user to do that.

### Issues

None

### Post-merge actions

None