### PR TITLE
Make Extension:MezaExt track 'master' while TransferPages in development

### DIFF
--- a/config/core/MezaCoreExtensions.yml
+++ b/config/core/MezaCoreExtensions.yml
@@ -179,7 +179,7 @@ list:
     version: "{{ mediawiki_default_branch }}"
   - name: MezaExt
     repo: https://github.com/enterprisemediawiki/MezaExt.git
-    version: tags/0.1.0
+    version: "master"
   # Extension:PdfHandler (breaks on very large PDFs)
   # https://github.com/wikimedia/mediawiki-extensions-PdfHandler
   # // Location of PdfHandler dependencies


### PR DESCRIPTION
### Changes

Makes Extension:MezaExt track `master`. This is low-risk because the extension is entirely for Meza, All changes are currently for TransferPages or CI. This will help speed up development of TransferPages. After TransferPages is (more) stable this should be changed back to a new release tag.

### Issues

None

### Post-merge actions

None