### PR TITLE
Bump MW to 1.31.2; remove pear/net_smtp from meza (part of MW now)

### DIFF
--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -137,7 +137,7 @@ use_default_ssh_config: True
 #
 
 # Version of MediaWiki core
-mediawiki_version: "1.31.1"
+mediawiki_version: "1.31.2"
 
 # Branch to use on many extensions extensions and skins
 mediawiki_default_branch: "REL1_31"

--- a/src/roles/mediawiki/templates/composer.local.json.j2
+++ b/src/roles/mediawiki/templates/composer.local.json.j2
@@ -17,11 +17,9 @@
 		{%- endfor -%}
 
 		{%- for ext in meza_core_extensions['list'] if ext.composer is defined %}
-		"{{ ext.composer }}": "{{ ext.version }}",
-		{# Note: pear/net_smtp is part of MW core in 1.32+. Need to add conditional comma here when pear/net_smtp is removed below. #}
+		"{{ ext.composer }}": "{{ ext.version }}"
+		{%- if not loop.last -%},{%- endif %}
 		{%- endfor %}
-
-		"pear/net_smtp": "1.8.0"
 
 	},
 	"extra": {


### PR DESCRIPTION
### Changes

* Bump MW to 1.31.2
* Remove `pear/net_smtp` from Meza since it's included within MediaWiki's `composer.json` now.

### Issues

* Closes #1210

### Post-merge actions

None