### PR TITLE
Check if apache group exists before setting as group for lock file

### DIFF
--- a/src/scripts/meza.py
+++ b/src/scripts/meza.py
@@ -242,7 +242,16 @@ def request_lock_for_deploy (env):
 		with open( lock_file, 'w' ) as f:
 			f.write( "{}\n{}".format(pid,timestamp) )
 			f.close()
-		meza_chown( lock_file, 'meza-ansible', 'apache' )
+
+		import grp
+
+		try:
+			grp.getgrnam('apache')
+			meza_chown( lock_file, 'meza-ansible', 'apache' )
+		except KeyError:
+			print('Group apache does not exist. Set "wheel" as group for lock file.')
+			meza_chown( lock_file, 'meza-ansible', 'wheel' )
+
 		os.chmod( lock_file, 0664 )
 
 		return { "pid": pid, "timestamp": timestamp }


### PR DESCRIPTION
### Changes

#1208 set group `apache` for the deploy lock file. This is great for future ability to unlock the deploy via the web interface, but unfortunately it makes it impossible to deploy initially since group `apache` doesn't exist initially. This PR adds a check for whether the apache group exists, and if not it sets the group to `wheel`.

### Issues

* Closes #1216

### Post-merge actions

None