### PR TITLE
Allow Meza to identify / create wikis based on sub-domains 

### DIFF
--- a/src/playbooks/create-wiki-promptless.yml
+++ b/src/playbooks/create-wiki-promptless.yml
@@ -5,7 +5,10 @@
   roles:
     - set-vars
     - create-wiki-wrapper
-
+  handlers:
+    - name: restart apache
+      service: name=httpd state=restarted
+      when: docker_skip_tasks is not defined or not docker_skip_tasks
 
 - hosts: parsoid-servers
   become: yes

--- a/src/playbooks/create-wiki.yml
+++ b/src/playbooks/create-wiki.yml
@@ -29,6 +29,11 @@
     - set-vars
     - create-wiki-wrapper
 
+  handlers:
+
+    - name: restart apache
+      service: name=httpd state=restarted
+      when: docker_skip_tasks is not defined or not docker_skip_tasks
 
 - hosts: parsoid-servers
   become: yes

--- a/src/roles/apache-php/templates/httpd.conf.j2
+++ b/src/roles/apache-php/templates/httpd.conf.j2
@@ -251,6 +251,10 @@ LogLevel warn
 </IfModule>
 
 <IfModule alias_module>
+        # setup the short-url alias to our controller
+        AliasMatch "^/demo$" /opt/htdocs/w
+        AliasMatch "^/demo/(.*)$" /opt/htdocs/w/$1
+
 	#
 	# Redirect: Allows you to tell clients about documents that used to
 	# exist in your server's namespace, but do not anymore. The client

--- a/src/roles/configure-wiki/tasks/main.yml
+++ b/src/roles/configure-wiki/tasks/main.yml
@@ -73,3 +73,14 @@
     - postLocalSettings.d/README.md
   delegate_to: localhost
   run_once: true
+
+- name: Ensure alias exists in Apache
+  blockinfile:
+    path: /etc/httpd/conf/httpd.conf
+    block: |
+      AliasMatch "^/{{ item }}$" /opt/htdocs/w
+      AliasMatch "^/{{ item }}/(.*)$" /opt/htdocs/w/$1
+    insertafter: "<IfModule alias_module>"
+  with_items: 
+    - "{{ list_of_wikis }}"
+  notify: "restart apache"

--- a/src/roles/htdocs/templates/.htaccess.j2
+++ b/src/roles/htdocs/templates/.htaccess.j2
@@ -30,10 +30,7 @@
     RewriteRule ^BackupDownload(?:/|$)(.*)$ - [L]
     {% endif %}
 
-    # Taken from MediaWiki.org [[Extension:Simple Farm]]
-    #
-    # Redirect virtual wiki path to physical wiki path. There
-    # can be no wiki accessible using this path.
-    RewriteRule ^(?!mediawiki(?:/|$))[^/]+(?:/(.*))?$ mediawiki/$1
+    # from https://www.mediawiki.org/wiki/Manual:Short_URL/Apache
+    RewriteRule ^/?wiki(/.*)?$ %{DOCUMENT_ROOT}/w/index.php [L]
 
 </IfModule>

--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -304,8 +304,8 @@
     # don't modify an existing checkout
     # assume deployer is playing with Blender source
     force: no
-    ignore_errors: yes
     umask: "0002"
+  ignore_errors: yes
 
 - name: Ensure BlenderSettings.php in place
   template:

--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -82,6 +82,7 @@
   tags:
     - latest
     - mediawiki-core
+
 - name: Ensure MediaWiki core ignores submodules
   blockinfile:
     path: "{{ m_mediawiki }}/.git/config"
@@ -91,6 +92,15 @@
   tags:
     - mediawiki-core
 
+# create symlink to core for short urls
+# tag it latest, so that the symlink gets created whenever core is downloaded
+- name: Create symlink to core, to enable short urls
+  file:
+    src: "{{ m_mediawiki }}"
+    dest: "{{ m_htdocs }}/w "
+    state: link
+  tags:
+    - latest
 #
 # EXTENSIONS AND SKINS
 #
@@ -291,6 +301,10 @@
     repo: https://github.com/jamesmontalvo3/WikiBlender.git
     dest: "{{ m_htdocs }}/WikiBlender"
     version: "master"
+    # don't modify an existing checkout
+    # assume deployer is playing with Blender source
+    force: no
+    ignore_errors: yes
     umask: "0002"
 
 - name: Ensure BlenderSettings.php in place
@@ -538,4 +552,3 @@
     group: root
     mode: 0755
   when: ansible_os_family == 'RedHat'
-

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -52,10 +52,16 @@ if( $wgCommandLineMode ) {
 
 }
 else {
-
-	// get $wikiId from URI
-	$uriParts = explode( '/', $_SERVER['REQUEST_URI'] );
-	$wikiId = strtolower( $uriParts[1] ); // URI has leading slash, so $uriParts[0] is empty string
+            // get $wikiId from subdomain
+            // FIXME make regex a config variable
+            // FIXME add 'ignore' list like 'www' that should not be a wiki
+      if ( preg_match( '%([a-z]+)\.([a-z]+)\..{2,4}[\d]*$%im', $_SERVER['HTTP_HOST'], $matches ) ) {
+        $wikiId = $matches[1];
+      } else {
+            // get $wikiId from URI
+        $uriParts = explode( '/', $_SERVER['REQUEST_URI'] );
+        $wikiId = strtolower( $uriParts[1] ); // URI has leading slash, so $uriParts[0] is empty string
+      }
 
 }
 
@@ -254,10 +260,12 @@ else {
 // Depending on proxy setup (particularly for Varnish/Squid caching) may need
 // to set $wgInternalServer:
 // ref: https://www.mediawiki.org/wiki/Manual:$wgInternalServer
-$wgServer = 'https://{{ wiki_app_fqdn }}';
+$wgServer = "https://" . $_SERVER['HTTP_HOST'] ;
 
 // https://www.mediawiki.org/wiki/Manual:$wgScriptPath
-$wgScriptPath = "/$wikiId";
+$wgScriptPath = "/w";
+// we're using short URLs
+$wgArticlePath = "/wiki/$1";
 
 // https://www.mediawiki.org/wiki/Manual:$wgUploadPath
 $wgUploadPath = "$wgScriptPath/img_auth.php";


### PR DESCRIPTION
This pull request only allows you to choose between subdomains or path-based wikis
For subdomains, the path will be hard-coded to '/wiki'.
e.g. Create wiki 'foo' => foo.example.org/wiki
For path based wikis, the wiki will be at /foo

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ x] Update documentation at https://www.mediawiki.org/wiki/Meza
