### PR TITLE
Allow specifying refspec in MW git repos

### DIFF
--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -80,6 +80,7 @@
     repo: https://github.com/wikimedia/mediawiki.git
     dest: "{{ m_mediawiki }}"
     version: "{{ mediawiki_version }}"
+    refspec: "{{ item.refspec | default('') }}"
     track_submodules: no
     recursive: no
     umask: "0002"
@@ -130,6 +131,7 @@
     repo: "{{ item.repo }}"
     dest: "{{ m_mediawiki }}/extensions/{{ item.name }}"
     version: "{{ item.version }}"
+    refspec: "{{ item.refspec | default('') }}"
     umask: "0002"
   with_items: "{{ meza_core_extensions.list }}"
   when: meza_core_extensions.list[0] is defined and item.repo is defined
@@ -153,6 +155,7 @@
     repo: "{{ item.repo }}"
     dest: "{{ m_mediawiki }}/skins/{{ item.name }}"
     version: "{{ item.version }}"
+    refspec: "{{ item.refspec | default('') }}"
   with_items: "{{ meza_core_skins.list }}"
   when: meza_core_skins.list[0] is defined and item.repo is defined
   tags:
@@ -169,6 +172,7 @@
     repo: "{{ item.repo }}"
     dest: "{{ m_mediawiki }}/extensions/{{ item.name }}"
     version: "{{ item.version }}"
+    refspec: "{{ item.refspec | default('') }}"
     umask: "0002"
     key_file: "{{ item.key_file | default(None) }}"
   with_items: "{{ meza_local_extensions.list }}"
@@ -186,6 +190,7 @@
     repo: "{{ item.repo }}"
     dest: "{{ m_mediawiki }}/skins/{{ item.name }}"
     version: "{{ item.version }}"
+    refspec: "{{ item.refspec | default('') }}"
   with_items: "{{ meza_local_skins.list }}"
   when: meza_local_skins.list[0] is defined and item.repo is defined
   tags:


### PR DESCRIPTION
### Changes

Allow specifying `refspec` to mediawiki git repos. This will allow specifying in-work gerrit patches for extensions, skins, and mediawiki core. For example:

```yaml
- name: PageForms
  repo: "https://gerrit.wikimedia.org/r/mediawiki/extensions/PageForms.git"
  version: "ad2e9469504e21df001e5160194b5a82847dc845"
  refspec: "refs/changes/03/518403/15"
```

Unfortunately it seems you need the hash of the gerrit patch, and can't track the latest commit. When you're on a Gerrit page like [this one](https://gerrit.wikimedia.org/r/c/mediawiki/extensions/VisualEditor/+/528893), you can get the hash here:

![image](https://user-images.githubusercontent.com/716482/62708192-8059ca80-b9b8-11e9-82f7-1839ed4e4f53.png)

### Issues

* Closes #1024

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Update documentation at https://www.mediawiki.org/wiki/Meza
