### PR TITLE
Allow specifying PHP max upload size in config

### DIFF
--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -257,6 +257,10 @@ m_simplesamlphp_group: wheel
 # PHP config
 #
 
+# PHP max file size. This gets applied to php.ini variables upload_max_filesize
+# and post_max_size for convenience.
+php_max_upload_filesize: "100M"
+
 # The OPcache shared memory storage size
 php_opcache_memory_consumption: 256
 

--- a/src/roles/apache-php/templates/php.ini.j2
+++ b/src/roles/apache-php/templates/php.ini.j2
@@ -660,7 +660,7 @@ auto_globals_jit = On
 ; Its value may be 0 to disable the limit. It is ignored if POST data reading
 ; is disabled through enable_post_data_reading.
 ; http://php.net/post-max-size
-post_max_size = 100M
+post_max_size = {{ php_max_upload_filesize }}
 
 ; Automatically add files before PHP document.
 ; http://php.net/auto-prepend-file
@@ -788,7 +788,7 @@ file_uploads = On
 
 ; Maximum allowed size for uploaded files.
 ; http://php.net/upload-max-filesize
-upload_max_filesize = 100M
+upload_max_filesize = {{ php_max_upload_filesize }}
 
 ; Maximum number of files that can be uploaded via a single request
 max_file_uploads = 20


### PR DESCRIPTION
### Changes

Allow specifying `php_max_upload_filesize` in config which sets `php.ini` variables `upload_max_filesize` and `post_max_size`. Example below would set the PHP max file upload size to 300 MB. This would be added to `public.yml`.

```yaml
php_max_upload_filesize: "300M"
```

### Issues

None

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Update documentation at https://www.mediawiki.org/wiki/Meza
