### PR TITLE
Use MediaWiki core version 1.31.3 + img_auth.php fix

### DIFF
--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -137,7 +137,10 @@ use_default_ssh_config: True
 #
 
 # Version of MediaWiki core
-mediawiki_version: "1.31.2"
+# The has below is MW 1.31.3 plus additional commits. This is specifically to
+# get the following addition to core, allowing specifying img_auth.php headers:
+# https://gerrit.wikimedia.org/r/c/mediawiki/core/+/529195
+mediawiki_version: "aeb36c13a50083436445e212b4af98175f2661d6"
 
 # Branch to use on many extensions extensions and skins
 mediawiki_default_branch: "REL1_31"


### PR DESCRIPTION
### Changes

* Bump MW to 1.31.3 plus additional commits (which will ultimately be part of 1.31.4
* This is specifically to get the following addition to core, allowing specifying img_auth.php headers: https://gerrit.wikimedia.org/r/c/mediawiki/core/+/529195

### Issues

* Addresses #1219
* The above issue will be closed with a separate pull request where Meza defaults to not caching Office documents, or at least provides easy options (rather than expecting users to adjust headers on their own)

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Update documentation at https://www.mediawiki.org/wiki/Meza
