### PR TITLE
Updating Data Transfer to fix import bug

### DIFF
--- a/config/core/MezaCoreExtensions.yml
+++ b/config/core/MezaCoreExtensions.yml
@@ -353,7 +353,7 @@ list:
 
   - name: DataTransfer
     repo: https://github.com/wikimedia/mediawiki-extensions-DataTransfer.git
-    version: "{{ mediawiki_default_branch }}"
+    version: "730cbfbcc7cc255724eaceb76a3abc6fcc9c93aa"
   - name: PageImporter
     repo: https://github.com/enterprisemediawiki/PageImporter.git
     version: tags/0.1.0


### PR DESCRIPTION
https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/DataTransfer/+/730cbfbcc7cc255724eaceb76a3abc6fcc9c93aa

### Changes

* Changed DataTransfer version from "{{ mediawiki_default_branch }}" to "730cbfbcc7cc255724eaceb76a3abc6fcc9c93aa"

### Issues

* Addresses the DataTransfer bug that replaces all multiple-instance templates on pages imported with the phrase "Array"

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] None that I know of
