### PR TITLE
Add /opt/data-meza/mw-temp that apache can modify

### DIFF
--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -188,6 +188,33 @@ clean_upload_stash_crontime: "0 18 * * *"
 # FILE MODES, OWNERS, GROUPS
 #
 
+#
+# PATH SPECIFICATIONS: PUT ALL PATH INFO UNDER m_paths
+# ----------------------------------------------------
+#
+# Use Capital X to give dirs "execute" (i.e. allow entry into dir) but leave
+# files' execute bit untouched.
+#
+# Examples:
+#   "u=rwX,g=rX,o="    --> 750 for dirs, files possibly between 640 and 751
+#   "u=rwX,g=rwX,o=rX" --> 775 for dirs, files possibly between 664 and 775
+#
+# Ref: https://www.g-loaded.eu/2005/11/08/the-use-of-the-uppercase-x-in-chmod/
+#
+m_paths:
+  mw_temp:
+    path: "{{ m_meza_data }}/mw-temp"
+    mode: "u=rwX,g=rwX,o=rX"
+    owner: apache
+    group: apache
+    # recurse: TBD if we want this within m_paths
+
+
+#
+# LEGACY PATH SPECIFICATIONS
+# --------------------------
+#
+
 m_meza_owner: meza-ansible
 m_meza_group: wheel
 # Don't set mode for /opt/meza for now. Don't want to impact execute bit which
@@ -223,7 +250,6 @@ m_uploads_dir_group: apache
 m_cache_directory_mode: "0770"
 m_cache_directory_owner: apache
 m_cache_directory_group: apache
-
 
 m_logs_mode: "0755"
 m_logs_owner: meza-ansible

--- a/src/roles/apache-php/tasks/main.yml
+++ b/src/roles/apache-php/tasks/main.yml
@@ -17,6 +17,14 @@
     group: apache
     mode: 0775
 
+- name: Ensure mw-temp directory configured
+  file:
+    state: directory
+    path: "{{ m_paths.mw_temp.path }}"
+    owner: "{{ m_paths.mw_temp.owner }}"
+    group: "{{ m_paths.mw_temp.group }}"
+    mode: "{{ m_paths.mw_temp.mode }}"
+
 - name: Ensure user meza-ansible and alt-meza-ansible in group "apache"
   user:
     name: "{{ item }}"


### PR DESCRIPTION
Apache cannot write to /opt/data-meza/tmp. For Special:TransferPages, it is necessary for Apache to write a temp file, which then is picked up by the MW job queue and executed as user meza-ansible.

### Changes

* Add `/opt/data-meza/mw-temp`
* Add `m_paths` to `defaults.yml` to start using better method of maintaining all paths

### Issues

* None

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Update documentation at https://www.mediawiki.org/wiki/Meza
