### PR TITLE
Add a calendar interface to Page Forms

### DIFF
--- a/config/core/MezaCoreExtensions.yml
+++ b/config/core/MezaCoreExtensions.yml
@@ -94,8 +94,7 @@ list:
     version: "{{ mediawiki_default_branch }}"
   - name: PageForms
     repo: https://github.com/wikimedia/mediawiki-extensions-PageForms.git
-    # commit includes spreadsheet sorting which didn't make PageForms 4.4.1
-    version: "730390a31a56c001af83948af1eefc5174abbe06"
+    version: "bb1beb015f0a16db10d96c895dfadf9eb691834d"
   - name: DismissableSiteNotice
     repo: https://github.com/wikimedia/mediawiki-extensions-DismissableSiteNotice.git
     version: "{{ mediawiki_default_branch }}"


### PR DESCRIPTION
### Changes

* Updating PageForms from:730390a31a56c001af83948af1eefc5174abbe06

to: bb1beb015f0a16db10d96c895dfadf9eb691834d

* Add calendar interface to Page Forms

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Test out calendar interface on PageForms
- [ ] Make sure everything is working nominally
