### PR TITLE
Make builds pass again; fix #1235 and #1237

### DIFF
--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -146,7 +146,7 @@ mediawiki_default_branch: "REL1_31"
 php_ius_version: "php71u"
 
 # Parsoid version
-m_parsoid_version: "tags/v0.9.0"
+m_parsoid_version: "tags/v0.10.0"
 
 # MediaWiki 1.27 and earlier require ElasticSearch 1.6
 # MediaWiki 1.28 and higher require ElasticSearch 2.x

--- a/src/roles/base/tasks/main.yml
+++ b/src/roles/base/tasks/main.yml
@@ -166,10 +166,9 @@
     name: firewalld
     state: started
     enabled: yes
-  when: docker_skip_tasks is not defined or not docker_skip_tasks
-
-- name: Try manually starting firewalld
-  shell: systemctl restart firewalld
+  when:
+    - docker_skip_tasks is not defined or not docker_skip_tasks
+    - firewall_skip_tasks is not defined or not firewall_skip_tasks
 
 #
 # SSH config

--- a/src/roles/base/tasks/main.yml
+++ b/src/roles/base/tasks/main.yml
@@ -162,9 +162,14 @@
     state: permissive # log actions that would be blocked if state=enforcing
 
 - name: ensure firewalld is running (and enable it at boot)
-  service: name=firewalld state=started enabled=yes
+  service:
+    name: firewalld
+    state: started
+    enabled: yes
   when: docker_skip_tasks is not defined or not docker_skip_tasks
 
+- name: Try manually starting firewalld
+  shell: systemctl restart firewalld
 
 #
 # SSH config

--- a/src/roles/firewalld/handlers/main.yml
+++ b/src/roles/firewalld/handlers/main.yml
@@ -1,4 +1,6 @@
 ---
 - name: restart firewalld
   service: name=firewalld state=restarted
-  when: docker_skip_tasks is not defined or not docker_skip_tasks
+  when:
+    - docker_skip_tasks is not defined or not docker_skip_tasks
+    - firewall_skip_tasks is not defined or not firewall_skip_tasks

--- a/src/roles/firewalld/tasks/main.yml
+++ b/src/roles/firewalld/tasks/main.yml
@@ -62,7 +62,11 @@
     zone: "{{firewalld_zone|default('public')}}"
   # strip "localhost" or inventory_hostname from list of servers to configure
   with_items: "{{ firewalld_servers | difference([ 'localhost', inventory_hostname ]) }}"
-  when: firewalld_service is defined and (docker_skip_tasks is not defined or not docker_skip_tasks)
+  when:
+    - firewalld_service is defined
+    - docker_skip_tasks is not defined or not docker_skip_tasks
+    - firewall_skip_tasks is not defined or not firewall_skip_tasks
+
 
 - name: set firewalld allow port {{ firewalld_port }} for list of servers
   firewalld:
@@ -73,4 +77,8 @@
     zone: "{{firewalld_zone|default('public')}}"
   # strip "localhost" or inventory_hostname from list of servers to configure
   with_items: "{{ firewalld_servers | difference([ 'localhost', inventory_hostname ]) }}"
-  when: firewalld_port is defined and firewalld_protocol is defined and (docker_skip_tasks is not defined or not docker_skip_tasks)
+  when:
+    - firewalld_port is defined
+    - firewalld_protocol is defined
+    - docker_skip_tasks is not defined or not docker_skip_tasks
+    - firewall_skip_tasks is not defined or not firewall_skip_tasks

--- a/src/roles/haproxy/tasks/main.yml
+++ b/src/roles/haproxy/tasks/main.yml
@@ -213,7 +213,9 @@
   with_items:
     - 80
     - 443
-  when: docker_skip_tasks is not defined or not docker_skip_tasks
+  when:
+    - docker_skip_tasks is not defined or not docker_skip_tasks
+    - firewall_skip_tasks is not defined or not firewall_skip_tasks
 
 - name: Ensure firewalld port 1936 OPEN when haproxy stats ENABLED
   firewalld:
@@ -222,7 +224,10 @@
     immediate: true
     state: enabled
     zone: "{{m_public_networking_zone|default('public')}}"
-  when: enable_haproxy_stats and (docker_skip_tasks is not defined or not docker_skip_tasks)
+  when:
+    - enable_haproxy_stats
+    - docker_skip_tasks is not defined or not docker_skip_tasks
+    - firewall_skip_tasks is not defined or not firewall_skip_tasks
 
 - name: Ensure firewalld port 1936 CLOSED when haproxy stats DISABLED
   firewalld:
@@ -231,7 +236,10 @@
     immediate: true
     state: disabled
     zone: "{{m_public_networking_zone|default('public')}}"
-  when: not enable_haproxy_stats and (docker_skip_tasks is not defined or not docker_skip_tasks)
+  when:
+    - not enable_haproxy_stats
+    - docker_skip_tasks is not defined or not docker_skip_tasks
+    - firewall_skip_tasks is not defined or not firewall_skip_tasks
 
 - name: Ensure firewalld port 8088 OPEN when PHP profiling ENABLED
   firewalld:
@@ -240,7 +248,10 @@
     immediate: true
     state: enabled
     zone: "{{m_public_networking_zone|default('public')}}"
-  when: m_setup_php_profiling and (docker_skip_tasks is not defined or not docker_skip_tasks)
+  when:
+    - m_setup_php_profiling
+    - docker_skip_tasks is not defined or not docker_skip_tasks
+    - firewall_skip_tasks is not defined or not firewall_skip_tasks
 
 - name: Ensure firewalld port 8088 CLOSED when PHP profiling DISABLED
   firewalld:
@@ -249,8 +260,10 @@
     immediate: true
     state: disabled
     zone: "{{m_public_networking_zone|default('public')}}"
-  when: not m_setup_php_profiling and (docker_skip_tasks is not defined or not docker_skip_tasks)
-
+  when:
+    - not m_setup_php_profiling
+    - docker_skip_tasks is not defined or not docker_skip_tasks
+    - firewall_skip_tasks is not defined or not firewall_skip_tasks
 
 # FIXME #747: haproxy will need to handle reverse proxy for Elasticsearch plugins
 # - name: Configure firewalld for Elasticsearch reverse proxy

--- a/src/roles/nodejs/tasks/setup-RedHat.yml
+++ b/src/roles/nodejs/tasks/setup-RedHat.yml
@@ -57,4 +57,4 @@
     lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
     name: "nodejs-{{ nodejs_version[0] }}.*"
     state: present
-    enablerepo: 'epel,nodesource'"
+    enablerepo: 'epel,nodesource'

--- a/src/roles/saml/tasks/main.yml
+++ b/src/roles/saml/tasks/main.yml
@@ -70,7 +70,6 @@
     src: "{{ item.filename }}.j2"
     dest: "{{ item.dest_path }}/{{ item.filename }}"
   with_items:
-
     # Config files for SimpleSamlPhp (PHP SAML library)
     - filename: "config.php"
       dest_path: "{{ m_simplesamlphp_path }}/config"

--- a/src/scripts/meza.py
+++ b/src/scripts/meza.py
@@ -98,7 +98,7 @@ def meza_command_deploy (argv):
 		else:
 			sys.exit(rc)
 
-	more_extra_vars = False
+	more_extra_vars = {}
 
 	# strip environment off of it
 	argv = argv[1:]
@@ -108,7 +108,16 @@ def meza_command_deploy (argv):
 		# remove -o and --overwrite from args;
 		argv = [value for value in argv[:] if value not in ["-o", "--overwrite"]]
 
-		more_extra_vars = { 'force_overwrite_from_backup': True }
+		more_extra_vars['force_overwrite_from_backup'] = True
+
+	if (len( set(argv).intersection({"--no-firewall"}) )) > 0:
+		# remove --no-firewall from args:
+		argv = [value for value in argv[:] if value not in ["--no-firewall"]]
+
+		more_extra_vars['firewall_skip_tasks'] = True
+
+	if len(more_extra_vars) == 0:
+		more_extra_vars = False
 
 	# This breaks continuous integration. FIXME to get it back.
 	# THIS WAS WRITTEN WHEN `meza` WAS A BASH SCRIPT

--- a/tests/deploys/backup-to-remote.controller.sh
+++ b/tests/deploys/backup-to-remote.controller.sh
@@ -9,11 +9,8 @@ set -eux
 
 echo "RUNNING TEST"
 
-# Skip firewalld tasks since they broke in Travis (Issue #1237)
-echo -e '\nfirewall_skip_tasks: True\n' >> '/opt/conf-meza/public/public.yml'
-
 # Now that environment is setup, deploy/install it
-meza deploy "$1"
+meza deploy "$1" --no-firewall
 
 # Need to sleep 10 seconds to let Parsoid finish loading
 sleep 10s

--- a/tests/deploys/backup-to-remote.controller.sh
+++ b/tests/deploys/backup-to-remote.controller.sh
@@ -9,6 +9,9 @@ set -eux
 
 echo "RUNNING TEST"
 
+# Skip firewalld tasks since they broke in Travis (Issue #1237)
+echo -e '\nfirewall_skip_tasks: True\n' >> '/opt/conf-meza/public/public.yml'
+
 # Now that environment is setup, deploy/install it
 meza deploy "$1"
 

--- a/tests/deploys/import-from-remote.controller.sh
+++ b/tests/deploys/import-from-remote.controller.sh
@@ -9,11 +9,8 @@ set -eux
 
 echo "RUNNING TEST"
 
-# Skip firewalld tasks since they broke in Travis (Issue #1237)
-echo -e '\nfirewall_skip_tasks: True\n' >> '/opt/conf-meza/public/public.yml'
-
 # Deploy environment with test config
-meza deploy "$1"
+meza deploy "$1" --no-firewall
 
 # Need to wait after install before checking that Parsoid is working
 sleep 10s

--- a/tests/deploys/import-from-remote.controller.sh
+++ b/tests/deploys/import-from-remote.controller.sh
@@ -9,6 +9,9 @@ set -eux
 
 echo "RUNNING TEST"
 
+# Skip firewalld tasks since they broke in Travis (Issue #1237)
+echo -e '\nfirewall_skip_tasks: True\n' >> '/opt/conf-meza/public/public.yml'
+
 # Deploy environment with test config
 meza deploy "$1"
 

--- a/tests/deploys/monolith-from-import.controller.sh
+++ b/tests/deploys/monolith-from-import.controller.sh
@@ -24,7 +24,7 @@ sed -r -i "s/INSERT_FQDN/$fqdn/g;" "/opt/conf-meza/secret/$env_name/secret.yml"
 git clone https://github.com/jamesmontalvo3/meza-test-backups.git "/opt/data-meza/backups/$env_name"
 
 # Deploy environment with test config
-meza deploy "$env_name"
+meza deploy "$env_name" --no-firewall
 
 # Need to wait after install before checking that Parsoid is working
 sleep 10s

--- a/tests/deploys/monolith-from-scratch.controller.sh
+++ b/tests/deploys/monolith-from-scratch.controller.sh
@@ -19,11 +19,8 @@ meza setup env monolith --fqdn="${fqdn}" --db_pass=1234 --private_net_zone=publi
 echo "print hosts file"
 cat /opt/conf-meza/secret/monolith/hosts
 
-# Skip firewalld tasks since they broke in Travis (Issue #1237)
-echo -e '\nfirewall_skip_tasks: True\n' >> '/opt/conf-meza/public/public.yml'
-
 # Now that environment monolith is setup, deploy/install it
-meza deploy monolith
+meza deploy monolith --no-firewall
 
 # Need to sleep 10 seconds to let Parsoid finish loading
 sleep 10s

--- a/tests/deploys/monolith-from-scratch.controller.sh
+++ b/tests/deploys/monolith-from-scratch.controller.sh
@@ -19,6 +19,9 @@ meza setup env monolith --fqdn="${fqdn}" --db_pass=1234 --private_net_zone=publi
 echo "print hosts file"
 cat /opt/conf-meza/secret/monolith/hosts
 
+# Skip firewalld tasks since they broke in Travis (Issue #1237)
+echo -e '\nfirewall_skip_tasks: True\n' >> '/opt/conf-meza/public/public.yml'
+
 # Now that environment monolith is setup, deploy/install it
 meza deploy monolith
 

--- a/tests/docker/import-from-alt-remote.setup.sh
+++ b/tests/docker/import-from-alt-remote.setup.sh
@@ -103,7 +103,6 @@ ${docker_exec_1[@]} bash -c "ansible-vault encrypt $secret_yml --vault-password-
 ${docker_exec_1[@]} cat "$hosts_file"
 ${docker_exec_1[@]} cat "$secret_yml"
 
-
 # garbage data into database and file uploads, just to check that the changes
 # get copied to CONTAINER 1
 ${docker_exec_2[@]} mysql -u root -p1234 wiki_top -e"INSERT INTO watchlist (wl_user, wl_namespace, wl_title) VALUES (10000,0,'FAKE PAGE');"

--- a/tests/docker/import-from-alt-remote.setup.sh
+++ b/tests/docker/import-from-alt-remote.setup.sh
@@ -111,7 +111,7 @@ ${docker_exec_2[@]} bash -c "echo 'fake data' > /opt/alt/backups/top/uploads/fak
 #
 # Re-deploy without --overwrite
 #
-${docker_exec_1[@]} meza deploy "$env_name" --tags "mediawiki" --skip-tags "latest" -vvv
+${docker_exec_1[@]} meza deploy "$env_name" --tags "mediawiki" --skip-tags "latest" -vvv --no-firewall
 
 
 #
@@ -136,7 +136,7 @@ ${docker_exec_1[@]} cat /opt/data-meza/uploads/top/fake.png \
 #
 # Re-deploy with --overwrite
 #
-${docker_exec_1[@]} meza deploy "$env_name" --overwrite --tags "mediawiki" --skip-tags "latest"
+${docker_exec_1[@]} meza deploy "$env_name" --overwrite --tags "mediawiki" --skip-tags "latest" --no-firewall
 
 
 #

--- a/tests/docker/import-from-remote.setup.sh
+++ b/tests/docker/import-from-remote.setup.sh
@@ -52,7 +52,8 @@ ${docker_exec_1[@]} sed -r -i "s/INSERT_FQDN/$docker_ip_1/g;" \
 # LocalSettings.php)
 ${docker_exec_1[@]} bash -c "echo -e 'allow_image_tags: True\n' >> '/opt/conf-meza/secret/$env_name/secret.yml'"
 
-
+# Skip firewalld tasks since they broke in Travis (Issue #1237)
+${docker_exec_1[@]} bash -c "echo -e '\nfirewall_skip_tasks: True\n' >> '/opt/conf-meza/public/public.yml'"
 
 # CONTAINER 2: get backup files
 ${docker_exec_2[@]} git clone \

--- a/tests/docker/import-from-remote.setup.sh
+++ b/tests/docker/import-from-remote.setup.sh
@@ -52,9 +52,6 @@ ${docker_exec_1[@]} sed -r -i "s/INSERT_FQDN/$docker_ip_1/g;" \
 # LocalSettings.php)
 ${docker_exec_1[@]} bash -c "echo -e 'allow_image_tags: True\n' >> '/opt/conf-meza/secret/$env_name/secret.yml'"
 
-# Skip firewalld tasks since they broke in Travis (Issue #1237)
-${docker_exec_1[@]} bash -c "echo -e '\nfirewall_skip_tasks: True\n' >> '/opt/conf-meza/public/public.yml'"
-
 # CONTAINER 2: get backup files
 ${docker_exec_2[@]} git clone \
 	https://github.com/jamesmontalvo3/meza-test-backups.git \

--- a/tests/docker/init-container.sh
+++ b/tests/docker/init-container.sh
@@ -83,7 +83,7 @@ docker_exec=( docker exec --tty "$container_id" env TERM=xterm )
 # 17.something), whereas Travis is on 1.12.something.
 ${docker_exec[@]} yum -y install firewalld
 ${docker_exec[@]} systemctl start firewalld
-${docker_exec[@]} firewall-offline-cmd --permanent --zone=public --change-interface=docker0
+${docker_exec[@]} firewall-offline-cmd --zone=public --change-interface=docker0
 
 if [ "$is_minion" == "no" ]; then
 

--- a/tests/docker/init-container.sh
+++ b/tests/docker/init-container.sh
@@ -83,7 +83,7 @@ docker_exec=( docker exec --tty "$container_id" env TERM=xterm )
 # 17.something), whereas Travis is on 1.12.something.
 ${docker_exec[@]} yum -y install firewalld
 ${docker_exec[@]} systemctl start firewalld
-${docker_exec[@]} firewall-cmd --permanent --zone=public --change-interface=docker0
+${docker_exec[@]} firewall-offline-cmd --permanent --zone=public --change-interface=docker0
 
 if [ "$is_minion" == "no" ]; then
 

--- a/tests/docker/init-container.sh
+++ b/tests/docker/init-container.sh
@@ -82,8 +82,8 @@ docker_exec=( docker exec --tty "$container_id" env TERM=xterm )
 # or Ubuntu 14.04 host. Only tested on new version of Docker (docker-ce version
 # 17.something), whereas Travis is on 1.12.something.
 ${docker_exec[@]} yum -y install firewalld
-${docker_exec[@]} systemctl start firewalld
 ${docker_exec[@]} firewall-offline-cmd --zone=public --change-interface=docker0
+${docker_exec[@]} systemctl start firewalld
 
 if [ "$is_minion" == "no" ]; then
 


### PR DESCRIPTION
Two problems stacked causing tests to fail.

### Changes

* Problem 1: Something changed about Travis. Either the version of Docker used, or perhaps some configuration. Root cause has yet to be determined. The problem was narrowed to firewall commands, which really shouldn't be run on containers in the first place. To address this, the variable `firewall_skip_tasks` is checked for on firewall tasks. If it is set to `True` then those tasks are skipped. Additionally, the `--no-firewall` option is added to `deploy` to trigger this setting (or it can be added in config). Travis tests all run `meza deploy --no-firewall` now. 
* Problem 2: Fixing problem 1 uncovered problem 2, which was also reported in #1235. The problem here appears to be due to some changes in Parsoid dependencies. Upgrading from Parsoid `0.9.0` to `0.10.0` fixed the problem. 

### Issues

* Closes #1235
* Closes #1237

### Post-merge actions

None