### PR TITLE
Python 2/3 compatibility

### DIFF
--- a/src/roles/base-config-scripts/templates/config.php.j2
+++ b/src/roles/base-config-scripts/templates/config.php.j2
@@ -74,7 +74,7 @@ $backups_environment = '{{ backups_environment }}';
 {% if wiki_backup_downloaders is defined %}
 # Users allowed to download specific wikis
 $wiki_backup_downloaders = array();
-{% for wiki, users in wiki_backup_downloaders.iteritems() %}
+{% for wiki, users in wiki_backup_downloaders.items() %}
 $wiki_backup_downloaders['{{ wiki }}'] = array(
 	{% for user in users %}
 	'{{ user }}',
@@ -105,7 +105,7 @@ $all_backup_downloaders = array(
 # CUSTOM __public__ DEPLOY VARIABLES
 # These should only come from public.yml
 #
-{% for key, value in public_deploy_vars.iteritems() %}
+{% for key, value in public_deploy_vars.items() %}
 
 {% if value is number -%}
 	${{ key }} = {{ value }};
@@ -117,7 +117,7 @@ $all_backup_downloaders = array(
 	${{ key }} = [];
 
 	{%- if value is mapping -%}
-		{%- for subkey, subvalue in value.iteritems() %}
+		{%- for subkey, subvalue in value.items() %}
 
 			{% if subvalue is number -%}
 				${{ key }}['{{ subkey }}'] = {{ subvalue }};
@@ -155,7 +155,7 @@ $all_backup_downloaders = array(
 # CUSTOM __{{ env }} environment__ DEPLOY VARIABLES
 # These should only come from env/{{ env }}.yml
 #
-{% for key, value in env_deploy_vars.iteritems() %}
+{% for key, value in env_deploy_vars.items() %}
 
 {% if value is number -%}
 	${{ key }} = {{ value }};
@@ -167,7 +167,7 @@ $all_backup_downloaders = array(
 	${{ key }} = [];
 
 	{%- if value is mapping -%}
-		{%- for subkey, subvalue in value.iteritems() %}
+		{%- for subkey, subvalue in value.items() %}
 
 			{% if subvalue is number -%}
 				${{ key }}['{{ subkey }}'] = {{ subvalue }};
@@ -204,7 +204,7 @@ $all_backup_downloaders = array(
 # CUSTOM __secret__ DEPLOY VARIABLES
 # These should only come from secret.yml
 #
-{% for key, value in secret_deploy_vars.iteritems() %}
+{% for key, value in secret_deploy_vars.items() %}
 
 {% if value is number -%}
 	${{ key }} = {{ value }};
@@ -216,7 +216,7 @@ $all_backup_downloaders = array(
 	${{ key }} = [];
 
 	{%- if value is mapping -%}
-		{%- for subkey, subvalue in value.iteritems() %}
+		{%- for subkey, subvalue in value.items() %}
 
 			{% if subvalue is number -%}
 				${{ key }}['{{ subkey }}'] = {{ subvalue }};
@@ -256,7 +256,7 @@ $all_backup_downloaders = array(
 # FIXME: remove deploy_vars in lieu of secret_deploy_vars when production wikis
 #        are updated.
 #
-{% for key, value in deploy_vars.iteritems() %}
+{% for key, value in deploy_vars.items() %}
 
 {% if value is number -%}
 	${{ key }} = {{ value }};
@@ -268,7 +268,7 @@ $all_backup_downloaders = array(
 	${{ key }} = [];
 
 	{%- if value is mapping -%}
-		{%- for subkey, subvalue in value.iteritems() %}
+		{%- for subkey, subvalue in value.items() %}
 
 			{% if subvalue is number -%}
 				${{ key }}['{{ subkey }}'] = {{ subvalue }};

--- a/src/roles/base-config-scripts/templates/config.sh.j2
+++ b/src/roles/base-config-scripts/templates/config.sh.j2
@@ -63,7 +63,7 @@ m_i18n="{{ m_i18n }}"
 # CUSTOM __public__ DEPLOY VARIABLES
 # These should only come from public.yml
 #
-{% for key, value in public_deploy_vars.iteritems() %}
+{% for key, value in public_deploy_vars.items() %}
 {% if value is string %}
 {{ key }}="{{ value }}"
 {% elif value is iterable %}
@@ -80,7 +80,7 @@ m_i18n="{{ m_i18n }}"
 # CUSTOM __{{ env }} environment__ DEPLOY VARIABLES
 # These should only come from env/{{ env }}.yml
 #
-{% for key, value in env_deploy_vars.iteritems() %}
+{% for key, value in env_deploy_vars.items() %}
 {% if value is string %}
 {{ key }}="{{ value }}"
 {% elif value is iterable %}
@@ -97,7 +97,7 @@ m_i18n="{{ m_i18n }}"
 # CUSTOM __secret__ DEPLOY VARIABLES
 # These should only come from secret.yml
 #
-{% for key, value in secret_deploy_vars.iteritems() %}
+{% for key, value in secret_deploy_vars.items() %}
 {% if value is string %}
 {{ key }}="{{ value }}"
 {% elif value is iterable %}
@@ -116,7 +116,7 @@ m_i18n="{{ m_i18n }}"
 # FIXME: remove deploy_vars in lieu of secret_deploy_vars when production wikis
 #        are updated.
 #
-{% for key, value in deploy_vars.iteritems() %}
+{% for key, value in deploy_vars.items() %}
 {% if value is string %}
 {{ key }}="{{ value }}"
 {% elif value is iterable %}

--- a/src/roles/saml/templates/samlLocalSettings.php.j2
+++ b/src/roles/saml/templates/samlLocalSettings.php.j2
@@ -37,7 +37,7 @@ if ( isset( $_SERVER['HTTP_X_SKIP_SAML'] ) ) {
 	// FIXME #822: The indenting below will be heinous when Ansible does its templating
 	{% if allow_skip_saml_users is defined -%}
 		$wgMezaAllowSkipSamlUsers = array();
-		{% for user, ipaddrs in allow_skip_saml_users.iteritems() -%}
+		{% for user, ipaddrs in allow_skip_saml_users.items() -%}
 		$wgMezaAllowSkipSamlUsers['{{ user }}'] = array(
 			{%- for ipaddr in ipaddrs -%}'{{ ipaddr }}',{%- endfor -%}
 		);

--- a/src/scripts/meza.py
+++ b/src/scripts/meza.py
@@ -951,7 +951,7 @@ def playbook_cmd ( playbook, env=False, more_extra_vars=False ):
 		extra_vars = {}
 
 	if more_extra_vars:
-		for varname, value in more_extra_vars.iteritems():
+		for varname, value in more_extra_vars.items():
 			extra_vars[varname] = value
 
 	if len(extra_vars) > 0:


### PR DESCRIPTION

In Python2, dictionaries have iterkeys(), itervalues(), and iteritems() methods. These methods have been removed in Python3. Playbooks and Jinja2 templates should use dict.keys(), dict.values(), and dict.items() in order to be compatible with both Python2 and Python3:

This change makes Meza compatible with both.  See 
https://docs.ansible.com/ansible/latest/user_guide/playbooks_python_version.html#dict-iteritems
and
https://stackoverflow.com/questions/30418481/error-dict-object-has-no-attribute-iteritems/30418498 for more

### Changes

Changes usage of 'iteritems' to 'items'

### Issues
Fixes an issue where you will get the error:

Error: “ 'dict' object has no attribute 'iteritems' ”

### Post-merge actions

Post-merge, the following actions need to be addressed:
Cherry-pick to the 28.x branch or rebase? 
