### PR TITLE
Test update to Semantic Result Formats jqplotseries (hidezeroes)

### DIFF
--- a/config/core/MezaCoreExtensions.yml
+++ b/config/core/MezaCoreExtensions.yml
@@ -27,7 +27,7 @@ list:
 
   - name: Semantic Result Formats
     composer: "mediawiki/semantic-result-formats"
-    version: "3.0.0"
+    version: "hidezeroes"
     config: |
       // In SRF 3.0+ you need to do this, too:
       wfLoadExtension( 'SemanticResultFormats' );


### PR DESCRIPTION
### Changes

* use SRF branch hidezeroes

### Issues

* Tests [SemanticResultFormats #558](https://github.com/SemanticMediaWiki/SemanticResultFormats/issues/558)

### Post-merge actions

This should not be merged into Meza master. This is a test branch which, if successful, will hopefully convince Jeroen to merge the hidezeroes branch of SRF into that master.