### PR TITLE
Update URL to IUS RPM

### DIFF
--- a/src/roles/apache-php/tasks/ius.yml
+++ b/src/roles/apache-php/tasks/ius.yml
@@ -1,15 +1,8 @@
 ---
-- name: Install IUS (CentOS) repo.
+- name: Install IUS repo.
   yum:
     lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
-    name: "https://centos{{ ansible_distribution_major_version }}.iuscommunity.org/ius-release.rpm"
-  when: ansible_distribution == "CentOS"
-
-- name: Install IUS (RHEL) repo.
-  yum:
-    lock_timeout: 180 # wait up to 3 minutes for a lock ansible/ansible#57189
-    name: "https://rhel{{ ansible_distribution_major_version }}.iuscommunity.org/ius-release.rpm"
-  when: ansible_distribution == "RedHat"
+    name: "https://repo.ius.io/ius-release-el{{ ansible_distribution_major_version }}.rpm"
 
 - name: Import IUS Community Project GPG key
   rpm_key:


### PR DESCRIPTION
Hi,

Today my `meza deploy` failed with the following error:

```
TASK [apache-php : Install IUS (RHEL) repo.] ***************************************************************************************************************************
Monday 01 June 2020  15:20:00 +1000 (0:00:00.051)       0:03:33.396 ***********
fatal: [localhost]: FAILED! => {
    "changed": false
}

MSG:

Failed to get nevra information from RPM package: https://rhel7.iuscommunity.org/ius-release.rpm
```

Browsing to the URL above refers to their issue https://github.com/iusrepo/announce/issues/18. It appears as though the URLs currently used in the meza playbooks were deprecated redirects.

### Changes

* Updates URL to RPM hosted by IUS
* There was previously different links for RHEL and CentOS, but they seem to have converged

### Issues

No open issue.

### Post-merge actions

n/a