### PR TITLE
Ensure PEAR channel up-to-date

### DIFF
--- a/src/roles/apache-php/tasks/mssql_driver_for_php.yml
+++ b/src/roles/apache-php/tasks/mssql_driver_for_php.yml
@@ -78,6 +78,9 @@
 #   shell: "scl enable devtoolset-7 bash"
 
 
+- name: Ensure PEAR channel up-to-date
+  shell: pear channel-update pecl.php.net
+
 #
 # Install sqlsrv drivers from PECL
 #


### PR DESCRIPTION
### Changes

Fix for the following error if using MSFT SQL add-on (for external MSSQL databases, not for wiki):

```
TASK [apache-php : Install sqlsrv and pdo_sqlsrv PECL packages] ****************
Friday 05 June 2020  16:02:48 -0500 (0:00:06.179)       0:02:28.082 ***********
failed: [localhost] (item=pecl/sqlsrv) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": "pecl/sqlsrv"
}

MSG:

failed to install pecl/sqlsrv: WARNING: channel "pecl.php.net" has updated its protocols, use "pear channel-update pecl.php.net" to update
```

### Issues

None

### Post-merge actions

Post-merge, the following actions need to be addressed:

- None