### PR TITLE
Add IPv6 bind if available to HAProxy

### DIFF
--- a/src/roles/haproxy/templates/haproxy.cfg.j2
+++ b/src/roles/haproxy/templates/haproxy.cfg.j2
@@ -56,11 +56,20 @@ defaults
 
 frontend www-http
 	bind *:80
+	{% if ansible_default_ipv6.address | length > 0 -%}
+	bind {{ ansible_default_ipv6.address }}:80
+	{%- endif %}
+	
 	reqadd X-Forwarded-Proto:\ http
 	default_backend www-backend
 
 frontend www-https
 	bind *:443 ssl crt /etc/haproxy/certs/meza.pem
+	{% if ansible_default_ipv6.address | length > 0 -%}
+	# Create an AAAA record in DNS using the IP below to IPv6 enable your wiki
+	bind {{ ansible_default_ipv6.address }}:443 ssl crt /etc/haproxy/certs/meza.pem
+	{%- endif %}
+	
 	reqadd X-Forwarded-Proto:\ https
 	# Keep letsencrypt stuff here for now. Probably add it back later.
 	# acl letsencrypt-acl path_beg /.well-known/acme-challenge/


### PR DESCRIPTION
### Changes

Modified Jinja template for HAProxy. 
When the host has an IPv6 address, add a couple bind lines for it
