### PR TITLE
Added config variable use_ntp

### DIFF
--- a/config/core/defaults.yml
+++ b/config/core/defaults.yml
@@ -75,6 +75,8 @@ m_timezone: "America/Chicago"
 
 meza_server_log_db: meza_server_log
 
+use_ntp: true
+
 ntp_server: [0.pool.ntp.org, 1.pool.ntp.org, 2.pool.ntp.org, 3.pool.ntp.org]
 
 m_language: en

--- a/src/roles/base/tasks/main.yml
+++ b/src/roles/base/tasks/main.yml
@@ -208,18 +208,20 @@
     state: installed
   tags:
   - latest
+  when: use_ntp
 
 - name: Ensure NTP is running and enabled as configured.
   service:
     name: ntpd
     state: started
     enabled: yes
-  when: docker_skip_tasks is not defined or not docker_skip_tasks
+  when: use_ntp
 
 - name: Copy the ntp.conf template file
   template: src=ntp.conf.j2 dest=/etc/ntp.conf
   notify:
     - restart ntpd
+  when: use_ntp
 
 # FIXME #809: PIP required first; has dependencies; needed on all hosts?
 # Speed up encrypt/decrypt operations


### PR DESCRIPTION
### Changes

* Added config variable `use_ntp` to config/core/defaults.yml
* Added `when: use_ntp` to "tasks" involving ntp to src/roles/base/tasks/main.yml

### Issues

* Collaborated with James to help fix server time issue

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Update documentation at https://www.mediawiki.org/wiki/Meza
