### PR TITLE
Resync master and 31.x

### DIFF
--- a/src/roles/composer/tasks/main.yml
+++ b/src/roles/composer/tasks/main.yml
@@ -27,9 +27,10 @@
     creates={{ composer_path }}
   when: not composer_bin.stat.exists
 
-- name: Update Composer to latest version (if configured).
+# Enforce composer 1.x per #1272. Per #1273 we should make Meza support Composer 2.x.
+- name: Set Composer to version 1.10.19
   shell: >
-    {{ php_executable }} {{ composer_path }} self-update
+    {{ php_executable }} {{ composer_path }} self-update 1.10.19
   register: composer_update
   changed_when: "'Updating to version' in composer_update.stdout"
   when: composer_keep_updated


### PR DESCRIPTION
### Changes

The `31.x` branch got out of sync with `master` yesterday to support a quick fix (9630b3015c876f9d6073d7999df81a6a177119a1) to get Composer to work.

This change merges that 31.x hotfix back into master.

### Issues

* Closes ##1272

### Post-merge actions

None