### PR TITLE
Bump base Vagrant RAM from 2GB to 4GB

### DIFF
--- a/vagrantconf.default.yml
+++ b/vagrantconf.default.yml
@@ -1,6 +1,6 @@
 ---
 app1:
-  memory: 2048
+  memory: 4096
   cpus: 1
 
 # To add a second app server, uncomment the lines below


### PR DESCRIPTION
### Changes

* In `vagrantconf.default.yml` set the default RAM to 4GB. Meza fails with 2GB.

### Issues

* None

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [x] No updates required to main docs. They already highly recommend 4GB.
- [ ] Update [Vagrant install docs](https://www.mediawiki.org/wiki/Meza/Install_with_Vagrant) to have 4GB as requirement
