### PR TITLE
31.13.0 release

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,41 @@
 Release Notes
 =============
 
+## Meza 31.12.0
+
+Testing fixes, Add LDAP module, Bump MW to 1.31.12
+
+### Commits since 31.11.0
+
+* e05ea12 Bump base Vagrant RAM from 2GB to 4GB, else problems (#1278)
+* 908ac75 Bump MW to 1.31.12 (#1277)
+* 2380aa2 Enforce Composer 1.x version (#1275)
+* 8b5c112 Added config variable use_ntp (#1271)
+* 4160ae3 Bump MediaWiki to 1.31.7 (#1267)
+* 65aa596 add ldap module (#1261)
+* 591df68 Point tests to new Docker images built from this repo; only run build process on commits to master
+* 8a22485 Remove secret.yml encryption per #1175
+* 57e8469 Need --skip-conn-check on getmeza.sh within docker; temporarily skip other builds
+* 11dc3e8 Make Dockerfiles pull FROM correct base image
+* f01ae65 Add later test images
+* 62886be Build test container 'base' on pushes to 'docker-build' branch
+* b5ce5e3 GitHub Actions fail-fast-->false, to prevent one failure from cancelling all jobs
+* 4cb414f Don't run tests twice for PRs
+* 83d4bd6 Enable testing in GitHub Actions and GitLab CI
+
+### Contributors
+
+* 16	James Montalvo
+* 1	Daren Welsh
+* 1	Vincent Brooks
+
+# How to upgrade
+
+```bash
+sudo meza update 31.12.0
+sudo meza deploy <insert-your-environment-name>
+```
+
 ## Meza 31.10.1
 
 Fix PEAR channel

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,26 @@
 Release Notes
 =============
 
+## Meza 31.13.0
+
+Add new backups-cleanup method
+
+### Commits since 31.12.0
+
+* bba5624 Add backups cleanup that goes into each wiki dir for better cleanup options
+* 805e3ed 31.12.0 release (#1279)
+
+### Contributors
+
+* 2	James Montalvo
+
+# How to upgrade
+
+```bash
+sudo meza update 31.13.0
+sudo meza deploy <insert-your-environment-name>
+```
+
 ## Meza 31.12.0
 
 Testing fixes, Add LDAP module, Bump MW to 1.31.12

--- a/src/roles/backups-cleanup/templates/backups-cleanup.sh.j2
+++ b/src/roles/backups-cleanup/templates/backups-cleanup.sh.j2
@@ -3,14 +3,32 @@
 # change directory to backups location
 cd {{ m_backups }}/{{ env }}
 
-# remove all odd-numbered days (keep only even-numbered days)
+# Apply backups cleanup rules at the backups+env root (without going into each wiki's directory)
+# DEPRECATED:
+#   1. Use method below going into each directory
+#   2. This will eventually be removed, but not before providing some notification to users
 {% if backups_cleanup.removal_rules is defined %}
 {% for removal_rule in backups_cleanup.removal_rules %}
 rm {{ removal_rule }} -f
 {% endfor %}
 {% endif %}
 
-# compress all SQL files
+# Apply backups cleanup rules for each wiki directory
+{% if backups_cleanup.removal_rules_each_wiki is defined %}
+# Loop over wiki directories
+for dir in {{ m_backups }}/{{ env }}/*/
+do
+    cd ${dir}
+    echo "Running backups cleanup rules for ${dir}:"
+    # Run removal rules like: rm $(ls -F *.sql | head -n -2) -f
+    {% for removal_rule in backups_cleanup.removal_rules_each_wiki %}
+    {{ removal_rule }}
+    {% endfor %}
+    cd ..
+done
+{% endif %}
+
+# compress all SQL files following rule
 {% if backups_cleanup.gzip_rules is defined %}
 echo "gzip start time: $(date +\"%T\")"
 {% for gzip_rule in backups_cleanup.gzip_rules %}


### PR DESCRIPTION
## Meza 31.13.0

Add new backups-cleanup method

### Commits since 31.12.0

* bba5624 Add backups cleanup that goes into each wiki dir for better cleanup options

### New config

Allows new config like:

```yaml
#
# Cleanup backups hourly, keeping only the latest of:
#  - *wiki.sql: Backups generated from this server prior to performing database modifications
#  - *wiki_push.sql: Backups generated from another server and pushed onto this server for overwrite purposes
#
backups_cleanup:
  crontime: "0 * * * *"
  removal_rules_each_wiki:
    - "rm $(ls -F *_wiki.sql | head -n -1) -f"
    - "rm $(ls -F *_wiki_push.sql | head -n -1) -f"
```

This will keep the `/opt/data-meza/backups/<environment name>/<wiki id>` clean, with only the latest `*_wiki.sql` and `*_wiki_push.sql` files. 