### PR TITLE
Only require the main tests, not the backups tests with infra failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,9 @@ jobs:
         test_type:
           - monolith-from-scratch
           - monolith-from-import
-          - import-from-remote
-          - backup-to-remote
-          - import-from-alt-remote
+          # - import-from-remote
+          # - backup-to-remote
+          # - import-from-alt-remote
 
     runs-on: ubuntu-latest
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,12 @@ jobs:
   include:
     - env: test_type=monolith-from-scratch
     - env: test_type=monolith-from-import
+
+    # Allowed to fail
+    - env: test_type=import-from-remote
+    - env: test_type=backup-to-remote
+    - env: test_type=import-from-alt-remote
+
   allow_failures:
     - env: test_type=import-from-remote
     - env: test_type=backup-to-remote

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,12 @@ services: docker
 jobs:
   fast_finish: true
   include:
-    env:
-      - test_type: monolith-from-scratch
-      - test_type: monolith-from-import
+    - env: test_type=monolith-from-scratch
+    - env: test_type=monolith-from-import
   allow_failures:
-    env:
-      - test_type: import-from-remote
-      - test_type: backup-to-remote
-      - test_type: import-from-alt-remote
+    - env: test_type=import-from-remote
+    - env: test_type=backup-to-remote
+    - env: test_type=import-from-alt-remote
 
 # before_install:
   # To upgrade Docker, uncomment the following lines. Do this only if there are

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,17 @@
 
 services: docker
 
-env:
-  - test_type: monolith-from-scratch
-  - test_type: monolith-from-import
-  - test_type: import-from-remote
-  - test_type: backup-to-remote
-  - test_type: import-from-alt-remote
+jobs:
+  fast_finish: true
+  include:
+    env:
+      - test_type: monolith-from-scratch
+      - test_type: monolith-from-import
+  allow_failures:
+    env:
+      - test_type: import-from-remote
+      - test_type: backup-to-remote
+      - test_type: import-from-alt-remote
 
 # before_install:
   # To upgrade Docker, uncomment the following lines. Do this only if there are


### PR DESCRIPTION
### Changes

* Removes the "backup" tests from GitHub actions
* Makes the "backup" tests allowed to fail in Travis CI

Backup tests aren't testing deploy capability, but pushing data from server to server. This capability could be tested before, but has stopped working in test environments despite working in real environments, and time is not available to fix the infrastructure issues.

### Issues

None

### Post-merge actions

None