### PR TITLE
SemanticCompoundQueries update to 2.1.0

### DIFF
--- a/config/core/MezaCoreExtensions.yml
+++ b/config/core/MezaCoreExtensions.yml
@@ -50,6 +50,8 @@ list:
   - name: SemanticCompoundQueries
     composer: "mediawiki/semantic-compound-queries"
     version: "2.1.0"
+    config: |
+      wfLoadExtension( 'SemanticCompoundQueries' );
   - name: SubPageList
     composer: "mediawiki/sub-page-list"
     version: "1.5.0"

--- a/config/core/MezaCoreExtensions.yml
+++ b/config/core/MezaCoreExtensions.yml
@@ -49,7 +49,7 @@ list:
 
   - name: SemanticCompoundQueries
     composer: "mediawiki/semantic-compound-queries"
-    version: "1.2.0"
+    version: "2.1.0"
   - name: SubPageList
     composer: "mediawiki/sub-page-list"
     version: "1.5.0"


### PR DESCRIPTION
### Changes

* Update SemanticCompoundQueries to 2.1.0

### Issues

* Previous version (1.2.0) was not compatible with MW, SMW, and PHP

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Update documentation at https://www.mediawiki.org/wiki/Meza
- [ ] Update version.json
- [ ] Update release
