### PR TITLE
fix: remove apache mod_proxy_html which was unused and isn't available on RHEL

### DIFF
--- a/src/roles/apache-php/tasks/main.yml
+++ b/src/roles/apache-php/tasks/main.yml
@@ -7,7 +7,6 @@
   with_items:
     - httpd-devel
     - mod_ssl
-    - mod_proxy_html
 
 - name: Make apache own htdocs directory
   file:

--- a/tests/containers/pre-yum/Dockerfile
+++ b/tests/containers/pre-yum/Dockerfile
@@ -32,7 +32,6 @@ RUN yum -y install \
 RUN yum -y install \
     httpd-devel \
     mod_ssl \
-    mod_proxy_html \
     zlib-devel \
     sqlite-devel \
     bzip2-devel \


### PR DESCRIPTION
### Changes

* Remove unused package mod_proxy_html
* This has no impact on CentOS
* On RedHat this package is no longer available, so deploys on RedHat were failing