### PR TITLE
Fix hyphen/underscore compatibility and elasticsearch startup failure.

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -234,20 +234,20 @@ m_php_fpm_port: 9090
 # All load balancer types
 load_balancers_all: >
   {{ groups['load_balancers'] | default([]) }} +
-  {{ groups['load_balancers-meza-internal'] | default([]) }} +
-  {{ groups['load_balancers-meza-external'] | default([]) }} +
+  {{ groups['load_balancers_meza_internal'] | default([]) }} +
+  {{ groups['load_balancers_meza_external'] | default([]) }} +
   {{ groups['load_balancers_nonmeza'] | default([]) }} +
   {{ groups['load_balancers_nonmeza_internal'] | default([]) }} +
   {{ groups['load_balancers_nonmeza_external'] | default([]) }}
 
 # Just load balancers for handling internal services
 load_balancers_internal: >
-  {{ groups['load_balancers-meza-internal'] | default([]) }} +
+  {{ groups['load_balancers_meza_internal'] | default([]) }} +
   {{ groups['load_balancers_nonmeza_internal'] | default([]) }}
 
 # Just load balancers for handling external traffic
 load_balancers_external: >
-  {{ groups['load_balancers-meza-external'] | default([]) }} +
+  {{ groups['load_balancers_meza_external'] | default([]) }} +
   {{ groups['load_balancers_nonmeza_external'] | default([]) }}
 
 # Just load balancers that handle internal and external
@@ -258,8 +258,8 @@ load_balancers_full: >
 # Just load balancers managed by Meza
 load_balancers_meza: >
   {{ groups['load_balancers'] | default([]) }} +
-  {{ groups['load_balancers-meza-internal'] | default([]) }} +
-  {{ groups['load_balancers-meza-external'] | default([]) }}
+  {{ groups['load_balancers_meza_internal'] | default([]) }} +
+  {{ groups['load_balancers_meza_external'] | default([]) }}
 
 # Just unmanaged load balancers (AWS, etc).
 load_balancers_nonmeza: >

--- a/src/playbooks/site.yml
+++ b/src/playbooks/site.yml
@@ -119,7 +119,7 @@
     - base-config-scripts
   tags: base
 
-- hosts: load_balancers,load_balancers-meza-internal,load_balancers-meza-external
+- hosts: load_balancers,load_balancers_meza_internal,load_balancers_meza_external
   become: yes
   tags:
     - load-balancer

--- a/src/roles/elasticsearch/tasks/main.yml
+++ b/src/roles/elasticsearch/tasks/main.yml
@@ -93,6 +93,19 @@
     - "{{ m_meza_data }}/elasticsearch/scripts"
     - "{{ m_meza_data }}/elasticsearch/log"
 
+# Copy java cacerts to /etc/elasticsearch to resolve issue with openjdk RPM
+# update. See:
+#
+# https://discuss.elastic.co/t/elasticsearch-is-incompatible-with-new-versions-of-openjdk-from-redhat/318928/7
+#
+- name: Copy extracted java cacerts to /etc/elasticsearch
+  copy:
+    src: /etc/pki/ca-trust/extracted/java/cacerts
+    dest: /etc/elasticsearch/cacerts-java-extracted
+    owner: elasticsearch
+    group: elasticsearch
+    mode: '0444'
+
 
 # CONFIGURE AND START ELASTICSEARCH
 # https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-configuration.html

--- a/src/roles/elasticsearch/templates/elasticsearch.yml.j2
+++ b/src/roles/elasticsearch/templates/elasticsearch.yml.j2
@@ -35,3 +35,13 @@ path.data: {{ m_meza_data }}/elasticsearch/data
 #
 path.logs: {{ m_meza_data }}/elasticsearch/log
 
+# Workaround for openjdk policy update which breaks elasticsearch's ability
+# to read /etc/pki/ca-trust/extracted/java/cacerts.
+#
+# Fixes xpack SSL java access denied at ES startup.
+#
+# Probably not the best way to do this. Suggestions welcome
+xpack.ssl.truststore.path: /etc/elasticsearch/cacerts-java-extracted
+xpack.ssl.truststore.password: changeit
+reindex.ssl.truststore.path: /etc/elasticsearch/cacerts-java-extracted
+reindex.ssl.truststore.password: changeit

--- a/src/roles/haproxy/tasks/main.yml
+++ b/src/roles/haproxy/tasks/main.yml
@@ -15,8 +15,8 @@
       'load_balancers' in groups
       and inventory_hostname in groups['load_balancers']
     ) or (
-      'load_balancers-meza-external' in groups
-      and inventory_hostname in groups['load_balancers-meza-external']
+      'load_balancers_meza_external' in groups
+      and inventory_hostname in groups['load_balancers_meza_external']
     )
 
 - name: Set fact if this load balancer will NOT handle external connections
@@ -28,8 +28,8 @@
         'load_balancers' in groups
         and inventory_hostname in groups['load_balancers']
       ) or (
-        'load_balancers-meza-external' in groups
-        and inventory_hostname in groups['load_balancers-meza-external']
+        'load_balancers_meza_external' in groups
+        and inventory_hostname in groups['load_balancers_meza_external']
       )
     )
 
@@ -241,7 +241,7 @@
     - https
   when:
     - ansible_distribution_file_variety == "RedHat"
-    - inventory_hostname in groups['load_balancers'] or inventory_hostname in groups['load_balancers-meza-external']
+    - inventory_hostname in groups['load_balancers'] or inventory_hostname in groups['load_balancers_meza_external']
 
 
 - name: Ensure SELinux context for firewalld haproxy service files
@@ -251,7 +251,7 @@
     - https
   when:
     - ansible_distribution_file_variety == "RedHat"
-    - inventory_hostname in groups['load_balancers'] or inventory_hostname in groups['load_balancers-meza-external']
+    - inventory_hostname in groups['load_balancers'] or inventory_hostname in groups['load_balancers_meza_external']
 
 
 # Allow http and https through firewall
@@ -294,7 +294,7 @@
     - >
       ('load_balancers' in groups and inventory_hostname in groups['load_balancers'])
       or
-      ('load_balancers-meza-external' in groups and inventory_hostname in groups['load_balancers-meza-external'])
+      ('load_balancers_meza_external' in groups and inventory_hostname in groups['load_balancers_meza_external'])
 
 
 - name: Ensure firewall port 1936 OPEN when haproxy stats ENABLED

--- a/src/roles/haproxy/tasks/main.yml
+++ b/src/roles/haproxy/tasks/main.yml
@@ -41,8 +41,8 @@
       'load_balancers' in groups
       and inventory_hostname in groups['load_balancers']
     ) or (
-      'load_balancers-meza-internal' in groups
-      and inventory_hostname in groups['load_balancers-meza-internal']
+      'load_balancers_meza_internal' in groups
+      and inventory_hostname in groups['load_balancers_meza_internal']
     )
 
 - name: Set fact if this load balancer will NOT handle internal connections
@@ -54,8 +54,8 @@
         'load_balancers' in groups
         and inventory_hostname in groups['load_balancers']
       ) or (
-        'load_balancers-meza-internal' in groups
-        and inventory_hostname in groups['load_balancers-meza-internal']
+        'load_balancers_meza_internal' in groups
+        and inventory_hostname in groups['load_balancers_meza_internal']
       )
     )
 


### PR DESCRIPTION
This PR hopefully changes the remaining group names in meza so that are compatible with newer ansible versions (those versions don't like hyphens in group names).

The PR also includes a fix for an elasticsearch startup error due to a policy change or openjdk update with newer RedHat 8 variants. See:

https://discuss.elastic.co/t/elasticsearch-is-incompatible-with-new-versions-of-openjdk-from-redhat/318928/7